### PR TITLE
Implement API with output values allocated by user

### DIFF
--- a/include/gauxc/xc_integrator.hpp
+++ b/include/gauxc/xc_integrator.hpp
@@ -69,10 +69,17 @@ public:
 
   exc_vxc_type_rks  eval_exc_vxc ( const MatrixType&, 
                                    const IntegratorSettingsXC& = IntegratorSettingsXC{} );
+  void eval_exc_vxc ( value_type&, MatrixType&, const MatrixType&,
+                       const IntegratorSettingsXC& = IntegratorSettingsXC{} );
   exc_vxc_type_uks  eval_exc_vxc ( const MatrixType&, const MatrixType&,
                                    const IntegratorSettingsXC& = IntegratorSettingsXC{} );
+  void eval_exc_vxc ( value_type&, MatrixType&, MatrixType&, const MatrixType&, const MatrixType&,
+                       const IntegratorSettingsXC& = IntegratorSettingsXC{} );
   exc_vxc_type_gks  eval_exc_vxc ( const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&,
                                    const IntegratorSettingsXC& = IntegratorSettingsXC{});
+  void eval_exc_vxc ( value_type&, MatrixType&, MatrixType&, MatrixType&, MatrixType&,
+                       const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&,
+                       const IntegratorSettingsXC& = IntegratorSettingsXC{});
 
   exc_grad_type eval_exc_grad( const MatrixType&, const IntegratorSettingsXC& = IntegratorSettingsXC{} );
   exc_grad_type eval_exc_grad( const MatrixType&, const MatrixType&, const IntegratorSettingsXC& = IntegratorSettingsXC{} );

--- a/include/gauxc/xc_integrator.hpp
+++ b/include/gauxc/xc_integrator.hpp
@@ -64,8 +64,12 @@ public:
   value_type    integrate_den( const MatrixType& );
 
   value_type    eval_exc( const MatrixType&, const IntegratorSettingsXC& = IntegratorSettingsXC{} );
+  void          eval_exc( value_type&, const MatrixType&, const IntegratorSettingsXC& = IntegratorSettingsXC{} );
   value_type    eval_exc( const MatrixType&, const MatrixType&, const IntegratorSettingsXC& = IntegratorSettingsXC{} );
+  void          eval_exc( value_type&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& = IntegratorSettingsXC{} );
   value_type    eval_exc( const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&,  const IntegratorSettingsXC& = IntegratorSettingsXC{} );
+  void          eval_exc( value_type&, const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&,
+                           const IntegratorSettingsXC& = IntegratorSettingsXC{} );
 
   exc_vxc_type_rks  eval_exc_vxc ( const MatrixType&, 
                                    const IntegratorSettingsXC& = IntegratorSettingsXC{} );
@@ -82,18 +86,28 @@ public:
                        const IntegratorSettingsXC& = IntegratorSettingsXC{});
 
   exc_grad_type eval_exc_grad( const MatrixType&, const IntegratorSettingsXC& = IntegratorSettingsXC{} );
+  void          eval_exc_grad( exc_grad_type&, const MatrixType&, const IntegratorSettingsXC& = IntegratorSettingsXC{} );
   exc_grad_type eval_exc_grad( const MatrixType&, const MatrixType&, const IntegratorSettingsXC& = IntegratorSettingsXC{} );
+  void          eval_exc_grad( exc_grad_type&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& = IntegratorSettingsXC{} );
 
   exx_type      eval_exx     ( const MatrixType&, 
+                               const IntegratorSettingsEXX& = IntegratorSettingsEXX{} );
+  void          eval_exx     ( MatrixType&, const MatrixType&, 
                                const IntegratorSettingsEXX& = IntegratorSettingsEXX{} );
 
   fxc_contraction_type_rks  eval_fxc_contraction ( const MatrixType&, const MatrixType&,
                                   const IntegratorSettingsXC& = IntegratorSettingsXC{} );
+  void          eval_fxc_contraction ( MatrixType&, const MatrixType&, const MatrixType&, 
+                                   const IntegratorSettingsXC& = IntegratorSettingsXC{} );
   fxc_contraction_type_uks  eval_fxc_contraction ( const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&,
                                   const IntegratorSettingsXC& = IntegratorSettingsXC{} );
+  void          eval_fxc_contraction ( MatrixType&, MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&,
+                                   const IntegratorSettingsXC& = IntegratorSettingsXC{} );
 
   dd_psi_type eval_dd_psi( const MatrixType&, unsigned );
+  void eval_dd_psi( dd_psi_type&, const MatrixType&, unsigned );
   dd_psi_potential_type eval_dd_psi_potential( const MatrixType&, unsigned );
+  void eval_dd_psi_potential( MatrixType&, const MatrixType&, unsigned );
 
   const util::Timer& get_timings() const;
   const LoadBalancer& load_balancer() const;

--- a/include/gauxc/xc_integrator/impl.hpp
+++ b/include/gauxc/xc_integrator/impl.hpp
@@ -64,11 +64,26 @@ typename XCIntegrator<MatrixType>::exc_vxc_type_rks
 };
 
 template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_exc_vxc( value_type& EXC, MatrixType& VXC, const MatrixType& P,
+                                             const IntegratorSettingsXC& ks_settings ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_exc_vxc(EXC, VXC, P, ks_settings);
+}
+
+template <typename MatrixType>
 typename XCIntegrator<MatrixType>::exc_vxc_type_uks
   XCIntegrator<MatrixType>::eval_exc_vxc( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
   if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
   return pimpl_->eval_exc_vxc(Ps, Pz, ks_settings);
 };
