### PR TITLE
Add sanity check for number of primitives

### DIFF
--- a/include/gauxc/shell.hpp
+++ b/include/gauxc/shell.hpp
@@ -138,6 +138,9 @@ public:
     alpha_( alpha ), coeff_( coeff ), O_( O ),
     nprim_( nprim.get() ), l_( l.get() ), pure_( pure.get() ) {
 
+    if(nprim_ > detail::shell_nprim_max)
+      throw std::out_of_range("Shell has too many primitives!\n");
+
     if( _normalize ) normalize();
     compute_shell_cutoff();
 

--- a/include/gauxc/shell.hpp
+++ b/include/gauxc/shell.hpp
@@ -14,6 +14,8 @@
 #include <array>
 #include <cmath>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 #include <cassert>
 #include <algorithm>
 #include <tuple>
@@ -138,7 +140,7 @@ public:
     alpha_( alpha ), coeff_( coeff ), O_( O ),
     nprim_( nprim.get() ), l_( l.get() ), pure_( pure.get() ) {
 
-    if(nprim_ > detail::shell_nprim_max) {
+    if(nprim_ > static_cast<int32_t>(detail::shell_nprim_max)) {
       std::ostringstream oss;
       oss << "Shell has too many primitives! expected <= " << detail::shell_nprim_max << " actual value " << nprim_ << "!\n";
       throw std::out_of_range(oss.str());

--- a/include/gauxc/shell.hpp
+++ b/include/gauxc/shell.hpp
@@ -138,8 +138,11 @@ public:
     alpha_( alpha ), coeff_( coeff ), O_( O ),
     nprim_( nprim.get() ), l_( l.get() ), pure_( pure.get() ) {
 
-    if(nprim_ > detail::shell_nprim_max)
-      throw std::out_of_range("Shell has too many primitives!\n");
+    if(nprim_ > detail::shell_nprim_max) {
+      std::ostringstream oss;
+      oss << "Shell has too many primitives! expected <= " << detail::shell_nprim_max << " actual value " << nprim_ << "!\n";
+      throw std::out_of_range(oss.str());
+    }
 
     if( _normalize ) normalize();
     compute_shell_cutoff();

--- a/tests/basisset_test.cxx
+++ b/tests/basisset_test.cxx
@@ -20,6 +20,8 @@
 
 #include <random>
 #include <algorithm>
+#include <stdexcept>
+#include <string>
 
 #include <gauxc/gauxc_config.hpp>
 
@@ -181,6 +183,25 @@ TEST_CASE("Shell", "[basisset]") {
       alpha, coeff, center );
 
     CHECK( sh.size() == 5 );
+
+  }
+
+  SECTION("Too Many Primitives") {
+
+    const auto nprim = PrimSize(detail::shell_nprim_max + 1);
+    const prim_array alpha = {0.8};
+    const prim_array coeff = {0.5};
+
+    try {
+      Shell<double> sh( nprim, AngularMomentum(0), SphericalType(false),
+        alpha, coeff, center );
+      FAIL( "Expected Shell construction to throw" );
+    } catch( const std::out_of_range& ex ) {
+      const std::string message = ex.what();
+      CHECK( message.find( "Shell has too many primitives!" ) != std::string::npos );
+      CHECK( message.find( "expected <= 32" ) != std::string::npos );
+      CHECK( message.find( "actual value 33" ) != std::string::npos );
+    }
 
   }
 


### PR DESCRIPTION
There's no check in GauXC on the maximum allowed number of primitives. I think any faulty code might error out even earlier due to overflows in the passed-in arrays, but this check will at least crash the code after the memory violation has occurred instead of producing faulty results.