### PR TITLE
Fetch dependencies as tarballs and verify checksums

### DIFF
--- a/cmake/gauxc-cub.cmake
+++ b/cmake/gauxc-cub.cmake
@@ -5,13 +5,13 @@ if( GAUXC_HAS_CUDA )
     include( gauxc-dep-versions )
 
     message( STATUS "Building Local CUB Installation" )
-    message( STATUS "CUB REPO = ${GAUXC_CUB_REPOSITORY}" )
-    message( STATUS "CUB REV  = ${GAUXC_CUB_REVISION}"   )
+    message( STATUS "CUB URL = ${GAUXC_CUB_URL}" )
 
     FetchContent_Declare(
       cub
-      GIT_REPOSITORY ${GAUXC_CUB_REPOSITORY} 
-      GIT_TAG        ${GAUXC_CUB_REVISION} 
+      URL ${GAUXC_CUB_URL}
+      URL_HASH SHA256=${GAUXC_CUB_SHA256}
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     )
 
     FetchContent_GetProperties( cub )

--- a/cmake/gauxc-cutlass.cmake
+++ b/cmake/gauxc-cutlass.cmake
@@ -8,13 +8,13 @@ endforeach()
 include( gauxc-dep-versions )
 
 message( STATUS "Building Local CUTLASS Installation" )
