### PR TITLE
Spellcheck Error Messages

### DIFF
--- a/include/gauxc/load_balancer.hpp
+++ b/include/gauxc/load_balancer.hpp
@@ -26,7 +26,7 @@ namespace detail {
 /// State tracker for LoadBalancer instances 
 struct LoadBalancerState {
   bool modified_weights_are_stored = false; 
-    ///< Whether the load balancer currently sotred partitioned weights
+    ///< Whether the load balancer currently stored partitioned weights
 };
 
 
@@ -136,15 +136,15 @@ public:
    *    - "REPLICATED": Read as "REPLICATED-PETITE"
    *    - "REPLICATED-PETITE": Replicate the load balancer function, only keep
    *                           non negligible basis functions
-   *    - "REPLICATE-FILLIN": Same as "REPLICATED-PETITE" except if two 
-   *                          non-adjacent bfns are kept, the gaps are filled in.
-   *                          This gurantees contiguous memory access but leads
-   *                          to significantly more work. Not advised for general 
-   *                          usage
+   *    - "REPLICATED-FILLIN": Same as "REPLICATED-PETITE" except if two 
+   *                           non-adjacent bfns are kept, the gaps are filled in.
+   *                           This gurantees contiguous memory access but leads
+   *                           to significantly more work. Not advised for general 
+   *                           usage
    * 
    *    Currently accepted values for Device execution space:
    *      - "DEFAULT": Read as "REPLICATED"
-   *      - "REPLICATAED": Same as Host::REPLICATED-PETITE
+   *      - "REPLICATED": Same as Host::REPLICATED-PETITE
    */
   LoadBalancerFactory( ExecutionSpace ex, std::string kernel_name );
 

--- a/include/gauxc/load_balancer.hpp
+++ b/include/gauxc/load_balancer.hpp
@@ -26,7 +26,7 @@ namespace detail {
 /// State tracker for LoadBalancer instances 
 struct LoadBalancerState {
   bool modified_weights_are_stored = false; 
-    ///< Whether the load balancer currently stored partitioned weights
+    ///< Whether the load balancer currently stores partitioned weights
 };
 
 

--- a/src/molgrid_defaults.cxx
+++ b/src/molgrid_defaults.cxx
@@ -119,7 +119,7 @@ std::tuple<RadialSize,AngularSize>
       }
 
     default:
-      GAUXC_GENERIC_EXCEPTION("Not A Resognized Standard Grid");
+      GAUXC_GENERIC_EXCEPTION("Not A Recognized Standard Grid");
       abort();
   }
 

