### PR TITLE
[HOST] Added option to disable Host integrator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ endif()
 # Decided if we're compiling device bindings
 if( GAUXC_ENABLE_CUDA )
   set( GAUXC_ENABLE_DEVICE TRUE CACHE BOOL "Enable Device Code" )
+else()
+  set( GAUXC_ENABLE_DEVICE FALSE CACHE BOOL "Enable Device Code" )
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules )
 
 # GauXC Options
+option( GAUXC_ENABLE_HOST     "Enable Host Integrator"      ON  )
 option( GAUXC_ENABLE_CUDA     "Enable CUDA Bindings"        OFF )
 option( GAUXC_ENABLE_MAGMA    "Enable MAGMA Linear Algebra" ON  )
 option( GAUXC_ENABLE_TESTS    "Enable Unit Tests"           ON  )
@@ -23,6 +24,12 @@ endif()
 # Decided if we're compiling device bindings
 if( GAUXC_ENABLE_CUDA )
   set( GAUXC_ENABLE_DEVICE TRUE CACHE BOOL "Enable Device Code" )
+endif()
+
+
+
+if( NOT (${GAUXC_ENABLE_HOST} OR ${GAUXC_ENABLE_DEVICE}) )
+  message( FATAL_ERROR "Neither Host nor Device Integrators have been enabled!" )
 endif()
 
 if( GAUXC_ENABLE_CUDA )

--- a/include/gauxc/gauxc_config.hpp.in
+++ b/include/gauxc/gauxc_config.hpp.in
@@ -1,5 +1,6 @@
 #pragma once
 
+#cmakedefine GAUXC_ENABLE_HOST
 #cmakedefine GAUXC_ENABLE_CUDA
 #cmakedefine GAUXC_ENABLE_MAGMA
 #cmakedefine GAUXC_ENABLE_GAU2GRID

--- a/include/gauxc/xc_integrator/default_xc_host_integrator.hpp
+++ b/include/gauxc/xc_integrator/default_xc_host_integrator.hpp
@@ -1,8 +1,10 @@
 #pragma once
+#include <gauxc/gauxc_config.hpp>
 #include <gauxc/xc_integrator/xc_integrator_impl.hpp>
 #include <gauxc/xc_integrator/xc_host_data.hpp>
 #include <gauxc/xc_integrator/xc_host_util.hpp>
 
+#ifdef GAUXC_ENABLE_HOST
 namespace GauXC  {
 namespace detail {
 
@@ -120,3 +122,4 @@ typename DefaultXCHostIntegrator<MatrixType>::exc_vxc_type
 
 }
 }
+#endif

