### PR TITLE
Fixes Molecule Ctors

### DIFF
--- a/include/gauxc/molecule.hpp
+++ b/include/gauxc/molecule.hpp
@@ -16,10 +16,16 @@
 namespace GauXC {
 
 class Molecule : public std::vector<Atom> {
+private:
+  /// Testes if the base class can be constructed from @p Args
+  template <typename... Args>
+  using can_construct_base_t = 
+    std::is_constructible_v<std::vector<Atom>, Args...>;
 
 public:
 
-  template <typename... Args>
+  template <typename... Args, 
+            typename = std::enable_if_t<can_construct_base_t<Args...>>>
   Molecule( Args&&... args ) :
     std::vector<Atom>( std::forward<Args>(args)... ) { }
 

--- a/include/gauxc/molecule.hpp
+++ b/include/gauxc/molecule.hpp
@@ -17,15 +17,15 @@ namespace GauXC {
 
 class Molecule : public std::vector<Atom> {
 private:
-  /// Testes if the base class can be constructed from @p Args
+  /// Tests if the base class can be constructed from @p Args
   template <typename... Args>
-  using can_construct_base_t = 
+  static constexpr auto can_construct_base_v = 
     std::is_constructible_v<std::vector<Atom>, Args...>;
 
 public:
 
   template <typename... Args, 
-            typename = std::enable_if_t<can_construct_base_t<Args...>>>
+            typename = std::enable_if_t<can_construct_base_v<Args...>>>
   Molecule( Args&&... args ) :
     std::vector<Atom>( std::forward<Args>(args)... ) { }
 

--- a/tests/ini_input.hpp
+++ b/tests/ini_input.hpp
@@ -24,7 +24,7 @@
  */
 static inline std::string& trim_left(std::string &s) {
     s.erase(s.begin(), std::find_if(s.begin(), s.end(),
-            std::not1(std::ptr_fun<int, int>(std::isspace))));
+            [](int ch) { return !std::isspace(ch); }));
     return s;
 }; // trim_left
 
@@ -36,7 +36,7 @@ static inline std::string& trim_left(std::string &s) {
  */
 static inline std::string& trim_right(std::string &s) {
     s.erase(std::find_if(s.rbegin(), s.rend(),
-            std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+            [](int ch) { return !std::isspace(ch); }).base(), s.end());
     return s;
 }; // trim_right
 

--- a/tests/moltypes_test.cxx
+++ b/tests/moltypes_test.cxx
@@ -47,6 +47,13 @@ TEST_CASE("Molecule", "[moltypes]") {
 
   size_t natoms_gen = 40;
 
+  SECTION("Default") {
+
+    Molecule mol;
+
+    CHECK(mol.natoms() == 0);
+  }
+
   SECTION("From std::vector<Atom>") {
 
     std::vector<Atom> atoms;
@@ -113,6 +120,25 @@ TEST_CASE("Molecule", "[moltypes]") {
 
   }
 
+  SECTION("Copy ctor") {
+
+    std::vector<Atom> atoms{Atom(AtomicNumber(1), 0.0, 0.0, 0.0)};
+    Molecule mol(atoms);
+
+    Molecule mol_copy(mol);
+    CHECK(mol == mol_copy);
+  }
+
+
+  SECTION("Move ctor") {
+
+    std::vector<Atom> atoms{Atom(AtomicNumber(1), 0.0, 0.0, 0.0)};
+    Molecule mol(atoms);
+
+    Molecule mol_copy(mol);
+    Molecule mol_move(std::move(mol));
+    CHECK(mol_move == mol_copy);
+  }
 
 }
 


### PR DESCRIPTION
The original templated ctor has a signature compatible with copy/move construction and a  higher precedence than the copy/move ctors. In turn, attempting to copy/move a `Molecule` object causes the compiler to pick the templated ctor, which leads to a compiler error. 

This PR:
- Introduces SFINAE to fix the titular problem.
- Adds unit tests so this doesn't break again.
- Removes the use of some deprecated C++ standard library functions.