--- a/src/xc_integrator/local_work_driver/device/scheme1_base.cxx
+++ b/src/xc_integrator/local_work_driver/device/scheme1_base.cxx
@@ -303,34 +303,34 @@ void AoSScheme1Base::eval_zmat_mgga_vxc_rks( XCDeviceData* _data, bool do_lapl){
 
 void AoSScheme1Base::eval_zmat_lda_vxc_uks( XCDeviceData* ){
 
-  GAUXC_GENERIC_EXCEPTION("UKS NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("UKS Not Yet Implemented For Device");
 
 }
 
 void AoSScheme1Base::eval_zmat_gga_vxc_uks( XCDeviceData* ){
 
-  GAUXC_GENERIC_EXCEPTION("UKS NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("UKS Not Yet Implemented For Device");
 
 }
 
 void AoSScheme1Base::eval_zmat_mgga_vxc_uks( XCDeviceData*, bool /*do_lapl*/){
-  GAUXC_GENERIC_EXCEPTION("UKS MGGA NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("UKS MGGA Not Yet Implemented For Device");
 }
 
 void AoSScheme1Base::eval_zmat_lda_vxc_gks( XCDeviceData* ){
 
-  GAUXC_GENERIC_EXCEPTION("GKS NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("GKS Not Yet Implemented For Device");
 
 }
 
 void AoSScheme1Base::eval_zmat_gga_vxc_gks( XCDeviceData* ){
 
-  GAUXC_GENERIC_EXCEPTION("GKS NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("GKS Not Yet Implemented For Device");
 
 }
 
 void AoSScheme1Base::eval_zmat_mgga_vxc_gks( XCDeviceData*, bool /*do_lapl*/){
-  GAUXC_GENERIC_EXCEPTION("GKS MGGA NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("GKS MGGA Not Yet Implemented For Device");
 }
 
 void AoSScheme1Base::eval_mmat_mgga_vxc_rks( XCDeviceData* _data, bool do_lapl){
@@ -356,10 +356,10 @@ void AoSScheme1Base::eval_mmat_mgga_vxc_rks( XCDeviceData* _data, bool do_lapl){
   data->device_backend_->check_error("mmat_mgga" __FILE__ ": " + std::to_string(__LINE__));
 }
 void AoSScheme1Base::eval_mmat_mgga_vxc_uks( XCDeviceData*, bool /*do_lapl*/){
-  GAUXC_GENERIC_EXCEPTION("UKS MGGA NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("UKS MGGA Not Yet Implemented For Device");
 }
 void AoSScheme1Base::eval_mmat_mgga_vxc_gks( XCDeviceData*, bool /*do_lapl*/){
-  GAUXC_GENERIC_EXCEPTION("GKS MGGA NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("GKS MGGA Not Yet Implemented For Device");
 }
 
 void AoSScheme1Base::eval_collocation( XCDeviceData* _data ) {
@@ -622,35 +622,35 @@ void AoSScheme1Base::eval_uvvar_mgga_rks( XCDeviceData* _data, bool do_lapl ){
 
 void AoSScheme1Base::eval_uvvar_lda_uks( XCDeviceData* ){
 
-  GAUXC_GENERIC_EXCEPTION("UKS NOT YET IMPLEMENTED FOR DEVICE"); 
+  GAUXC_GENERIC_EXCEPTION("UKS Not Yet Implemented For Device"); 
 
 }
 
 void AoSScheme1Base::eval_uvvar_gga_uks( XCDeviceData* ){
 
-  GAUXC_GENERIC_EXCEPTION("UKS NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("UKS Not Yet Implemented For Device");
 
 }
 
 void AoSScheme1Base::eval_uvvar_mgga_uks( XCDeviceData*, bool /*do_lapl*/ ){
-  GAUXC_GENERIC_EXCEPTION("UKS MGGA NOT YET IMPLEMENTED FOR DEVICE"); 
+  GAUXC_GENERIC_EXCEPTION("UKS MGGA Not Yet Implemented For Device"); 
 }
 
 
 void AoSScheme1Base::eval_uvvar_lda_gks( XCDeviceData* ){
 
-    GAUXC_GENERIC_EXCEPTION("GKS NOT YET IMPLEMENTED FOR DEVICE");
+    GAUXC_GENERIC_EXCEPTION("GKS Not Yet Implemented For Device");
 
 }
 
 void AoSScheme1Base::eval_uvvar_gga_gks( XCDeviceData* ){
 
-    GAUXC_GENERIC_EXCEPTION("GKS NOT YET IMPLEMENTED FOR DEVICE");
+    GAUXC_GENERIC_EXCEPTION("GKS Not Yet Implemented For Device");
 
 }
 
 void AoSScheme1Base::eval_uvvar_mgga_gks( XCDeviceData*, bool /*do_lapl*/ ){
-  GAUXC_GENERIC_EXCEPTION("GKS MGGA NOT YET IMPLEMENTED FOR DEVICE"); 
+  GAUXC_GENERIC_EXCEPTION("GKS MGGA Not Yet Implemented For Device"); 
 }
 
 void AoSScheme1Base::eval_kern_exc_vxc_lda( const functional_type& func, 

--- a/src/xc_integrator/local_work_driver/factory.cxx
+++ b/src/xc_integrator/local_work_driver/factory.cxx
@@ -68,7 +68,7 @@ LocalWorkDriverFactory::ptr_return_t
 
 
   default:
-    GAUXC_GENERIC_EXCEPTION("Execution Space Not Regognized");
+    GAUXC_GENERIC_EXCEPTION("Execution Space Not Recognized");
 
   }
 

--- a/src/xc_integrator/local_work_driver/host/reference_local_host_work_driver.cxx
+++ b/src/xc_integrator/local_work_driver/host/reference_local_host_work_driver.cxx
@@ -628,7 +628,7 @@ void ReferenceLocalHostWorkDriver::eval_zmat_lda_vxc_gks( size_t npts, size_t nb
 							const double* dbasis_z_eval, const double* dden_x_eval, 
 							const double* dden_y_eval, const double* dden_z_eval, double* Z, size_t ldz ) {
 
-    if( ldz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
+    if( ldz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
     blas::lacpy( 'A', nbf, npts, basis_eval, nbf, Z, nbf );
 
     for( int32_t i = 0; i < (int32_t)npts; ++i ) {
@@ -664,8 +664,8 @@ void ReferenceLocalHostWorkDriver::eval_zmat_lda_vxc_gks( size_t npts, size_t nb
               size_t ldzs, double* Zz, size_t ldzz ) {
 
 
-    if( ldzs != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
-    if( ldzz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
+    if( ldzs != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
+    if( ldzz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
     blas::lacpy( 'A', nbf, npts, basis_eval, nbf, Zs, ldzs);
     blas::lacpy( 'A', nbf, npts, basis_eval, nbf, Zz, ldzz);
 
@@ -721,7 +721,7 @@ void ReferenceLocalHostWorkDriver::eval_zmat_lda_vxc_gks( size_t npts, size_t nb
               const double* dden_x_eval,
               const double* dden_y_eval, const double* dden_z_eval, double* Z, size_t ldz ) {
 
-    if( ldz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
+    if( ldz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
     blas::lacpy( 'A', nbf, npts, basis_eval, nbf, Z, nbf );
 
     for( int32_t i = 0; i < (int32_t)npts; ++i ) {
@@ -765,8 +765,8 @@ void ReferenceLocalHostWorkDriver::eval_zmat_mgga_vxc_uks( size_t npts, size_t n
               size_t ldzs, double* Zz, size_t ldzz ) {
 
 
-    if( ldzs != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
-    if( ldzz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
+    if( ldzs != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
+    if( ldzz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
     blas::lacpy( 'A', nbf, npts, basis_eval, nbf, Zs, ldzs);
     blas::lacpy( 'A', nbf, npts, basis_eval, nbf, Zz, ldzz);
 
@@ -828,7 +828,7 @@ void ReferenceLocalHostWorkDriver::eval_zmat_mgga_vxc_uks( size_t npts, size_t n
               const double* dbasis_z_eval,
               double* mmat_x, double* mmat_y, double* mmat_z, size_t ldm ) {
 
-    if( ldm != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
+    if( ldm != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
     
     blas::lacpy( 'A', nbf, npts, dbasis_x_eval, nbf, mmat_x, ldm);
     blas::lacpy( 'A', nbf, npts, dbasis_y_eval, nbf, mmat_y, ldm);
@@ -866,8 +866,8 @@ void ReferenceLocalHostWorkDriver::eval_mmat_mgga_vxc_uks(size_t npts, size_t nb
               double* mmat_xs, double* mmat_ys, double* mmat_zs, size_t ldms,
               double* mmat_xz, double* mmat_yz, double* mmat_zz, size_t ldmz) {
 
-    if( ldms != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
-    if( ldmz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
+    if( ldms != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
+    if( ldmz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
     
     blas::lacpy( 'A', nbf, npts, dbasis_x_eval, nbf, mmat_xs, ldms);
     blas::lacpy( 'A', nbf, npts, dbasis_y_eval, nbf, mmat_ys, ldms);
@@ -933,10 +933,10 @@ void ReferenceLocalHostWorkDriver::eval_zmat_gga_vxc_gks( size_t npts, size_t nb
     auto *HY = HZ + npts;
     auto *HX = HY + npts;
 
-    if( ldzs != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
-    if( ldzz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
-    if( ldzx != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
-    if( ldzy != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("INVALID DIMS"));
+    if( ldzs != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
+    if( ldzz != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
+    if( ldzx != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
+    if( ldzy != nbf ) GAUXC_GENERIC_EXCEPTION(std::string("Invalid Dims"));
 
     blas::lacpy( 'A', nbf, npts, basis_eval, nbf, Zs, ldzs);
     blas::lacpy( 'A', nbf, npts, basis_eval, nbf, Zz, ldzz);

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc_grad.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc_grad.hpp
@@ -99,7 +99,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
   // Check that Partition Weights have been calculated
   auto& lb_state = this->load_balancer_->state();
   if( not lb_state.modified_weights_are_stored ) {
-    GAUXC_GENERIC_EXCEPTION("Weights Have Not Beed Modified"); 
+    GAUXC_GENERIC_EXCEPTION("Weights Have Not Been Modified"); 
   }
 
   // Do XC integration in task batches

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc_vxc.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc_vxc.hpp
@@ -117,7 +117,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
                       value_type* VXCz, int64_t ldvxcz,
                       value_type* EXC, const IntegratorSettingsXC& settings ) {
   GauXC::util::unused(m,n,Ps,ldps,Pz,ldpz,VXCs,ldvxcs,VXCz,ldvxcz,EXC,settings);
-  GAUXC_GENERIC_EXCEPTION("UKS NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("UKS Not Yet Implemented For Device");
 }
 
 template <typename ValueType>
@@ -136,7 +136,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
                       value_type* VXCx, int64_t ldvxcx,
                       value_type* EXC, const IntegratorSettingsXC& settings ) {
   GauXC::util::unused(m,n,Ps,ldps,Pz,ldpz,Py,ldpy,Px,ldpx,VXCs,ldvxcs,VXCz,ldvxcz,VXCy,ldvxcy,VXCx,ldvxcx,EXC,settings);
-  GAUXC_GENERIC_EXCEPTION("GKS NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("GKS Not Yet Implemented For Device");
 }
 
 
@@ -170,7 +170,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
   // Check that Partition Weights have been calculated
   auto& lb_state = this->load_balancer_->state();
   if( not lb_state.modified_weights_are_stored ) {
-    GAUXC_GENERIC_EXCEPTION("Weights Have Not Beed Modified"); 
+    GAUXC_GENERIC_EXCEPTION("Weights Have Not Been Modified"); 
   }
 
 #if 0
@@ -305,7 +305,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
                             host_task_iterator task_begin, host_task_iterator task_end,
                             XCDeviceData& device_data ) {
   GauXC::util::unused(basis,Ps,ldps,Pz,ldpz,task_begin,task_end,device_data);
-  GAUXC_GENERIC_EXCEPTION("UKS NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("UKS Not Yet Implemented For Device");
 }
 
 template <typename ValueType>
@@ -318,7 +318,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
                             XCDeviceData& device_data ) {
 
   GauXC::util::unused(basis,Ps,ldps,Pz,ldpz,VXCs,ldvxcs,VXCz,ldvxcz,EXC,N_EL,task_begin,task_end,device_data);
-  GAUXC_GENERIC_EXCEPTION("UKS NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("UKS Not Yet Implemented For Device");
 }
 
 template <typename ValueType>
@@ -330,7 +330,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
                             host_task_iterator task_begin, host_task_iterator task_end,
                             XCDeviceData& device_data ) {
   GauXC::util::unused(basis,Ps,ldps,Pz,ldpz,Py,ldpy,Px,ldpx,task_begin,task_end,device_data);
-  GAUXC_GENERIC_EXCEPTION("GKS NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("GKS Not Yet Implemented For Device");
 }
 
 template <typename ValueType>
@@ -347,7 +347,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
                             XCDeviceData& device_data ) {
 
   GauXC::util::unused(basis,Ps,ldps,Pz,ldpz,Py,ldpy,Px,ldpx,VXCs,ldvxcs,VXCz,ldvxcz,VXCy,ldvxcy,VXCx,ldvxcx,EXC,N_EL,task_begin,task_end,device_data);
-  GAUXC_GENERIC_EXCEPTION("GKS NOT YET IMPLEMENTED FOR DEVICE");
+  GAUXC_GENERIC_EXCEPTION("GKS Not Yet Implemented For Device");
 }
 
 

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exx.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exx.hpp
@@ -142,7 +142,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
   // Check that Partition Weights have been calculated
   auto& lb_state = this->load_balancer_->state();
   if( not lb_state.modified_weights_are_stored ) {
-    GAUXC_GENERIC_EXCEPTION("Weights Have Not Beed Modified"); 
+    GAUXC_GENERIC_EXCEPTION("Weights Have Not Been Modified"); 
   }
 
   // Reset the coulomb screening data
@@ -254,7 +254,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
   // Check that Partition Weights have been calculated
   auto& lb_state = this->load_balancer_->state();
   if( not lb_state.modified_weights_are_stored ) {
-    GAUXC_GENERIC_EXCEPTION("Weights Have Not Beed Modified"); 
+    GAUXC_GENERIC_EXCEPTION("Weights Have Not Been Modified"); 
   }
 
     task_end = std::stable_partition( task_begin, task_end,

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_integrate_den.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_integrate_den.hpp
@@ -72,10 +72,6 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
                        int64_t ldp, value_type* N_EL,
                        host_task_iterator task_begin, host_task_iterator task_end,
                        XCDeviceData& device_data ) {
-#if 0
-  GAUXC_GENERIC_EXCEPTION("NYI");
-#else
-
 
   auto* lwd = dynamic_cast<LocalDeviceWorkDriver*>(this->local_work_driver_.get() );
 
@@ -99,7 +95,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
   // Check that Partition Weights have been calculated
   auto& lb_state = this->load_balancer_->state();
   if( not lb_state.modified_weights_are_stored ) {
-    GAUXC_GENERIC_EXCEPTION("Weights Have Not Beed Modified"); 
+    GAUXC_GENERIC_EXCEPTION("Weights Have Not Been Modified"); 
   }
 
   // Do XC integration in task batches
@@ -143,7 +139,6 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
   this->timer_.time_op("XCIntegrator.DeviceToHostCopy",[&](){
     device_data.retrieve_den_integrands( N_EL );
   });
-#endif
 }
 
 }

--- a/src/xc_integrator/replicated/device/replicated_xc_device_integrator.cxx
+++ b/src/xc_integrator/replicated/device/replicated_xc_device_integrator.cxx
@@ -49,7 +49,7 @@ typename ReplicatedXCDeviceIntegratorFactory<ValueType>::ptr_return_t
     );
 
   else
-    GAUXC_GENERIC_EXCEPTION("INTEGRATOR KERNEL " + integrator_kernel + " NOT RECOGNIZED");
+    GAUXC_GENERIC_EXCEPTION("Integrator Kernel " + integrator_kernel + " Not Recognized");
 
 
 }

--- a/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_exc_grad.hpp
+++ b/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_exc_grad.hpp
@@ -88,7 +88,7 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
   // Check that Partition Weights have been calculated
   auto& lb_state = this->load_balancer_->state();
   if( not lb_state.modified_weights_are_stored ) {
-    GAUXC_GENERIC_EXCEPTION("Weights Have Not Beed Modified"); 
+    GAUXC_GENERIC_EXCEPTION("Weights Have Not Been Modified"); 
   }
 
   // Zero out integrands

--- a/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_exc_vxc.hpp
+++ b/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_exc_vxc.hpp
@@ -117,7 +117,7 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
   const bool is_uks = (Pz != nullptr) and (VXCz != nullptr) and (VXCy == nullptr) and (VXCx == nullptr);
   const bool is_rks = not is_uks and not is_gks;
   if (not is_rks and not is_uks and not is_gks) {
-    GAUXC_GENERIC_EXCEPTION("MUST BE EITHER RKS, UKS, or GKS!");
+    GAUXC_GENERIC_EXCEPTION("Must Be Either RKS, UKS, or GKS!");
   }
 
 
@@ -139,7 +139,7 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
   const bool needs_laplacian = func.needs_laplacian(); 
   
   if (func.is_mgga() and is_gks) {
-    GAUXC_GENERIC_EXCEPTION("GKS NOT YET IMPLEMENTED WITH mGGA FUNCTIONALS!");
+    GAUXC_GENERIC_EXCEPTION("GKS Not Yet Implemented With MGGA Functionals!");
   }
 
   // Get basis map
@@ -159,7 +159,7 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
   // Check that Partition Weights have been calculated
   auto& lb_state = this->load_balancer_->state();
   if( not lb_state.modified_weights_are_stored ) {
-    GAUXC_GENERIC_EXCEPTION("Weights Have Not Beed Modified");
+    GAUXC_GENERIC_EXCEPTION("Weights Have Not Been Modified");
   }
 
   // Zero out integrands

--- a/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_exx.hpp
+++ b/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_exx.hpp
@@ -40,13 +40,13 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
   // Check that P / VXC are sane
   const int64_t nbf = basis.nbf();
   if( m != n ) 
-    GAUXC_GENERIC_EXCEPTION(" P/VXC Must Be Square");
+    GAUXC_GENERIC_EXCEPTION("P/VXC Must Be Square");
   if( m != nbf ) 
-    GAUXC_GENERIC_EXCEPTION(" P/VXC Must Have Same Dimension as Basis");
+    GAUXC_GENERIC_EXCEPTION("P/VXC Must Have Same Dimension as Basis");
   if( ldp < nbf )
-    GAUXC_GENERIC_EXCEPTION(" Invalid LDP");
+    GAUXC_GENERIC_EXCEPTION("Invalid LDP");
   if( ldk < nbf )
-    GAUXC_GENERIC_EXCEPTION(" Invalid LDVXC");
+    GAUXC_GENERIC_EXCEPTION("Invalid LDVXC");
 
 
   // Get Tasks
@@ -296,7 +296,7 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
   // Check that Partition Weights have been calculated
   auto& lb_state = this->load_balancer_->state();
   if( not lb_state.modified_weights_are_stored ) {
-    GAUXC_GENERIC_EXCEPTION("Weights Have Not Beed Modified"); 
+    GAUXC_GENERIC_EXCEPTION("Weights Have Not Been Modified"); 
   }
 
   // Zero out integrands

--- a/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_integrate_den.hpp
+++ b/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_integrate_den.hpp
@@ -82,7 +82,7 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
   // Compute Partition Weights
   auto& lb_state = this->load_balancer_->state();
   if( not lb_state.modified_weights_are_stored ) {
-    GAUXC_GENERIC_EXCEPTION("Weights Have Not Beed Modified"); 
+    GAUXC_GENERIC_EXCEPTION("Weights Have Not Been Modified"); 
   }
 
 

--- a/src/xc_integrator/replicated/host/replicated_xc_host_integrator.cxx
+++ b/src/xc_integrator/replicated/host/replicated_xc_host_integrator.cxx
@@ -49,7 +49,7 @@ typename ReplicatedXCHostIntegratorFactory<ValueType>::ptr_return_t
     );
 
   else
-    GAUXC_GENERIC_EXCEPTION("INTEGRATOR KERNEL: " + integrator_kernel + " NOT RECOGNIZED");
+    GAUXC_GENERIC_EXCEPTION("Integrator Kernel: " + integrator_kernel + " Not Recognized");
 
   return nullptr;
 

--- a/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_exc_grad.hpp
+++ b/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_exc_grad.hpp
@@ -18,7 +18,7 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
   eval_exc_grad_( int64_t m, int64_t n, const value_type* P,
                  int64_t ldp, value_type* EXC_GRAD ) { 
                  
-  GAUXC_GENERIC_EXCEPTION("NYI" );                 
+  GAUXC_GENERIC_EXCEPTION("ShellBatched exc_grad NYI" );                 
   util::unused(m,n,P,ldp,EXC_GRAD);
 }
 

--- a/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_exx.hpp
+++ b/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_exx.hpp
@@ -18,7 +18,7 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
   eval_exx_( int64_t m, int64_t n, const value_type* P,
              int64_t ldp, value_type* K, int64_t ldk, 
              const IntegratorSettingsEXX& settings ) { 
-  GAUXC_GENERIC_EXCEPTION("NYI" );                 
+  GAUXC_GENERIC_EXCEPTION("ShellBatched EXX NYI");                 
   util::unused(m,n,P,ldp,K,ldk,settings);
 }
 

--- a/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_integrate_den.hpp
+++ b/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_integrate_den.hpp
@@ -18,7 +18,7 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
   integrate_den_( int64_t m, int64_t n, const value_type* P,
                  int64_t ldp, value_type* N_EL ) { 
                  
-  GAUXC_GENERIC_EXCEPTION("NYI" );                 
+  GAUXC_GENERIC_EXCEPTION("ShellBatched integrate_den NYI" );                 
   util::unused(m,n,P,ldp,N_EL);
 }
 

--- a/src/xc_integrator/xc_data/device/xc_device_data.hpp
+++ b/src/xc_integrator/xc_data/device/xc_device_data.hpp
@@ -249,7 +249,7 @@ struct required_term_storage {
     const bool is_xc = tracker.exc_vxc or tracker.exc_grad;
     if(is_xc) {
       if( tracker.xc_approx == _UNDEFINED )
-        GAUXC_GENERIC_EXCEPTION("NO XC APPROX SET");
+        GAUXC_GENERIC_EXCEPTION("No XC Approx Set");
       //const bool is_lda  = is_xc and tracker.xc_approx == LDA;
       const bool is_gga  = is_xc and tracker.xc_approx == GGA;
       const bool need_tau  = tracker.xc_approx == MGGA_TAU;

--- a/src/xc_integrator/xc_data/device/xc_device_stack_data.cxx
+++ b/src/xc_integrator/xc_data/device/xc_device_stack_data.cxx
@@ -724,13 +724,13 @@ void XCDeviceStackData::pack_and_send( integrator_term_tracker ,
   } // Loop over tasks
 
   if( points_x_pack.size() != total_npts_task_batch )
-    GAUXC_GENERIC_EXCEPTION("Inconsisdent Points-X allocation");
+    GAUXC_GENERIC_EXCEPTION("Inconsistent Points-X allocation");
   if( points_y_pack.size() != total_npts_task_batch )
-    GAUXC_GENERIC_EXCEPTION("Inconsisdent Points-Y allocation");
+    GAUXC_GENERIC_EXCEPTION("Inconsistent Points-Y allocation");
   if( points_z_pack.size() != total_npts_task_batch )
-    GAUXC_GENERIC_EXCEPTION("Inconsisdent Points-Z allocation");
+    GAUXC_GENERIC_EXCEPTION("Inconsistent Points-Z allocation");
   if( weights_pack.size() != total_npts_task_batch )
-    GAUXC_GENERIC_EXCEPTION("Inconsisdent weights allocation");
+    GAUXC_GENERIC_EXCEPTION("Inconsistent weights allocation");
 
 
 
@@ -760,7 +760,7 @@ void XCDeviceStackData::copy_weights_to_tasks( host_task_iterator task_begin, ho
     []( const auto& a, const auto& b ) { return a + b.points.size(); } );
 
   if( local_npts != total_npts_task_batch )
-    GAUXC_GENERIC_EXCEPTION("NPTS MISMATCH");
+    GAUXC_GENERIC_EXCEPTION("NPTS Mismatch");
 
   // Copy weights into contiguous host data
   std::vector<double> weights_host(local_npts);


### PR DESCRIPTION
Users of GauXC deserve well-formatted, typo-free error messages. This PR fixes some typos and enforces a standard capitalization scheme in user-facing messages, plus fixes a few comments here and there.