### PR TITLE
Temporary fix for `nprim_pair_max` Override

### DIFF
--- a/include/gauxc/gauxc_config.hpp.in
+++ b/include/gauxc/gauxc_config.hpp.in
@@ -19,6 +19,7 @@
 #cmakedefine GAUXC_ENABLE_FAST_RSQRT
 
 #cmakedefine GAUXC_ENABLE_DEVICE
+#cmakedefine GAUXC_SHELLPAIR_PRIMPAIR_MAX @GAUXC_SHELLPAIR_PRIMPAIR_MAX@
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
   #define HOST_DEVICE_ACCESSIBLE __host__ __device__

--- a/include/gauxc/shell_pair.hpp
+++ b/include/gauxc/shell_pair.hpp
@@ -16,7 +16,11 @@ namespace detail {
     double x, y, z;
   };
 
+#ifdef GAUXC_SHELLPAIR_PRIMPAIR_MAX
+  static constexpr size_t nprim_pair_max = GAUXC_SHELLPAIR_PRIMPAIR_MAX;
+#else
   static constexpr size_t nprim_pair_max = 64ul;
+#endif
 
   template <typename Integral>
   inline intmax_t csr_index( size_t i, size_t j, Integral* row_ptr, Integral* col_ind ) {


### PR DESCRIPTION
Adds an (undocumented) `GAUXC_SHELLPAIR_PRIMPAIR_MAX` configure variable to modulate `nprim_pair_max`. This is a temporary solution for #56 until a more permanent/performant solution can be put in place. Setting this parameter > 64 with GPU sn-K will likely lead to performance degradation and potential runtime errors.