### PR TITLE
Bump `actions/checkout` Version

### DIFF
--- a/.github/workflows/build_and_test_compiler_zoo.yml
+++ b/.github/workflows/build_and_test_compiler_zoo.yml
@@ -22,7 +22,7 @@ jobs:
               openmp_flag: ON
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Compiler 
       shell: bash
@@ -71,7 +71,7 @@ jobs:
             flags: [ {magma: OFF, cutlass: OFF}, {magma: ON, cutlass: OFF}, {magma: OFF, cutlass: ON} ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Build Type
       shell: bash
@@ -109,7 +109,7 @@ jobs:
         image: dbwy/chemistry
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Compiler 
       shell: bash
@@ -142,7 +142,7 @@ jobs:
         image: dbwy/chemistry
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Compiler 
       shell: bash
@@ -170,7 +170,7 @@ jobs:
         image: dbwy/chemistry
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Compiler 
       shell: bash


### PR DESCRIPTION
Actions keeps complaining about an deprecated node.js version, bumping the checkout version addresses this