### PR TITLE
Handle external gau2grid

### DIFF
--- a/cmake/gauxc-gau2grid.cmake
+++ b/cmake/gauxc-gau2grid.cmake
@@ -1,36 +1,41 @@
 if( GAUXC_ENABLE_GAU2GRID )
-
-if( GAUXC_FORCE_EXTERNAL_GAU2GRID )
-
-  find_package( gau2grid CONFIG QUIET ) 
-  if( NOT gau2grid_FOUND )
-  
-    include( gauxc-dep-versions )
-  
-    message( STATUS "Could not find Gau2grid... Building" )
-    message( STATUS "GAU2GRID REPO = ${GAUXC_GAU2GRID_REPOSITORY}" )
-    message( STATUS "GAU2GRID REV  = ${GAUXC_GAU2GRID_REVISION}"   )
-  
-    FetchContent_Declare(
-      gau2grid
-      GIT_REPOSITORY ${GAUXC_GAU2GRID_REPOSITORY} 
-      GIT_TAG        ${GAUXC_GAU2GRID_REVISION} 
-    )
-  
-    set( MAX_AM 6 CACHE STRING "" )
-    set( DISABLE_PRAGMA ON CACHE BOOL "" )
-    FetchContent_MakeAvailable( gau2grid )
-  
-  endif()
-  
   if( NOT TARGET gau2grid::gg )
-    message( STATUS "Something Went Horribly Wrong With Gau2Grid discovery!" )
-  endif()
-
-else()
-
-  add_subdirectory( ${PROJECT_SOURCE_DIR}/external/gau2grid ${PROJECT_BINARY_DIR}/external/gau2grid )
-
-endif()
-
+  
+    # First try to find the package if target doesn't exist
+    find_package( gau2grid CONFIG QUIET ) 
+    
+    if( NOT gau2grid_FOUND )
+    
+      message( STATUS "Could not find Gau2grid... Building" )
+      
+      if( GAUXC_FORCE_EXTERNAL_GAU2GRID )
+        
+        include( gauxc-dep-versions )
+        
+        message( STATUS "GAU2GRID REPO = ${GAUXC_GAU2GRID_REPOSITORY}" )
+        message( STATUS "GAU2GRID REV  = ${GAUXC_GAU2GRID_REVISION}"   )
+        
+        FetchContent_Declare(
+          gau2grid
+          GIT_REPOSITORY ${GAUXC_GAU2GRID_REPOSITORY} 
+          GIT_TAG        ${GAUXC_GAU2GRID_REVISION} 
+        )
+        
+        set( MAX_AM 6 CACHE STRING "" )
+        set( DISABLE_PRAGMA ON CACHE BOOL "" )
+        FetchContent_MakeAvailable( gau2grid )
+        
+        if( NOT TARGET gau2grid::gg )
+          message( STATUS "Something Went Horribly Wrong With Gau2Grid discovery!" )
+        endif()
+      
+      else()
+      
+        message( STATUS "Building Pregenerated Gau2grid" )
+        add_subdirectory( ${PROJECT_SOURCE_DIR}/external/gau2grid ${PROJECT_BINARY_DIR}/external/gau2grid )
+      
+      endif()
+    
+    endif() # If not discoverable
+  endif() # If target not present
 endif() # If enabled


### PR DESCRIPTION
By default, GauXC expects to handle gau2grid via a pre-generated source (unless forced with `GAUXC_FORCE_EXTERNAL_GAU2GRID`). It is desirable to handle the case where gau2grid is built in an external tree (#93).

Closes #93 