### PR TITLE
Make HDF5 Enablement Less Strict

### DIFF
--- a/cmake/gauxc-config.cmake.in
+++ b/cmake/gauxc-config.cmake.in
@@ -20,7 +20,7 @@ set( GAUXC_ENABLE_CUTLASS    @GAUXC_ENABLE_CUTLASS@   )
 set( GAUXC_ENABLE_MPI        @GAUXC_ENABLE_MPI@       )
 set( GAUXC_ENABLE_OPENMP     @GAUXC_ENABLE_OPENMP@    )
 set( GAUXC_ENABLE_GAU2GRID   @GAUXC_ENABLE_GAU2GRID@  )
-set( GAUXC_ENABLE_HDF5       @GAUXC_ENABLE_HDF5@      )
+set( GAUXC_HAS_HDF5          @GAUXC_HAS_HDF5@         )
 
 
 if( GAUXC_ENABLE_HOST )
@@ -49,7 +49,7 @@ if( GAUXC_ENABLE_OPENMP )
   find_dependency( OpenMP )
 endif()
 
-if( GAUXC_ENABLE_HDF5 )
+if( GAUXC_HAS_HDF5 )
   find_dependency( HighFive )
 endif()
 

--- a/cmake/gauxc-dep-versions.cmake
+++ b/cmake/gauxc-dep-versions.cmake
@@ -18,3 +18,6 @@ set( GAUXC_GAU2GRID_REVISION   v2.0.6 )
 
 set( GAUXC_INTEGRATORXX_REPOSITORY https://github.com/wavefunction91/IntegratorXX.git )
 set( GAUXC_INTEGRATORXX_REVISION   ea07dedd37e7bd49ea06394eb811599002b34b49 )
+
+set( GAUXC_HIGHFIVE_REPOSITORY https://github.com/BlueBrain/HighFive.git )
+set( GAUXC_HIGHFIVE_REVISION 805f0e13d09b47c4b01d40682621904aa3b31bb8 )

--- a/include/gauxc/external/hdf5.hpp
+++ b/include/gauxc/external/hdf5.hpp
@@ -6,7 +6,7 @@
  * See LICENSE.txt for details
  */
 #include <gauxc/gauxc_config.hpp>
-#ifdef GAUXC_ENABLE_HDF5
+#ifdef GAUXC_HAS_HDF5
 #include <gauxc/shell.hpp>
 #include <gauxc/atom.hpp>
 

--- a/include/gauxc/gauxc_config.hpp.in
+++ b/include/gauxc/gauxc_config.hpp.in
@@ -15,7 +15,7 @@
 #cmakedefine GAUXC_ENABLE_NCCL
 #cmakedefine GAUXC_ENABLE_CUTLASS
 #cmakedefine GAUXC_ENABLE_GAU2GRID
-#cmakedefine GAUXC_ENABLE_HDF5
+#cmakedefine GAUXC_HAS_HDF5
 #cmakedefine GAUXC_ENABLE_FAST_RSQRT
 
 #cmakedefine GAUXC_ENABLE_DEVICE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,12 +72,6 @@ if( GAUXC_CXX_HAS_WSHADOW )
   target_compile_options( gauxc PRIVATE $<$<COMPILE_LANGUAGE:CXX>: -Wshadow> )
 endif()
 
-
-configure_file( 
-  ${PROJECT_SOURCE_DIR}/include/gauxc/gauxc_config.hpp.in
-  ${PROJECT_BINARY_DIR}/include/gauxc/gauxc_config.hpp
-)
-
 target_link_libraries( gauxc PUBLIC 
   ExchCXX::ExchCXX 
   IntegratorXX::IntegratorXX 
@@ -103,6 +97,13 @@ add_subdirectory( external )
 
 
 add_library( gauxc::gauxc ALIAS gauxc )
+
+# Generate config file
+configure_file( 
+  ${PROJECT_SOURCE_DIR}/include/gauxc/gauxc_config.hpp.in
+  ${PROJECT_BINARY_DIR}/include/gauxc/gauxc_config.hpp
+)
+
 
 include( GNUInstallDirs )
 

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -11,11 +11,11 @@ if( GAUXC_ENABLE_HDF5 )
   if(HDF5_FOUND)
     set(GAUXC_HAS_HDF5 TRUE CACHE BOOL "" FORCE)
     message(STATUS "Enabling HDF5 Bindings")
-    message(STATUS "HighFive GIT_REPOSITORY = https://github.com/BlueBrain/HighFive.git")
-    message(STATUS "HighFive GIT_TAG = 805f0e13d09b47c4b01d40682621904aa3b31bb8")
+    message(STATUS "HighFive REPO = ${GAUXC_HIGHFIVE_REPOSITORY}")
+    message(STATUS "HighFive REV  = ${GAUXC_HIGHFIVE_REVISION}  ")
     FetchContent_Declare( HighFive
-      GIT_REPOSITORY https://github.com/BlueBrain/HighFive.git
-      GIT_TAG        805f0e13d09b47c4b01d40682621904aa3b31bb8
+      GIT_REPOSITORY ${GAUXC_HIGHFIVE_REPOSITORY}
+      GIT_TAG        ${GAUXC_HIGHFIVE_REVISION}  
     )
     
     set(HIGHFIVE_USE_BOOST OFF CACHE BOOL "" )

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -7,19 +7,29 @@
 #
 if( GAUXC_ENABLE_HDF5 )
   include(FetchContent)
-  find_package(HDF5 REQUIRED)
-  FetchContent_Declare( HighFive
-    GIT_REPOSITORY https://github.com/BlueBrain/HighFive.git
-    GIT_TAG        805f0e13d09b47c4b01d40682621904aa3b31bb8
-  )
-  
-  set(HIGHFIVE_USE_BOOST OFF CACHE BOOL "" )
-  set(HIGHFIVE_UNIT_TESTS OFF CACHE BOOL "" )
-  set(HIGHFIVE_EXAMPLES OFF CACHE BOOL "" )
-  #set(HIGHFIVE_PARALLEL_HDF5 ON CACHE BOOL "" )
-  set(HIGHFIVE_BUILD_DOCS OFF CACHE BOOL "" )
-  FetchContent_MakeAvailable( HighFive )
-  
-  target_sources( gauxc PRIVATE hdf5_write.cxx hdf5_read.cxx )
-  target_link_libraries( gauxc PUBLIC HighFive )
+  find_package(HDF5)
+  if(HDF5_FOUND)
+    set(GAUXC_HAS_HDF5 TRUE CACHE BOOL "" FORCE)
+    message(STATUS "Enabling HDF5 Bindings")
+    message(STATUS "HighFive GIT_REPOSITORY = https://github.com/BlueBrain/HighFive.git")
+    message(STATUS "HighFive GIT_TAG = 805f0e13d09b47c4b01d40682621904aa3b31bb8")
+    FetchContent_Declare( HighFive
+      GIT_REPOSITORY https://github.com/BlueBrain/HighFive.git
+      GIT_TAG        805f0e13d09b47c4b01d40682621904aa3b31bb8
+    )
+    
+    set(HIGHFIVE_USE_BOOST OFF CACHE BOOL "" )
+    set(HIGHFIVE_UNIT_TESTS OFF CACHE BOOL "" )
+    set(HIGHFIVE_EXAMPLES OFF CACHE BOOL "" )
+    #set(HIGHFIVE_PARALLEL_HDF5 ON CACHE BOOL "" )
+    set(HIGHFIVE_BUILD_DOCS OFF CACHE BOOL "" )
+    FetchContent_MakeAvailable( HighFive )
+    
+    target_sources( gauxc PRIVATE hdf5_write.cxx hdf5_read.cxx )
+    target_link_libraries( gauxc PUBLIC HighFive )
+  else()
+    message(WARNING "GAUXC_ENABLE_HDF5 was enabled, but HDF5 was not found, Disabling HDF5 Bindings")
+  endif()
+else()
+  message(STATUS "Disabling HDF5 Bindings")
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,10 @@
 #
 # See LICENSE.txt for details
 #
+if(NOT GAUXC_HAS_HDF5)
+  message(WARNING "GauXC Tests were ENABLED but HDF5 was not FOUND/ENABLED. Please enable and ensure discovery of HDF5. Skipping Tests")
+  return()
+endif()
 message( STATUS "Building GauXC Tests" )
 add_library( gauxc_catch2 INTERFACE )
 


### PR DESCRIPTION
Previously, the build would fail if `GAUXC_ENABLE_HDF5` was set and `HDF5` was not found. This is unnecessary. This PR introduces an additional `GAUXC_HAS_HDF5` which indicates that `GAUXC_ENABLE_HDF5` was set **and** `HDF5` was found. All appropriate logic has been updated and addition logic (with warning) skipping UTs if `GAUXC_HAS_HDF5` is false-y.