### PR TITLE
always use preferred linalg-modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ set( FETCHCONTENT_UPDATES_DISCONNECTED ON CACHE BOOL "Disable FC Updates" )
 project( GauXC VERSION 0.0.1 LANGUAGES C CXX )
 
 # Place local modules in the path
-list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
-list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules )
+list( PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
+list( PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules )
 include( gauxc-linalg-modules )
 
 # Guard some options settings to only default when not a subproject
@@ -82,4 +82,11 @@ add_subdirectory( src )
 
 if( CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND GAUXC_ENABLE_TESTS AND BUILD_TESTING )
   add_subdirectory( tests )
+endif()
+
+list(REMOVE_AT CMAKE_MODULE_PATH 0)
+list(REMOVE_AT CMAKE_MODULE_PATH 0)
+
+if( linalg-cmake-modules_POPULATED )
+  list(REMOVE_AT CMAKE_MODULE_PATH 0)
 endif()

--- a/cmake/gauxc-config.cmake.in
+++ b/cmake/gauxc-config.cmake.in
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.18 FATAL_ERROR) # Require CMake 3.18+
 
 get_filename_component(GauXC_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
-list(APPEND CMAKE_MODULE_PATH ${GauXC_CMAKE_DIR}                      )
-list(APPEND CMAKE_MODULE_PATH ${GauXC_CMAKE_DIR}/linalg-cmake-modules )
+list(PREPEND CMAKE_MODULE_PATH ${GauXC_CMAKE_DIR}                      )
+list(PREPEND CMAKE_MODULE_PATH ${GauXC_CMAKE_DIR}/linalg-cmake-modules )
 include(CMakeFindDependencyMacro)
 
 # Always Required Dependencies
@@ -61,3 +61,6 @@ if(NOT TARGET gauxc::gauxc)
 endif()
 
 set(GauXC_LIBRARIES gauxc::gauxc)
+
+list(REMOVE_AT CMAKE_MODULE_PATH 0)
+list(REMOVE_AT CMAKE_MODULE_PATH 0)

--- a/cmake/gauxc-config.cmake.in
+++ b/cmake/gauxc-config.cmake.in
@@ -53,14 +53,11 @@ if( GAUXC_ENABLE_HDF5 )
   find_dependency( HighFive )
 endif()
 
-list(REMOVE_AT CMAKE_MODULE_PATH -1)
-list(REMOVE_AT CMAKE_MODULE_PATH -1)
+list(REMOVE_AT CMAKE_MODULE_PATH 0)
+list(REMOVE_AT CMAKE_MODULE_PATH 0)
 
 if(NOT TARGET gauxc::gauxc)
     include("${GauXC_CMAKE_DIR}/gauxc-targets.cmake")
 endif()
 
 set(GauXC_LIBRARIES gauxc::gauxc)
-
-list(REMOVE_AT CMAKE_MODULE_PATH 0)
-list(REMOVE_AT CMAKE_MODULE_PATH 0)

--- a/cmake/gauxc-linalg-modules.cmake
+++ b/cmake/gauxc-linalg-modules.cmake
@@ -7,5 +7,5 @@ FetchContent_Declare( linalg-cmake-modules
 FetchContent_GetProperties( linalg-cmake-modules )
 if( NOT linalg-cmake-modules_POPULATED )
   FetchContent_Populate( linalg-cmake-modules )
-  list( APPEND CMAKE_MODULE_PATH ${linalg-cmake-modules_SOURCE_DIR} )
+  list( PREPEND CMAKE_MODULE_PATH ${linalg-cmake-modules_SOURCE_DIR} )
 endif()


### PR DESCRIPTION
Recreating PR #38. Set `CMAKE_MODULE_PATH` appropriately to always use preferred linalg-modules. 