-message( STATUS "CUTLASS REPO = ${GAUXC_CUTLASS_REPOSITORY}" )
-message( STATUS "CUTLASS REV  = ${GAUXC_CUTLASS_REVISION}"   )
+message( STATUS "CUTLASS URL = ${GAUXC_CUTLASS_URL}" )
 
 FetchContent_Declare(
   cutlass
-  GIT_REPOSITORY ${GAUXC_CUTLASS_REPOSITORY} 
-  GIT_TAG        ${GAUXC_CUTLASS_REVISION} 
+  URL ${GAUXC_CUTLASS_URL}
+  URL_HASH SHA256=${GAUXC_CUTLASS_SHA256}
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 FetchContent_GetProperties( cutlass )

--- a/cmake/gauxc-dep-versions.cmake
+++ b/cmake/gauxc-dep-versions.cmake
@@ -1,20 +1,23 @@
 set( GAUXC_LINALG_MODULES_REPOSITORY https://github.com/wavefunction91/linalg-cmake-modules.git )
 set( GAUXC_LINALG_MODULES_REVISION  9d2c273a671d6811e9fd432f6a4fa3d915b144b8 )
 
-set( GAUXC_CUB_REPOSITORY https://github.com/NVIDIA/cub.git )
-set( GAUXC_CUB_REVISION   1.10.0 )
+set( GAUXC_CUB_URL https://github.com/NVIDIA/cub/archive/refs/tags/1.10.0.tar.gz )
+set( GAUXC_CUB_SHA256 8531e09f909aa021125cffa70a250761dfc247f960d7a1a12f65e6651ffb6477 )
 
-set( GAUXC_CUTLASS_REPOSITORY https://github.com/NVIDIA/cutlass.git )
-set( GAUXC_CUTLASS_REVISION v2.10.0 )
+set( GAUXC_CUTLASS_URL https://github.com/NVIDIA/cutlass/archive/refs/tags/v2.10.0.tar.gz )
+set( GAUXC_CUTLASS_SHA256 8f56727c0c7ca59f67f6904972958a6e7e925f72e112056e6df7bb3fdeacefd7 )
+
+set( GAUXC_EIGEN3_URL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz )
+set( GAUXC_EIGEN3_SHA256 8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72 )
 
 set( GAUXC_EXCHCXX_REPOSITORY https://github.com/wavefunction91/ExchCXX.git )
 set( GAUXC_EXCHCXX_REVISION   v1.0.0 )
 
-set( GAUXC_GAU2GRID_REPOSITORY https://github.com/dgasmith/gau2grid.git )
-set( GAUXC_GAU2GRID_REVISION   v2.0.6 )
+set( GAUXC_GAU2GRID_URL https://github.com/psi4/gau2grid/archive/refs/tags/v2.0.6.tar.gz )
+set( GAUXC_GAU2GRID_SHA256 36217829819d569bc8d22c7c87ac5f07d3aa11e85a840dabd5d1cb29cd27ecf8 )
 
 set( GAUXC_INTEGRATORXX_REPOSITORY https://github.com/wavefunction91/IntegratorXX.git )
 set( GAUXC_INTEGRATORXX_REVISION   1369be58d7a3235dac36d75dd964fef058830622 )
 
-set( GAUXC_HIGHFIVE_REPOSITORY https://github.com/highfive-devs/HighFive.git )
-set( GAUXC_HIGHFIVE_REVISION 805f0e13d09b47c4b01d40682621904aa3b31bb8 )
+set( GAUXC_HIGHFIVE_URL https://github.com/highfive-devs/highfive/archive/refs/tags/v2.5.0.tar.gz )
+set( GAUXC_HIGHFIVE_SHA256 28e1f16590cd803167e27c952de96b0cdbbe183bf455d52945424b0d545c41e0 )

--- a/cmake/gauxc-eigen3.cmake
+++ b/cmake/gauxc-eigen3.cmake
@@ -2,12 +2,14 @@ find_package( Eigen3 CONFIG HINTS ${EIGEN3_ROOT_DIR} )
 if( NOT Eigen3_FOUND )
   
   message( STATUS "Could Not Find Eigen3... Building" )
-  message( STATUS "EIGEN3 REPO = https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz" )
+  message( STATUS "EIGEN3 URL = ${GAUXC_EIGEN3_URL}" )
   #message( STATUS "EIGEN3 REV  = "   )
 
   FetchContent_Declare(
     eigen3
-    URL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+    URL ${GAUXC_EIGEN3_URL}
+    URL_HASH SHA256=${GAUXC_EIGEN3_SHA256}
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
   )
 
   FetchContent_GetProperties( eigen3 )

--- a/cmake/gauxc-gau2grid.cmake
+++ b/cmake/gauxc-gau2grid.cmake
@@ -12,13 +12,13 @@ if( GAUXC_ENABLE_GAU2GRID )
         
         include( gauxc-dep-versions )
         
-        message( STATUS "GAU2GRID REPO = ${GAUXC_GAU2GRID_REPOSITORY}" )
-        message( STATUS "GAU2GRID REV  = ${GAUXC_GAU2GRID_REVISION}"   )
+        message( STATUS "GAU2GRID URL = ${GAUXC_GAU2GRID_URL}" )
         
         FetchContent_Declare(
           gau2grid
-          GIT_REPOSITORY ${GAUXC_GAU2GRID_REPOSITORY} 
-          GIT_TAG        ${GAUXC_GAU2GRID_REVISION} 
+          URL ${GAUXC_GAU2GRID_URL}
+          URL_HASH SHA256=${GAUXC_GAU2GRID_SHA256}
+          DOWNLOAD_EXTRACT_TIMESTAMP TRUE
         )
         
         set( MAX_AM 6 CACHE STRING "" )

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -17,11 +17,11 @@ if( GAUXC_ENABLE_HDF5 )
     message(STATUS "Enabling HDF5 Bindings")
     find_package(HighFive QUIET)
     if(NOT HighFive_FOUND)
-      message(STATUS "HighFive REPO = ${GAUXC_HIGHFIVE_REPOSITORY}")
-      message(STATUS "HighFive REV  = ${GAUXC_HIGHFIVE_REVISION}  ")
+      message(STATUS "HighFive URL = ${GAUXC_HIGHFIVE_URL}")
       FetchContent_Declare( HighFive
-        GIT_REPOSITORY ${GAUXC_HIGHFIVE_REPOSITORY}
-        GIT_TAG        ${GAUXC_HIGHFIVE_REVISION}  
+        URL ${GAUXC_HIGHFIVE_URL}
+        URL_HASH SHA256=${GAUXC_HIGHFIVE_SHA256}
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
       )
     
       set(HIGHFIVE_USE_BOOST OFF CACHE BOOL "" )


### PR DESCRIPTION
Download dependencies via FetchContent as tarball rather than git repo, verify tarballs based on their checksum.