### PR TITLE
add missing `std::` to `shell_pair.hpp`

### DIFF
--- a/include/gauxc/shell_pair.hpp
+++ b/include/gauxc/shell_pair.hpp
@@ -19,7 +19,7 @@ namespace detail {
   };
 
   template <typename Integral>
-  inline intmax_t csr_index( size_t i, size_t j, Integral* row_ptr, Integral* col_ind ) {
+  inline std::intmax_t csr_index( size_t i, size_t j, Integral* row_ptr, Integral* col_ind ) {
     const auto j_st = col_ind + row_ptr[i];
     const auto j_en = col_ind + row_ptr[i+1];
     auto it = std::lower_bound(j_st, j_en, j);


### PR DESCRIPTION
Continues the good work of #136.

Current `GauXC` is killing Psi4's CI's `gcc 14.2` lane due to `error: ‘intmax_t’ does not name a type; did you mean ‘int8_t’?`. Let's give the compiler some help in finding this.