+
+template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_exc_vxc( value_type& EXC, MatrixType& VXCs, MatrixType& VXCz,
+                                             const MatrixType& Ps, const MatrixType& Pz,
+                                             const IntegratorSettingsXC& ks_settings ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_exc_vxc(EXC, VXCs, VXCz, Ps, Pz, ks_settings);
+}
 
 template <typename MatrixType>
 typename XCIntegrator<MatrixType>::exc_vxc_type_gks
@@ -77,6 +92,14 @@ typename XCIntegrator<MatrixType>::exc_vxc_type_gks
       if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
         return pimpl_->eval_exc_vxc(Ps, Pz, Py, Px, ks_settings);
   };
+
+template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_exc_vxc( value_type& EXC, MatrixType& VXCs, MatrixType& VXCz, MatrixType& VXCy, MatrixType& VXCx,
+                                             const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px,
+                                             const IntegratorSettingsXC& ks_settings ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_exc_vxc(EXC, VXCs, VXCz, VXCy, VXCx, Ps, Pz, Py, Px, ks_settings);
+}
 
 template <typename MatrixType>
 typename XCIntegrator<MatrixType>::exc_grad_type

--- a/include/gauxc/xc_integrator/impl.hpp
+++ b/include/gauxc/xc_integrator/impl.hpp
@@ -43,6 +43,12 @@ typename XCIntegrator<MatrixType>::value_type
 }
 
 template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_exc( value_type& EXC, const MatrixType& P, const IntegratorSettingsXC& ks_settings ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_exc(EXC, P, ks_settings);
+}
+
+template <typename MatrixType>
 typename XCIntegrator<MatrixType>::value_type
   XCIntegrator<MatrixType>::eval_exc( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
   if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
@@ -50,10 +56,23 @@ typename XCIntegrator<MatrixType>::value_type
 }
 
 template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_exc( value_type& EXC, const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_exc(EXC, Ps, Pz, ks_settings);
+}
+
+template <typename MatrixType>
 typename XCIntegrator<MatrixType>::value_type
   XCIntegrator<MatrixType>::eval_exc( const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px, const IntegratorSettingsXC& ks_settings ) {
   if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
   return pimpl_->eval_exc(Ps, Pz, Py, Px, ks_settings);
+}
+
+template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_exc( value_type& EXC, const MatrixType& Ps, const MatrixType& Pz,
+                                         const MatrixType& Py, const MatrixType& Px, const IntegratorSettingsXC& ks_settings ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_exc(EXC, Ps, Pz, Py, Px, ks_settings);
 }
 
 template <typename MatrixType>
@@ -109,11 +128,24 @@ typename XCIntegrator<MatrixType>::exc_grad_type
 };
 
 template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_exc_grad( exc_grad_type& EXC_GRAD, const MatrixType& P, const IntegratorSettingsXC& ks_settings ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_exc_grad(EXC_GRAD, P, ks_settings);
+}
+
+template <typename MatrixType>
 typename XCIntegrator<MatrixType>::exc_grad_type
   XCIntegrator<MatrixType>::eval_exc_grad( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
   if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
   return pimpl_->eval_exc_grad(Ps, Pz, ks_settings);
 };
+
+template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_exc_grad( exc_grad_type& EXC_GRAD, const MatrixType& Ps, const MatrixType& Pz,
+                                              const IntegratorSettingsXC& ks_settings ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_exc_grad(EXC_GRAD, Ps, Pz, ks_settings);
+}
 
 template <typename MatrixType>
 typename XCIntegrator<MatrixType>::exx_type
@@ -124,12 +156,25 @@ typename XCIntegrator<MatrixType>::exx_type
 };
 
 template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_exx( MatrixType& K, const MatrixType& P, const IntegratorSettingsEXX& settings ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_exx(K, P, settings);
+}
+
+template <typename MatrixType>
 typename XCIntegrator<MatrixType>::fxc_contraction_type_rks
   XCIntegrator<MatrixType>::eval_fxc_contraction( const MatrixType& P, const MatrixType& tP, 
                                                const IntegratorSettingsXC& ks_settings ) { 
   if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
   return pimpl_->eval_fxc_contraction(P, tP, ks_settings);
 };
+
+template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_fxc_contraction( MatrixType& FXC, const MatrixType& P, const MatrixType& tP,
+                                                     const IntegratorSettingsXC& ks_settings ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_fxc_contraction(FXC, P, tP, ks_settings);
+}
 
 template <typename MatrixType>
 typename XCIntegrator<MatrixType>::fxc_contraction_type_uks
@@ -140,6 +185,13 @@ typename XCIntegrator<MatrixType>::fxc_contraction_type_uks
 };
 
 template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_fxc_contraction( MatrixType& FXCs, MatrixType& FXCz, const MatrixType& Ps, const MatrixType& Pz,
+                                                     const MatrixType& tPs, const MatrixType& tPz, const IntegratorSettingsXC& ks_settings ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_fxc_contraction(FXCs, FXCz, Ps, Pz, tPs, tPz, ks_settings);
+}
+
+template <typename MatrixType>
 typename XCIntegrator<MatrixType>::dd_psi_type
   XCIntegrator<MatrixType>::eval_dd_psi(const MatrixType& P, unsigned max_Ylm) {
   if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
@@ -147,10 +199,22 @@ typename XCIntegrator<MatrixType>::dd_psi_type
 }
 
 template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_dd_psi( dd_psi_type& ddPsi, const MatrixType& P, unsigned max_Ylm ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_dd_psi(ddPsi, P, max_Ylm);
+}
+
+template <typename MatrixType>
 typename XCIntegrator<MatrixType>::dd_psi_potential_type
   XCIntegrator<MatrixType>::eval_dd_psi_potential(const MatrixType& X, unsigned max_Ylm) {
   if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
   return pimpl_->eval_dd_psi_potential(X, max_Ylm);
+}
+
+template <typename MatrixType>
+void XCIntegrator<MatrixType>::eval_dd_psi_potential( MatrixType& Vddx, const MatrixType& X, unsigned max_Ylm ) {
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_dd_psi_potential(Vddx, X, max_Ylm);
 }
 
 