--- a/include/gauxc/xc_integrator/integrator_defaults.hpp
+++ b/include/gauxc/xc_integrator/integrator_defaults.hpp
@@ -6,10 +6,12 @@
 namespace GauXC  {
 namespace detail {
 
+#ifdef GAUXC_ENABLE_HOST
 template <typename MatrixType, typename... Args>
 std::unique_ptr<XCIntegratorImpl<MatrixType>> make_default_host_integrator( Args&&... args ) {
   return std::make_unique<DefaultXCHostIntegrator<MatrixType>>( std::forward<Args>(args)... );
 }
+#endif
 
 #ifdef GAUXC_ENABLE_CUDA
 template <typename MatrixType, typename... Args>

--- a/include/gauxc/xc_integrator/integrator_factory.hpp
+++ b/include/gauxc/xc_integrator/integrator_factory.hpp
@@ -13,12 +13,20 @@ std::unique_ptr<XCIntegratorImpl<MatrixType>>
 
     if( ex == ExecutionSpace::Host ) {
 
+#ifdef GAUXC_ENABLE_HOST
+
       return make_default_host_integrator<MatrixType>(
         comm,
         std::make_shared<functional_type>(func),
         std::make_shared<BasisSet<typename MatrixType::value_type>>(basis),
         lb
       );
+#else
+
+      throw std::runtime_error("GAUXC_ENABLE_HOST is FALSE");
+      return nullptr;
+
+#endif
 
     } else {
 

--- a/include/gauxc/xc_integrator/xc_host_data.hpp
+++ b/include/gauxc/xc_integrator/xc_host_data.hpp
@@ -2,6 +2,9 @@
 #include <vector>
 #include <cstdint>
 
+#include <gauxc/gauxc_config.hpp>
+
+#ifdef GAUXC_ENABLE_HOST
 namespace GauXC {
 
 template <typename F>
@@ -35,3 +38,4 @@ struct XCHostData {
 };
 
 }
+#endif

--- a/include/gauxc/xc_integrator/xc_host_util.hpp
+++ b/include/gauxc/xc_integrator/xc_host_util.hpp
@@ -4,6 +4,7 @@
 #include <gauxc/xc_integrator.hpp>
 #include "xc_integrator_state.hpp"
 
+#ifdef GAUXC_ENABLE_HOST
 namespace GauXC  {
 namespace integrator {
 namespace host {
@@ -39,3 +40,4 @@ inline void process_batches_host_replicated_p( size_t n_deriv, Args&&... args ) 
 }
 }
 }
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,14 +1,12 @@
 # Parallelism
 find_package( OpenMP  REQUIRED )
 find_package( MPI     REQUIRED )
-find_package( LAPACK  REQUIRED )
 
 # Required Dependencies
 include( gauxc-integratorxx )
 include( gauxc-exchcxx      )
 include( gauxc-cereal       )
 include( gauxc-eigen3       )
-include( gauxc-gau2grid     )
 
 
 add_library( gauxc STATIC 
@@ -49,12 +47,7 @@ target_link_libraries( gauxc PUBLIC
   MPI::MPI_C 
   OpenMP::OpenMP_CXX
   Eigen3::Eigen 
-  LAPACK::lapack
 )
-
-if( GAUXC_ENABLE_GAU2GRID )
-  target_link_libraries( gauxc PUBLIC gauxc_gau2grid )
-endif()
 
 if( GAUXC_ENABLE_CEREAL )
   target_link_libraries( gauxc PUBLIC cereal )

--- a/src/integrator/CMakeLists.txt
+++ b/src/integrator/CMakeLists.txt
@@ -100,7 +100,9 @@ target_include_directories( gauxc
 )
 
 # Host Integrator Utilities
-include( host/gauxc-host_integrator.cmake )
+if( GAUXC_ENABLE_HOST )
+  include( host/gauxc-host_integrator.cmake )
+endif()
 
 if( GAUXC_ENABLE_CUDA )
   include( cuda/gauxc-cuda_integrator.cmake )

--- a/src/integrator/host/gauxc-host_integrator.cmake
+++ b/src/integrator/host/gauxc-host_integrator.cmake
@@ -1,7 +1,15 @@
+find_package( LAPACK  REQUIRED )
+include( gauxc-gau2grid     )
 target_sources( gauxc PRIVATE host/xc_host_util.cxx
                               host/host_weights.cxx
                               host/host_collocation.cxx
                               host/host_zmat.cxx
                               host/blas.cxx
 )
+
+target_link_libraries( gauxc PUBLIC LAPACK::lapack )
+
+if( GAUXC_ENABLE_GAU2GRID )
+  target_link_libraries( gauxc PUBLIC gauxc_gau2grid )
+endif()
 

--- a/tests/collocation.cxx
+++ b/tests/collocation.cxx
@@ -10,7 +10,9 @@
 #define MAX_NPTS_CHECK 67
 
 
+#ifdef GAUXC_ENABLE_HOST
 #include "host/host_collocation.hpp"
+#endif
 
 
 
@@ -40,6 +42,7 @@ struct ref_collocation_data {
 
 };
 
+#ifdef GAUXC_ENABLE_HOST
 void generate_collocation_data( const Molecule& mol, const BasisSet<double>& basis,
                                 std::ofstream& out_file, size_t ntask_save = 10 ) {
 
@@ -171,6 +174,8 @@ void test_host_collocation_deriv1( const BasisSet<double>& basis, std::ifstream&
   }
 
 }
+
+#endif
 
 
 #ifdef GAUXC_ENABLE_CUDA
@@ -910,6 +915,10 @@ void test_cuda_collocation_masked_combined_deriv1( const BasisSet<double>& basis
 
 //#define GENERATE_TESTS
 
+#if defined(GENERATE_TESTS) && !defined(GAUXC_ENABLE_HOST)
+  #error "Host Integrator Must Be Enabled to Generate Tests"
+#endif
+
 TEST_CASE( "Water / cc-pVDZ", "[collocation]" ) {
 
 #ifdef GENERATE_TESTS
@@ -933,6 +942,7 @@ TEST_CASE( "Water / cc-pVDZ", "[collocation]" ) {
   std::ifstream ref_data( GAUXC_REF_DATA_PATH "/water_cc-pVDZ_collocation.bin", 
                           std::ios::binary );
 
+#ifdef GAUXC_ENABLE_HOST
   SECTION( "Host Eval" ) {
     test_host_collocation( basis, ref_data );
   }
@@ -940,6 +950,7 @@ TEST_CASE( "Water / cc-pVDZ", "[collocation]" ) {
   SECTION( "Host Eval Grad" ) {
     test_host_collocation_deriv1( basis, ref_data );
   }
+#endif
 
 #ifdef GAUXC_ENABLE_CUDA
   SECTION( "CUDA Eval: Petite Shell List" ) {

--- a/tests/weights.cxx
+++ b/tests/weights.cxx
@@ -6,7 +6,9 @@
 #include <string>
 #include <mpi.h>
 
+#ifdef GAUXC_ENABLE_HOST
 #include "host/host_weights.hpp"
+#endif
 
 #ifdef GAUXC_ENABLE_CUDA
 #include <gauxc/exceptions/cuda_exception.hpp>
@@ -34,6 +36,7 @@ struct ref_weights_data {
 };
 
 
+#ifdef GAUXC_ENABLE_HOST
 void generate_weights_data( const Molecule& mol, const BasisSet<double>& basis,
                                 std::ofstream& out_file, size_t ntask_save = 15 ) {
 
@@ -109,6 +112,7 @@ void test_host_weights( std::ifstream& in_file ) {
   }
 
 }
+#endif
 
 #ifdef GAUXC_ENABLE_CUDA
 void test_cuda_weights( std::ifstream& in_file ) {
@@ -210,9 +214,11 @@ TEST_CASE( "Benzene", "[weights]" ) {
   std::ifstream ref_data( GAUXC_REF_DATA_PATH "/benzene_weights_ssf.bin", 
                           std::ios::binary );
 
+#ifdef GAUXC_ENABLE_HOST
   SECTION( "Host Weights" ) {
     test_host_weights( ref_data );
   }
+#endif
 
 #ifdef GAUXC_ENABLE_CUDA
   SECTION( "Device Weights" ) {

--- a/tests/xc_integrator.cxx
+++ b/tests/xc_integrator.cxx
@@ -66,9 +66,11 @@ TEST_CASE( "Benzene / PBE0 / cc-pVDZ", "[xc-integrator]" ) {
   MPI_Comm comm = MPI_COMM_WORLD;
   Molecule mol  = make_benzene();
 
+#ifdef GAUXC_ENABLE_HOST
   SECTION( "Host" ) {
     test_xc_integrator( ExecutionSpace::Host, comm, mol );
   }
+#endif
 
 #ifdef GAUXC_ENABLE_CUDA
   SECTION( "Device" ) {


### PR DESCRIPTION
Add option to disable host integrator, helps on architectures which don't have reliable BLAS/python installations