### PR TITLE
Allow building of shared libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@ include( gauxc-integratorxx )
 include( gauxc-exchcxx      )
 
 
-add_library( gauxc STATIC 
+add_library( gauxc 
   grid.cxx 
   grid_impl.cxx 
   grid_factory.cxx


### PR DESCRIPTION
Remove STATIC attribute from gauxc library to allow building shared libraries with `-DBUILD_SHARED_LIBS=ON`

Closes #159 