--- a/include/gauxc/xc_integrator/replicated/impl.hpp
+++ b/include/gauxc/xc_integrator/replicated/impl.hpp
@@ -78,6 +78,13 @@ typename ReplicatedXCIntegrator<MatrixType>::value_type
 }
 
 template <typename MatrixType>
+void ReplicatedXCIntegrator<MatrixType>::eval_exc_( value_type& EXC, const MatrixType& P, const IntegratorSettingsXC& ks_settings ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  pimpl_->eval_exc( P.rows(), P.cols(), P.data(), P.rows(), &EXC, ks_settings );
+}
+
+template <typename MatrixType>
 typename ReplicatedXCIntegrator<MatrixType>::value_type 
   ReplicatedXCIntegrator<MatrixType>::eval_exc_( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
 
@@ -91,6 +98,14 @@ typename ReplicatedXCIntegrator<MatrixType>::value_type
 }
 
 template <typename MatrixType>
+void ReplicatedXCIntegrator<MatrixType>::eval_exc_( value_type& EXC, const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  const size_t n = Ps.rows();
+  pimpl_->eval_exc( n, n, Ps.data(), n, Pz.data(), n, &EXC, ks_settings );
+}
+
+template <typename MatrixType>
 typename ReplicatedXCIntegrator<MatrixType>::value_type 
   ReplicatedXCIntegrator<MatrixType>::eval_exc_( const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px, const IntegratorSettingsXC& ks_settings ) {
 
@@ -101,6 +116,15 @@ typename ReplicatedXCIntegrator<MatrixType>::value_type
   pimpl_->eval_exc( n, n, Ps.data(), n, Pz.data(), n, Py.data(), n, Px.data(), n, &EXC, ks_settings );
 
   return EXC;
+}
+
+template <typename MatrixType>
+void ReplicatedXCIntegrator<MatrixType>::eval_exc_( value_type& EXC, const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px,
+                                                    const IntegratorSettingsXC& ks_settings ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  const size_t n = Ps.rows();
+  pimpl_->eval_exc( n, n, Ps.data(), n, Pz.data(), n, Py.data(), n, Px.data(), n, &EXC, ks_settings );
 }
 
 template <typename MatrixType>
@@ -235,6 +259,18 @@ typename ReplicatedXCIntegrator<MatrixType>::exc_grad_type
 }
 
 template <typename MatrixType>
+void ReplicatedXCIntegrator<MatrixType>::eval_exc_grad_( exc_grad_type& EXC_GRAD, const MatrixType& P, const IntegratorSettingsXC& ks_settings ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+
+  const size_t natoms = pimpl_->load_balancer().molecule().natoms();
+  const size_t grad_sz = 3 * natoms;
+  if( EXC_GRAD.size() < grad_sz ) EXC_GRAD.resize( grad_sz );
+
+  pimpl_->eval_exc_grad( P.rows(), P.cols(), P.data(), P.rows(), EXC_GRAD.data(), ks_settings );
+}
+
+template <typename MatrixType>
 typename ReplicatedXCIntegrator<MatrixType>::exc_grad_type 
   ReplicatedXCIntegrator<MatrixType>::eval_exc_grad_( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
 
@@ -246,6 +282,18 @@ typename ReplicatedXCIntegrator<MatrixType>::exc_grad_type
 
   return EXC_GRAD;
 
+}
+
+template <typename MatrixType>
+void ReplicatedXCIntegrator<MatrixType>::eval_exc_grad_( exc_grad_type& EXC_GRAD, const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+
+  const size_t natoms = pimpl_->load_balancer().molecule().natoms();
+  const size_t grad_sz = 3 * natoms;
+  if( EXC_GRAD.size() < grad_sz ) EXC_GRAD.resize( grad_sz );
+
+  pimpl_->eval_exc_grad( Ps.rows(), Ps.cols(), Ps.data(), Ps.rows(), Pz.data(), Pz.rows(), EXC_GRAD.data(), ks_settings );
 }
 
 template <typename MatrixType>
@@ -262,6 +310,16 @@ typename ReplicatedXCIntegrator<MatrixType>::exx_type
   return K;
 
 }
+
+template <typename MatrixType>
+void ReplicatedXCIntegrator<MatrixType>::eval_exx_( MatrixType& K, const MatrixType& P, const IntegratorSettingsEXX& settings ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  if( K.rows() < P.rows() || K.cols() < P.cols() )
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated K matrix");
+
+  pimpl_->eval_exx( P.rows(), P.cols(), P.data(), P.rows(), K.data(), K.rows(), settings );
+}
 template <typename MatrixType>
 typename ReplicatedXCIntegrator<MatrixType>::fxc_contraction_type_rks
   ReplicatedXCIntegrator<MatrixType>::eval_fxc_contraction_( const MatrixType& P, 
@@ -275,6 +333,19 @@ typename ReplicatedXCIntegrator<MatrixType>::fxc_contraction_type_rks
                         FXC.data(), FXC.rows(), ks_settings );
 
   return FXC;
