### PR TITLE
Fix OneDFT MPI double-counting of EXC energy

### DIFF
--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_onedft.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_onedft.hpp
@@ -220,6 +220,8 @@ eval_exc_vxc_onedft_( int64_t m, int64_t n,
     c10::cuda::CUDACachingAllocator::emptyCache();
     EXC[0] = exc.item<double>();
     // std::cout << "EXC: " << EXC[0] << std::endl;
+  } else {
+    EXC[0] = 0.0;
   }
 
   if ( world_size == 1 ) {

--- a/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_onedft.hpp
+++ b/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_onedft.hpp
@@ -129,8 +129,9 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
     auto exc = (exc_on_grid * features_dict.at(feat_map.at(ONEDFT_FEATURE::WEIGHTS))).sum();
     exc.backward();
     EXC[0] = exc.item().to<double>();
+  } else {
+    EXC[0] = 0.0;
   }
-  // MPI_Bcast(EXC, 1, MPI_DOUBLE, 0, rt.comm());
   // TODO: stop here if only exc
 
   send_buffer_onedft_outputs(2/*ndm*/, features_dict, tasks, rt, sendcounts, displs);


### PR DESCRIPTION
In the OneDFT integrator path, only rank 0 computes the XC energy from the neural network model. The energy is then allreduced with `MPI_SUM` across all MPI ranks. On repeated calls, non-rank-0 ranks still hold the correct energy value from the previous allreduce, causing the Sum to yield **2× the correct value**.

**Fix:** Zero `EXC[0]` on non-rank-0 processes before the allreduce, so only rank 0's contribution is summed. This affects both the host and device integrator paths.

This error was actually caught by an MPI test that was failing. Test passes after this edit.