### PR TITLE
[BUGFIX] Ensure exception propagation in `shellbatched` code path

### DIFF
--- a/src/xc_integrator/replicated/device/shellbatched_replicated_xc_device_integrator_exc_vxc.hpp
+++ b/src/xc_integrator/replicated/device/shellbatched_replicated_xc_device_integrator_exc_vxc.hpp
@@ -208,6 +208,7 @@ void ShellBatchedReplicatedXCDeviceIntegrator<ValueType>::
   // Execute remaining tasks sequentially
   if( task_future.valid() ) {
     task_future.wait();
+    task_future.get();
   }
   while( not incore_device_task_queue.empty() ) {
     execute_incore_device_task();


### PR DESCRIPTION
Use of `std::async` in the `shellbatched` code paths requires the invocation of `std::future::get` every time a future is digested to ensure exception propagation. We did this in the critical path, but missed the final check.

Reported by @mikovtun.