+}
+
+template <typename MatrixType>
+void ReplicatedXCIntegrator<MatrixType>::eval_fxc_contraction_( MatrixType& FXC, const MatrixType& P,
+  const MatrixType& tP, const IntegratorSettingsXC& ks_settings ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  if( FXC.rows() < P.rows() || FXC.cols() < P.cols() )
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated FXC matrix");
+
+  pimpl_->eval_fxc_contraction( P.rows(), P.cols(), P.data(), P.rows(),
+                        tP.data(), tP.rows(),
+                        FXC.data(), FXC.rows(), ks_settings );
 }
 
 template <typename MatrixType>
@@ -298,6 +369,25 @@ typename ReplicatedXCIntegrator<MatrixType>::fxc_contraction_type_uks
 }
 
 template <typename MatrixType>
+void ReplicatedXCIntegrator<MatrixType>::eval_fxc_contraction_( MatrixType& FXCs, MatrixType& FXCz,
+  const MatrixType& Ps, const MatrixType& Pz, const MatrixType& tPs, const MatrixType& tPz,
+  const IntegratorSettingsXC& ks_settings ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  if( FXCs.rows() < Ps.rows() || FXCs.cols() < Ps.cols() )
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated FXCs matrix");
+  if( FXCz.rows() < Pz.rows() || FXCz.cols() < Pz.cols() )
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated FXCz matrix");
+
+  pimpl_->eval_fxc_contraction( Ps.rows(), Ps.cols(), Ps.data(), Ps.rows(),
+                        Pz.data(), Pz.rows(),
+                        tPs.data(), tPs.rows(),
+                        tPz.data(), tPz.rows(),
+                        FXCs.data(), FXCs.rows(),
+                        FXCz.data(), FXCz.rows(), ks_settings );
+}
+
+template <typename MatrixType>
 typename ReplicatedXCIntegrator<MatrixType>::dd_psi_type
   ReplicatedXCIntegrator<MatrixType>::eval_dd_psi_( const MatrixType& P, unsigned max_Ylm ) {
 
@@ -308,6 +398,19 @@ typename ReplicatedXCIntegrator<MatrixType>::dd_psi_type
   std::vector<value_type> ddPsi(natoms * Ylm_sz, 0.0);
   pimpl_->eval_dd_psi(P.rows(), P.cols(), P.data(), P.rows(), max_Ylm, ddPsi.data(), Ylm_sz);
   return ddPsi;
+}
+
+template <typename MatrixType>
+void ReplicatedXCIntegrator<MatrixType>::eval_dd_psi_( dd_psi_type& ddPsi, const MatrixType& P, unsigned max_Ylm ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+
+  const size_t natoms = pimpl_->load_balancer().molecule().natoms();
+  const size_t Ylm_sz = (max_Ylm + 1) * ( max_Ylm + 1);
+  const size_t psi_sz = natoms * Ylm_sz;
+  if( ddPsi.size() < psi_sz ) ddPsi.resize( psi_sz );
+
+  pimpl_->eval_dd_psi(P.rows(), P.cols(), P.data(), P.rows(), max_Ylm, ddPsi.data(), Ylm_sz);
 }
 
 template <typename MatrixType>
@@ -322,6 +425,19 @@ typename ReplicatedXCIntegrator<MatrixType>::dd_psi_potential_type
   pimpl_->eval_dd_psi_potential(X.rows(), X.cols(), X.data(), max_Ylm, Vddx.data());
   return Vddx;                      
 
+}
+
+template <typename MatrixType>
+void ReplicatedXCIntegrator<MatrixType>::eval_dd_psi_potential_( MatrixType& Vddx, const MatrixType& X, unsigned max_Ylm ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+
+  const size_t nbf = pimpl_->load_balancer().basis().nbf();
+  if( Vddx.rows() < nbf || Vddx.cols() < nbf )
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated Vddx matrix");
+
+  Vddx.setZero();
+  pimpl_->eval_dd_psi_potential(X.rows(), X.cols(), X.data(), max_Ylm, Vddx.data());
 }
 
 }

--- a/include/gauxc/xc_integrator/replicated/impl.hpp
+++ b/include/gauxc/xc_integrator/replicated/impl.hpp
@@ -119,6 +119,36 @@ typename ReplicatedXCIntegrator<MatrixType>::exc_vxc_type_rks
 }
 
 template <typename MatrixType>
+void
+  ReplicatedXCIntegrator<MatrixType>::eval_exc_vxc_(value_type& EXC, MatrixType& VXC, const MatrixType& P, const IntegratorSettingsXC& ks_settings ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  if( VXC.rows() < P.rows() || VXC.cols() < P.cols() ) 
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated VXC matrix");
+
+  pimpl_->eval_exc_vxc( P.rows(), P.cols(), P.data(), P.rows(),
+                        VXC.data(), VXC.rows(), &EXC, ks_settings );
+}
+
+template <typename MatrixType>
+void
+  ReplicatedXCIntegrator<MatrixType>::eval_exc_vxc_( value_type& EXC, MatrixType& VXCs, MatrixType& VXCz,
+                                                     const MatrixType& Ps, const MatrixType& Pz,
+                                                     const IntegratorSettingsXC& ks_settings ) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  if( VXCs.rows() < Ps.rows() || VXCs.cols() < Ps.cols() )
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated VXCs matrix");
+  if( VXCz.rows() < Pz.rows() || VXCz.cols() < Pz.cols() )
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated VXCz matrix");
+
+  pimpl_->eval_exc_vxc( Ps.rows(), Ps.cols(), Ps.data(), Ps.rows(),
+                        Pz.data(), Pz.rows(),
+                        VXCs.data(), VXCs.rows(),
+                        VXCz.data(), VXCz.rows(), &EXC, ks_settings );
+}
+
+template <typename MatrixType>
 typename ReplicatedXCIntegrator<MatrixType>::exc_vxc_type_uks
   ReplicatedXCIntegrator<MatrixType>::eval_exc_vxc_( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
 
@@ -158,6 +188,35 @@ typename ReplicatedXCIntegrator<MatrixType>::exc_vxc_type_gks
                         VXCx.data(), VXCx.rows(), &EXC, ks_settings );
 
   return std::make_tuple( EXC, VXCs, VXCz, VXCy, VXCx);
