### PR TITLE
Libxc should be cited alongside GauXC

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If GauXC was used for the evaluation of exchange-correlation related
 quantities in your publication, we request that you also cite
 [Libxc](https://libxc.gitlab.io/) which provides the underlying
 implementation of the exchange-correlation functionals used in GauXC
-(via the ExchCXX library):
+via the [ExchCXX](https://github.com/wavefunction91/ExchCXX) library:
 
 ```
 % Actual Implementations of the Density Functionals

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Please cite the following publications if GauXC was used in your publication:
 ## Density functionals
 
 If GauXC was used for the evaluation of exchange-correlation related
-quantities in your publication, you should also cite
+quantities in your publication, we request that you also cite
 [Libxc](https://libxc.gitlab.io/) which provides the underlying
 implementation of the exchange-correlation functionals used in GauXC
 (via the ExchCXX library):

--- a/README.md
+++ b/README.md
@@ -75,19 +75,9 @@ We have also receieved significant support from industry collaborators:
 
 # Publications
 
+## GauXC
 Please cite the following publications if GauXC was used in your publication:
 ```
-% Actual Implementations of the Density Functionals
-@article{lehtola2018libxc,
-  author  = {Lehtola, Susi and Steigemann, Conrad and Oliveira, Micael J. T. and Marques, Miguel A. L.},
-  journal = {SoftwareX},
-  title   = {Recent developments in {LIBXC}---a comprehensive library of functionals for density functional theory},
-  year    = {2018},
-  pages   = {1--5},
-  volume  = {7},
-  doi     = {10.1016/j.softx.2017.11.002},
-}
-
 % Distributed Memory Seminumerical Exact Exchange implementation
 @article{williams2023distributed,
   title = {Distributed memory, GPU accelerated Fock construction for hybrid, Gaussian basis density functional theory},
@@ -146,9 +136,28 @@ Please cite the following publications if GauXC was used in your publication:
   doi={10.1140/epjb/e2018-90170-1},
   url={https://link.springer.com/article/10.1140/epjb/e2018-90170-1}
 }
-
 ```
 
+## Density functionals
+
+If GauXC was used for the evaluation of exchange-correlation related
+quantities in your publication, you should also cite
+[Libxc](https://libxc.gitlab.io/) which provides the underlying
+implementation of the exchange-correlation functionals used in GauXC
+(via the ExchCXX library):
+
+```
+% Actual Implementations of the Density Functionals
+@article{lehtola2018libxc,
+  author  = {Lehtola, Susi and Steigemann, Conrad and Oliveira, Micael J. T. and Marques, Miguel A. L.},
+  journal = {SoftwareX},
+  title   = {Recent developments in {LIBXC}---a comprehensive library of functionals for density functional theory},
+  year    = {2018},
+  pages   = {1--5},
+  volume  = {7},
+  doi     = {10.1016/j.softx.2017.11.002},
+}
+```
 
 # Build Instructions
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ We have also receieved significant support from industry collaborators:
 
 Please cite the following publications if GauXC was used in your publication:
 ```
+% Actual Implementations of the Density Functionals
+@article{lehtola2018libxc,
+  author  = {Lehtola, Susi and Steigemann, Conrad and Oliveira, Micael J. T. and Marques, Miguel A. L.},
+  journal = {SoftwareX},
+  title   = {Recent developments in {LIBXC}---a comprehensive library of functionals for density functional theory},
+  year    = {2018},
+  pages   = {1--5},
+  volume  = {7},
+  doi     = {10.1016/j.softx.2017.11.002},
+}
+
 % Distributed Memory Seminumerical Exact Exchange implementation
 @article{williams2023distributed,
   title = {Distributed memory, GPU accelerated Fock construction for hybrid, Gaussian basis density functional theory},
@@ -135,6 +146,7 @@ Please cite the following publications if GauXC was used in your publication:
   doi={10.1140/epjb/e2018-90170-1},
   url={https://link.springer.com/article/10.1140/epjb/e2018-90170-1}
 }
+
 ```
 
 


### PR DESCRIPTION
The GauXC citations don't include Libxc at the moment. Libxc should be included in the list of citations to make sure people don't cite just GauXC...