### PR TITLE
add missing `#include <cstdint>` to `shell_pair.hpp`

### DIFF
--- a/include/gauxc/shell_pair.hpp
+++ b/include/gauxc/shell_pair.hpp
@@ -10,6 +10,8 @@
 #include <gauxc/basisset.hpp>
 #include <gauxc/exceptions.hpp>
 
+#include <cstdint>
+
 namespace GauXC {
 namespace detail {
   struct cartesian_point {


### PR DESCRIPTION
gcc 13.2 fails to build otherwise