+
+}
+
+template <typename MatrixType>
+void
+  ReplicatedXCIntegrator<MatrixType>::eval_exc_vxc_( value_type& EXC, MatrixType& VXCs, MatrixType& VXCz,
+                                                     MatrixType& VXCy, MatrixType& VXCx,
+                                                     const MatrixType& Ps, const MatrixType& Pz,
+                                                     const MatrixType& Py, const MatrixType& Px,
+                                                     const IntegratorSettingsXC& ks_settings) {
+
+  if( not pimpl_ ) GAUXC_PIMPL_NOT_INITIALIZED();
+  if( VXCs.rows() < Ps.rows() || VXCs.cols() < Ps.cols() )
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated VXCs matrix");
+  if( VXCz.rows() < Pz.rows() || VXCz.cols() < Pz.cols() )
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated VXCz matrix");
+  if( VXCy.rows() < Py.rows() || VXCy.cols() < Py.cols() )
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated VXCy matrix");
+  if( VXCx.rows() < Px.rows() || VXCx.cols() < Px.cols() )
+    GAUXC_GENERIC_EXCEPTION("Dimension mismatch in preallocated VXCx matrix");
+
+  pimpl_->eval_exc_vxc( Ps.rows(), Ps.cols(), Ps.data(), Ps.rows(),
+                        Pz.data(), Pz.rows(),
+                        Py.data(), Py.rows(),
+                        Px.data(), Px.rows(),
+                        VXCs.data(), VXCs.rows(),
+                        VXCz.data(), VXCz.rows(),
+                        VXCy.data(), VXCy.rows(),
+                        VXCx.data(), VXCx.rows(), &EXC, ks_settings );
 
 }
 

