### PR TITLE
Make XC Integrators Propagate State

### DIFF
--- a/include/gauxc/xc_integrator/default_xc_cuda_integrator.hpp
+++ b/include/gauxc/xc_integrator/default_xc_cuda_integrator.hpp
@@ -113,6 +113,7 @@ typename DefaultXCCudaIntegrator<MatrixType>::exc_vxc_type
     *cuda_data_, tasks, P.data(), VXC.data(), &EXC, &N_EL 
   );
 
+  cuda_data_.reset(); // Free up CUDA memory
 
 
   if( world_size > 1 ) {

--- a/include/gauxc/xc_integrator/default_xc_host_integrator.hpp
+++ b/include/gauxc/xc_integrator/default_xc_host_integrator.hpp
@@ -67,10 +67,16 @@ typename DefaultXCHostIntegrator<MatrixType>::exc_vxc_type
 
   // Compute Local contributions to EXC / VXC
   process_batches_host_replicated_p< value_type>(
-    n_deriv, XCWeightAlg::SSF, *this->func_, *this->basis_,
-    this->load_balancer_->molecule(), this->load_balancer_->molmeta(),
-    *host_data_, tasks, P.data(), VXC.data(), &EXC, &N_EL 
+    n_deriv, this->integrator_state_, XCWeightAlg::SSF, *this->func_, 
+    *this->basis_, this->load_balancer_->molecule(), 
+    this->load_balancer_->molmeta(), *host_data_, tasks, P.data(), 
+    VXC.data(), &EXC, &N_EL 
   );
+
+
+  // Update State of Integrator
+  this->integrator_state_.load_balancer_populated     = true;
+  this->integrator_state_.modified_weights_are_stored = true;
 
 
   int world_size;

--- a/include/gauxc/xc_integrator/xc_host_util.hpp
+++ b/include/gauxc/xc_integrator/xc_host_util.hpp
@@ -2,6 +2,7 @@
 #include <gauxc/xc_integrator/xc_host_data.hpp>
 
 #include <gauxc/xc_integrator.hpp>
+#include "xc_integrator_state.hpp"
 
 namespace GauXC  {
 namespace integrator {
@@ -10,6 +11,7 @@ namespace host {
 
 template <typename F, size_t n_deriv>
 void process_batches_host_replicated_p(
+  XCIntegratorState      integrator_state,
   XCWeightAlg            weight_alg,
   const functional_type& func,
   const BasisSet<F>&     basis,

--- a/include/gauxc/xc_integrator/xc_integrator_impl.hpp
+++ b/include/gauxc/xc_integrator/xc_integrator_impl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <gauxc/xc_integrator.hpp>
+#include "xc_integrator_state.hpp"
 
 namespace GauXC {
 namespace detail {
@@ -22,6 +23,7 @@ protected:
   std::shared_ptr<basisset_type>   basis_;
 
   std::shared_ptr<LoadBalancer>    load_balancer_;
+  XCIntegratorState                integrator_state_;
 
   virtual exc_vxc_type eval_exc_vxc_( const MatrixType& ) = 0;
   

--- a/include/gauxc/xc_integrator/xc_integrator_state.hpp
+++ b/include/gauxc/xc_integrator/xc_integrator_state.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace GauXC {
+
+struct XCIntegratorState {
+  bool load_balancer_populated     = false;
+  bool modified_weights_are_stored = false;
+};
+
+}

--- a/src/integrator/cuda/xc_cuda_data.cxx
+++ b/src/integrator/cuda/xc_cuda_data.cxx
@@ -37,7 +37,7 @@ XCCudaData<F>::XCCudaData( size_t _natoms,
   GAUXC_CUDA_ERROR( "MemInfo Failed", stat );
 
   // Allocate up to fill_fraction
-  size_t fill_sz = fill_fraction * cuda_total;
+  size_t fill_sz = fill_fraction * cuda_avail;
   stat = cudaMalloc( &device_ptr, fill_sz );
   GAUXC_CUDA_ERROR( "CUDA Malloc Failed", stat );
 

--- a/tests/xc_integrator.cxx
+++ b/tests/xc_integrator.cxx
@@ -8,7 +8,7 @@ using namespace GauXC;
 
 
 
-void test_xc_integrator( ExecutionSpace ex, MPI_Comm comm, Molecule mol ) {
+void test_xc_integrator( ExecutionSpace ex, MPI_Comm comm, Molecule mol, const bool check_state_propagation = false ) {
 
   BasisSet<double> basis = make_ccpvdz( mol, SphericalType(true) );
 
@@ -50,6 +50,14 @@ void test_xc_integrator( ExecutionSpace ex, MPI_Comm comm, Molecule mol ) {
 
   auto VXC_diff_nrm = ( VXC - VXC_ref ).norm();
   CHECK( VXC_diff_nrm / basis.nbf() < 1e-10 ); 
+
+  // Check if the integrator propagates state correctly
+  if( check_state_propagation ) {
+    auto [ EXC1, VXC1 ] = integrator.eval_exc_vxc( P );
+    CHECK( EXC1 == Approx( EXC_ref ) );
+    auto VXC1_diff_nrm = ( VXC1 - VXC_ref ).norm();
+    CHECK( VXC1_diff_nrm / basis.nbf() < 1e-10 ); 
+  }
 }
 
 
@@ -59,7 +67,7 @@ TEST_CASE( "Benzene / PBE0 / cc-pVDZ", "[xc-integrator]" ) {
   Molecule mol  = make_benzene();
 
   SECTION( "Host" ) {
-    test_xc_integrator( ExecutionSpace::Host, comm, mol );
+    test_xc_integrator( ExecutionSpace::Host, comm, mol, true );
   }
 
 #ifdef GAUXC_ENABLE_CUDA

--- a/tests/xc_integrator.cxx
+++ b/tests/xc_integrator.cxx
@@ -8,7 +8,7 @@ using namespace GauXC;
 
 
 
-void test_xc_integrator( ExecutionSpace ex, MPI_Comm comm, Molecule mol, const bool check_state_propagation = false ) {
+void test_xc_integrator( ExecutionSpace ex, MPI_Comm comm, Molecule mol, const bool check_state_propagation = true ) {
 
   BasisSet<double> basis = make_ccpvdz( mol, SphericalType(true) );
 
@@ -67,7 +67,7 @@ TEST_CASE( "Benzene / PBE0 / cc-pVDZ", "[xc-integrator]" ) {
   Molecule mol  = make_benzene();
 
   SECTION( "Host" ) {
-    test_xc_integrator( ExecutionSpace::Host, comm, mol, true );
+    test_xc_integrator( ExecutionSpace::Host, comm, mol );
   }
 
 #ifdef GAUXC_ENABLE_CUDA


### PR DESCRIPTION
1. Fixes bug in host integrator when subsequent calls to `eval_exc_vxc` with the same inputs yielded incorrect outputs. The weights were being modified twice
2. Fixes two bugs in CUDA integrator:
  - Frees up CUDA memory once integration is done to avoid large persistent allocations of device memory between integrator calls 
  - Deduces CUDA stack based on available memory, not total memory

Closes #8 