--- a/include/gauxc/xc_integrator/replicated_xc_integrator.hpp
+++ b/include/gauxc/xc_integrator/replicated_xc_integrator.hpp
@@ -51,6 +51,9 @@ private:
   value_type    eval_exc_     ( const MatrixType&, const IntegratorSettingsXC& ) override;
   value_type    eval_exc_     ( const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
   value_type    eval_exc_     ( const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
+  void          eval_exc_     ( value_type&, const MatrixType&, const IntegratorSettingsXC& ) override;
+  void          eval_exc_     ( value_type&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
+  void          eval_exc_     ( value_type&, const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
   exc_vxc_type_rks  eval_exc_vxc_ ( const MatrixType&, const IntegratorSettingsXC& ) override;
   exc_vxc_type_uks  eval_exc_vxc_ ( const MatrixType&, const MatrixType&, const IntegratorSettingsXC&) override;
   exc_vxc_type_gks  eval_exc_vxc_ ( const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
@@ -60,11 +63,18 @@ private:
                       const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
   exc_grad_type eval_exc_grad_( const MatrixType&, const IntegratorSettingsXC& ) override;
   exc_grad_type eval_exc_grad_( const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
+  void          eval_exc_grad_( exc_grad_type&, const MatrixType&, const IntegratorSettingsXC& ) override;
+  void          eval_exc_grad_( exc_grad_type&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
   exx_type      eval_exx_     ( const MatrixType&, const IntegratorSettingsEXX& ) override;
+  void          eval_exx_     ( MatrixType&, const MatrixType&, const IntegratorSettingsEXX& ) override;
   fxc_contraction_type_rks  eval_fxc_contraction_ ( const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
   fxc_contraction_type_uks  eval_fxc_contraction_ ( const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC&) override;
+  void          eval_fxc_contraction_ ( MatrixType&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
+  void          eval_fxc_contraction_ ( MatrixType&, MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC&) override;
   dd_psi_type   eval_dd_psi_( const MatrixType& , unsigned ) override;
   dd_psi_potential_type   eval_dd_psi_potential_( const MatrixType& , unsigned ) override;
+  void          eval_dd_psi_( dd_psi_type&, const MatrixType&, unsigned ) override;
+  void          eval_dd_psi_potential_( MatrixType&, const MatrixType&, unsigned ) override;
   const util::Timer& get_timings_() const override;
   const LoadBalancer& get_load_balancer_() const override;
   LoadBalancer& get_load_balancer_() override;

--- a/include/gauxc/xc_integrator/replicated_xc_integrator.hpp
+++ b/include/gauxc/xc_integrator/replicated_xc_integrator.hpp
@@ -54,6 +54,10 @@ private:
   exc_vxc_type_rks  eval_exc_vxc_ ( const MatrixType&, const IntegratorSettingsXC& ) override;
   exc_vxc_type_uks  eval_exc_vxc_ ( const MatrixType&, const MatrixType&, const IntegratorSettingsXC&) override;
   exc_vxc_type_gks  eval_exc_vxc_ ( const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
+  void eval_exc_vxc_( value_type& EXC, MatrixType& VXC, const MatrixType&, const IntegratorSettingsXC& ) override;
+  void eval_exc_vxc_( value_type& EXC, MatrixType& VXCs, MatrixType& VXCz, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
+  void eval_exc_vxc_( value_type& EXC, MatrixType& VXCs, MatrixType& VXCz, MatrixType& VXCy, MatrixType& VXCx,
+                      const MatrixType&, const MatrixType&, const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
   exc_grad_type eval_exc_grad_( const MatrixType&, const IntegratorSettingsXC& ) override;
   exc_grad_type eval_exc_grad_( const MatrixType&, const MatrixType&, const IntegratorSettingsXC& ) override;
   exx_type      eval_exx_     ( const MatrixType&, const IntegratorSettingsEXX& ) override;

--- a/include/gauxc/xc_integrator/xc_integrator_impl.hpp
+++ b/include/gauxc/xc_integrator/xc_integrator_impl.hpp
@@ -46,6 +46,12 @@ protected:
   virtual exc_vxc_type_uks  eval_exc_vxc_ ( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) = 0;
   virtual exc_vxc_type_gks  eval_exc_vxc_ ( const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px, 
                                             const IntegratorSettingsXC& ks_settings ) = 0;
+  virtual void eval_exc_vxc_( value_type& EXC, MatrixType& VXC, const MatrixType& P, const IntegratorSettingsXC& ks_settings ) = 0;
+  virtual void eval_exc_vxc_( value_type& EXC, MatrixType& VXCs, MatrixType& VXCz, const MatrixType& Ps, const MatrixType& Pz,
+                              const IntegratorSettingsXC& ks_settings ) = 0;
+  virtual void eval_exc_vxc_( value_type& EXC, MatrixType& VXCs, MatrixType& VXCz, MatrixType& VXCy, MatrixType& VXCx,
+                              const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px,
+                              const IntegratorSettingsXC& ks_settings ) = 0;
   virtual exc_grad_type eval_exc_grad_( const MatrixType& P, const IntegratorSettingsXC& ks_settings ) = 0;
   virtual exc_grad_type eval_exc_grad_( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) = 0;
   virtual exx_type      eval_exx_     ( const MatrixType&     P, 
@@ -116,12 +122,27 @@ public:
     return eval_exc_vxc_(P, ks_settings);
   }
 
+  void eval_exc_vxc( value_type& EXC, MatrixType& VXC, const MatrixType& P, const IntegratorSettingsXC& ks_settings ) {
+    eval_exc_vxc_( EXC, VXC, P, ks_settings );
+  }
+
   exc_vxc_type_uks eval_exc_vxc( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
     return eval_exc_vxc_(Ps, Pz, ks_settings);
   }
 
+  void eval_exc_vxc( value_type& EXC, MatrixType& VXCs, MatrixType& VXCz, const MatrixType& Ps, const MatrixType& Pz,
+                     const IntegratorSettingsXC& ks_settings ) {
+    eval_exc_vxc_( EXC, VXCs, VXCz, Ps, Pz, ks_settings );
+  }
+
   exc_vxc_type_gks eval_exc_vxc( const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px, const IntegratorSettingsXC& ks_settings ) {
     return eval_exc_vxc_(Ps, Pz, Py, Px, ks_settings);
+  }
+
+  void eval_exc_vxc( value_type& EXC, MatrixType& VXCs, MatrixType& VXCz, MatrixType& VXCy, MatrixType& VXCx,
+                     const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px,
+                     const IntegratorSettingsXC& ks_settings ) {
+    eval_exc_vxc_( EXC, VXCs, VXCz, VXCy, VXCx, Ps, Pz, Py, Px, ks_settings );
   }
 
   /** Integrate EXC gradient for RKS

--- a/include/gauxc/xc_integrator/xc_integrator_impl.hpp
+++ b/include/gauxc/xc_integrator/xc_integrator_impl.hpp
@@ -41,6 +41,9 @@ protected:
   virtual value_type        eval_exc_     ( const MatrixType& P, const IntegratorSettingsXC& ks_settings ) = 0;
   virtual value_type        eval_exc_     ( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) = 0;
   virtual value_type        eval_exc_     ( const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px, const IntegratorSettingsXC& ks_settings ) = 0;
+  virtual void              eval_exc_     ( value_type& EXC, const MatrixType& P, const IntegratorSettingsXC& ks_settings ) = 0;
+  virtual void              eval_exc_     ( value_type& EXC, const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) = 0;
+  virtual void              eval_exc_     ( value_type& EXC, const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px, const IntegratorSettingsXC& ks_settings ) = 0;
 
   virtual exc_vxc_type_rks  eval_exc_vxc_ ( const MatrixType& P, const IntegratorSettingsXC& ks_settings ) = 0;
   virtual exc_vxc_type_uks  eval_exc_vxc_ ( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) = 0;
@@ -54,16 +57,26 @@ protected:
                               const IntegratorSettingsXC& ks_settings ) = 0;
   virtual exc_grad_type eval_exc_grad_( const MatrixType& P, const IntegratorSettingsXC& ks_settings ) = 0;
   virtual exc_grad_type eval_exc_grad_( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) = 0;
+  virtual void eval_exc_grad_( exc_grad_type& EXC_GRAD, const MatrixType& P, const IntegratorSettingsXC& ks_settings ) = 0;
+  virtual void eval_exc_grad_( exc_grad_type& EXC_GRAD, const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) = 0;
   virtual exx_type      eval_exx_     ( const MatrixType&     P, 
+                                        const IntegratorSettingsEXX& settings ) = 0;
+  virtual void          eval_exx_     ( MatrixType& K, const MatrixType& P,
                                         const IntegratorSettingsEXX& settings ) = 0;
   virtual fxc_contraction_type_rks  eval_fxc_contraction_ ( const MatrixType& P,
     const MatrixType& tP, const IntegratorSettingsXC& ks_settings ) = 0;
   virtual fxc_contraction_type_uks  eval_fxc_contraction_ ( const MatrixType& Ps, const MatrixType& Pz, 
     const MatrixType& tPs, const MatrixType& tPz,  const IntegratorSettingsXC& ks_settings ) = 0;
+  virtual void eval_fxc_contraction_ ( MatrixType& FXC, const MatrixType& P, const MatrixType& tP,
+    const IntegratorSettingsXC& ks_settings ) = 0;
+  virtual void eval_fxc_contraction_ ( MatrixType& FXCs, MatrixType& FXCz, const MatrixType& Ps, const MatrixType& Pz,
+    const MatrixType& tPs, const MatrixType& tPz, const IntegratorSettingsXC& ks_settings ) = 0;
 
 
   virtual dd_psi_type   eval_dd_psi_( const MatrixType& P, unsigned max_Ylm ) = 0;
   virtual dd_psi_potential_type   eval_dd_psi_potential_( const MatrixType& X, unsigned max_Ylm ) = 0;
+  virtual void eval_dd_psi_( dd_psi_type& ddPsi, const MatrixType& P, unsigned max_Ylm ) = 0;
+  virtual void eval_dd_psi_potential_( MatrixType& Vddx, const MatrixType& X, unsigned max_Ylm ) = 0;
   virtual const util::Timer& get_timings_() const = 0;
   virtual const LoadBalancer& get_load_balancer_() const = 0;
   virtual LoadBalancer& get_load_balancer_() = 0;
@@ -95,6 +108,10 @@ public:
     return eval_exc_(P, ks_settings);
   }
 
+  void eval_exc( value_type& EXC, const MatrixType& P, const IntegratorSettingsXC& ks_settings ) {
+    eval_exc_( EXC, P, ks_settings );
+  }
+
   /** Integrate EXC for UKS
    *
    *  @param[in] P The alpha density matrix
@@ -104,6 +121,10 @@ public:
     return eval_exc_(Ps, Pz, ks_settings);
   }
 
+  void eval_exc( value_type& EXC, const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
+    eval_exc_( EXC, Ps, Pz, ks_settings );
+  }
+
   /** Integrate EXC for GKS
    *
    *  @param[in] P The alpha density matrix
@@ -111,6 +132,11 @@ public:
    */
   value_type eval_exc( const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px,  const IntegratorSettingsXC& ks_settings ) {
     return eval_exc_(Ps, Pz, Py, Px, ks_settings);
+  }
+
+  void eval_exc( value_type& EXC, const MatrixType& Ps, const MatrixType& Pz, const MatrixType& Py, const MatrixType& Px,
+                 const IntegratorSettingsXC& ks_settings ) {
+    eval_exc_( EXC, Ps, Pz, Py, Px, ks_settings );
   }
 
   /** Integrate EXC / VXC (Mean field terms) for RKS
@@ -154,6 +180,10 @@ public:
     return eval_exc_grad_(P, ks_settings);
   }
 
+  void eval_exc_grad( exc_grad_type& EXC_GRAD, const MatrixType& P, const IntegratorSettingsXC& ks_settings ) {
+    eval_exc_grad_( EXC_GRAD, P, ks_settings );
+  }
+
   /** Integrate EXC gradient for UKS
    *
    *  @param[in] P The alpha density matrix
@@ -161,6 +191,10 @@ public:
    */
   exc_grad_type eval_exc_grad( const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
     return eval_exc_grad_(Ps, Pz, ks_settings);
+  }
+
+  void eval_exc_grad( exc_grad_type& EXC_GRAD, const MatrixType& Ps, const MatrixType& Pz, const IntegratorSettingsXC& ks_settings ) {
+    eval_exc_grad_( EXC_GRAD, Ps, Pz, ks_settings );
   }
 
   /** Integrate Exact Exchange for RHF
@@ -172,6 +206,10 @@ public:
     return eval_exx_(P,settings);
   }
 
+  void eval_exx( MatrixType& K, const MatrixType& P, const IntegratorSettingsEXX& settings ) {
+    eval_exx_( K, P, settings );
+  }
+
   
   /** Integrate FXC contraction for RKS
    * 
@@ -181,6 +219,10 @@ public:
    */
   fxc_contraction_type_rks eval_fxc_contraction( const MatrixType& P, const MatrixType& tP, const IntegratorSettingsXC& ks_settings ) {
     return eval_fxc_contraction_(P, tP, ks_settings);
+  }
+
+  void eval_fxc_contraction( MatrixType& FXC, const MatrixType& P, const MatrixType& tP, const IntegratorSettingsXC& ks_settings ) {
+    eval_fxc_contraction_( FXC, P, tP, ks_settings );
   }
 
   /** Integrate FXC contraction for UKS
@@ -196,6 +238,11 @@ public:
     return eval_fxc_contraction_(Ps, Pz, tPs, tPz, ks_settings);
   }
 
+  void eval_fxc_contraction( MatrixType& FXCs, MatrixType& FXCz, const MatrixType& Ps, const MatrixType& Pz,
+                             const MatrixType& tPs, const MatrixType& tPz, const IntegratorSettingsXC& ks_settings ) {
+    eval_fxc_contraction_( FXCs, FXCz, Ps, Pz, tPs, tPz, ks_settings );
+  }
+
   /** Evaluate Psi vector for ddX
    *
    *  @param[in] P        The density matrix
@@ -206,6 +253,10 @@ public:
     return eval_dd_psi_(P,max_Ylm);
   }
 
+  void eval_dd_psi( dd_psi_type& ddPsi, const MatrixType& P, unsigned max_Ylm ) {
+    eval_dd_psi_( ddPsi, P, max_Ylm );
+  }
+
   /** Evaluate Psi Potential for ddX
    *
    *  @param[in] X        The local ASC coefficients, (nharmonics, atom) array in column-major ordering.
@@ -214,6 +265,10 @@ public:
    */   
   dd_psi_potential_type eval_dd_psi_potential( const MatrixType& X, unsigned max_Ylm ) {
     return eval_dd_psi_potential_(X,max_Ylm);
+  }
+
+  void eval_dd_psi_potential( MatrixType& Vddx, const MatrixType& X, unsigned max_Ylm ) {
+    eval_dd_psi_potential_( Vddx, X, max_Ylm );
   }
 
   /** Get internal timers

--- a/tests/xc_integrator.cxx
+++ b/tests/xc_integrator.cxx
@@ -203,6 +203,16 @@ void test_xc_integrator( ExecutionSpace ex, const RuntimeEnvironment& rt,
     auto VXC_diff_nrm = ( VXC - VXC_ref ).norm();
     CHECK( EXC == Approx( EXC_ref ) );
     CHECK( VXC_diff_nrm / basis.nbf() < 1e-10 ); 
+
+    // Check preallocated EXC/VXC API
+    {
+      matrix_type VXC_out( P.rows(), P.cols() );
+      double EXC_out = 0.0;
+      integrator.eval_exc_vxc( EXC_out, VXC_out, P );
+      auto VXC_out_diff_nrm = ( VXC_out - VXC_ref ).norm();
+      CHECK( EXC_out == Approx( EXC_ref ) );
+      CHECK( VXC_out_diff_nrm / basis.nbf() < 1e-10 );
+    }
     // Check if the integrator propagates state correctly
     {
       auto [ EXC1, VXC1 ] = integrator.eval_exc_vxc( P );
@@ -224,6 +234,19 @@ void test_xc_integrator( ExecutionSpace ex, const RuntimeEnvironment& rt,
     CHECK( EXC == Approx( EXC_ref ) );
     CHECK( VXC_diff_nrm / basis.nbf() < 1e-10 );
     CHECK( VXCz_diff_nrm / basis.nbf() < 1e-10 );
+
+    // Check preallocated EXC/VXC API
+    {
+      matrix_type VXC_out( P.rows(), P.cols() );
+      matrix_type VXCz_out( Pz.rows(), Pz.cols() );
+      double EXC_out = 0.0;
+      integrator.eval_exc_vxc( EXC_out, VXC_out, VXCz_out, P, Pz );
+      auto VXC_out_diff_nrm = ( VXC_out - VXC_ref ).norm();
+      auto VXCz_out_diff_nrm = ( VXCz_out - VXCz_ref ).norm();
+      CHECK( EXC_out == Approx( EXC_ref ) );
+      CHECK( VXC_out_diff_nrm / basis.nbf() < 1e-10 );
+      CHECK( VXCz_out_diff_nrm / basis.nbf() < 1e-10 );
+    }
     // Check if the integrator propagates state correctly
     {
       auto [ EXC1, VXC1, VXCz1 ] = integrator.eval_exc_vxc( P, Pz );
@@ -251,6 +274,25 @@ void test_xc_integrator( ExecutionSpace ex, const RuntimeEnvironment& rt,
     CHECK( VXCz_diff_nrm / basis.nbf() < 1e-10 );
     CHECK( VXCy_diff_nrm / basis.nbf() < 1e-10 );
     CHECK( VXCx_diff_nrm / basis.nbf() < 1e-10 );
+
+    // Check preallocated EXC/VXC API
+    {
+      matrix_type VXC_out( P.rows(), P.cols() );
+      matrix_type VXCz_out( Pz.rows(), Pz.cols() );
+      matrix_type VXCy_out( Py.rows(), Py.cols() );
+      matrix_type VXCx_out( Px.rows(), Px.cols() );
+      double EXC_out = 0.0;
+      integrator.eval_exc_vxc( EXC_out, VXC_out, VXCz_out, VXCy_out, VXCx_out, P, Pz, Py, Px );
+      auto VXC_out_diff_nrm = ( VXC_out - VXC_ref ).norm();
+      auto VXCz_out_diff_nrm = ( VXCz_out - VXCz_ref ).norm();
+      auto VXCy_out_diff_nrm = ( VXCy_out - VXCy_ref ).norm();
+      auto VXCx_out_diff_nrm = ( VXCx_out - VXCx_ref ).norm();
+      CHECK( EXC_out == Approx( EXC_ref ) );
+      CHECK( VXC_out_diff_nrm / basis.nbf() < 1e-10 );
+      CHECK( VXCz_out_diff_nrm / basis.nbf() < 1e-10 );
+      CHECK( VXCy_out_diff_nrm / basis.nbf() < 1e-10 );
+      CHECK( VXCx_out_diff_nrm / basis.nbf() < 1e-10 );
+    }
     // Check if the integrator propagates state correctly
     {
       auto [ EXC1, VXC1, VXCz1, VXCy1, VXCx1] = integrator.eval_exc_vxc( P, Pz, Py, Px );


### PR DESCRIPTION
Instead of allocating output values in the `integrator.eval_*` functions these allow the user to perform the allocation and GauXC will use the preallocated memory for performing the evaluations.

Required for #171 