### PR TITLE
Guard OneDFT code with GAUXC_HAS_ONEDFT and remove unused CUDA header

### DIFF
--- a/src/xc_integrator/integrator_util/CMakeLists.txt
+++ b/src/xc_integrator/integrator_util/CMakeLists.txt
@@ -11,5 +11,7 @@
 #
 target_sources( gauxc PRIVATE integrator_common.cxx integral_bounds.cxx 
                             exx_screening.cxx 
-                            spherical_harmonics.cxx 
-                            onedft_util.cxx )
+                            spherical_harmonics.cxx )
+if( GAUXC_HAS_ONEDFT )
+  target_sources( gauxc PRIVATE onedft_util.cxx )
+endif()

--- a/src/xc_integrator/integrator_util/CMakeLists.txt
+++ b/src/xc_integrator/integrator_util/CMakeLists.txt
@@ -12,6 +12,6 @@
 target_sources( gauxc PRIVATE integrator_common.cxx integral_bounds.cxx 
                             exx_screening.cxx 
                             spherical_harmonics.cxx )
-if( GAUXC_HAS_ONEDFT )
+if( GAUXC_ENABLE_ONEDFT )
   target_sources( gauxc PRIVATE onedft_util.cxx )
 endif()

--- a/src/xc_integrator/integrator_util/onedft_util.hpp
+++ b/src/xc_integrator/integrator_util/onedft_util.hpp
@@ -1,9 +1,6 @@
 #include <gauxc/gauxc_config.hpp>
 #include <torch/script.h>
 #include <torch/torch.h>
-#ifdef GAUXC_HAS_CUDA
-#include <torch/csrc/cuda/CUDAPluggableAllocator.h>
-#endif
 #include <nlohmann/json.hpp>
 #include <gauxc/xc_integrator/local_work_driver.hpp>
 

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator.cxx
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator.cxx
@@ -16,7 +16,9 @@
 #include "incore_replicated_xc_device_integrator_exx.hpp"
 #include "incore_replicated_xc_device_integrator_fxc_contraction.hpp"
 #include "incore_replicated_xc_device_integrator_dd.hpp"
+#ifdef GAUXC_HAS_ONEDFT
 #include "incore_replicated_xc_device_integrator_onedft.hpp"
+#endif
 namespace GauXC  {
 namespace detail {
 

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_onedft.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_onedft.hpp
@@ -13,6 +13,7 @@
 #include "device/common/device_blas.hpp"
 #include "integrator_util/onedft_util.hpp"
 #include <cuda_runtime.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 #include "device/cuda/cuda_backend.hpp"
 #include <cstddef> // for size_t
 

--- a/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator.cxx
+++ b/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator.cxx
@@ -17,7 +17,9 @@
 #include "reference_replicated_xc_host_integrator_fxc_contraction.hpp"
 #include "reference_replicated_xc_host_integrator_dd_psi.hpp"
 #include "reference_replicated_xc_host_integrator_dd_psi_potential.hpp"
+#ifdef GAUXC_HAS_ONEDFT
 #include "reference_replicated_xc_host_integrator_onedft.hpp"
+#endif
 
 namespace GauXC::detail {
 

--- a/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator.hpp
+++ b/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator.hpp
@@ -75,9 +75,17 @@ protected:
                       value_type* EXC, const IntegratorSettingsXC& ks_settings ) override;
 
   /// Onedft
+#ifdef GAUXC_HAS_ONEDFT
   void eval_exc_vxc_onedft_( int64_t m, int64_t n, const value_type* Ps, int64_t ldps,
                      const value_type* Pz, int64_t ldpz, value_type* VXCs, int64_t ldvxcs,
                      value_type* VXCz, int64_t ldvxcz, value_type* EXC, const IntegratorSettingsXC& ks_settings ) override;
+#else
+  void eval_exc_vxc_onedft_( int64_t, int64_t, const value_type*, int64_t,
+                     const value_type*, int64_t, value_type*, int64_t,
+                     value_type*, int64_t, value_type*, const IntegratorSettingsXC& ) override {
+    throw std::runtime_error("OneDFT support not compiled");
+  }
+#endif
                      
   /// RKS EXC Gradient
   void eval_exc_grad_( int64_t m, int64_t n, const value_type* P, int64_t ldp, 
@@ -154,6 +162,7 @@ protected:
 
   void dd_psi_potential_local_work_( const value_type* X, value_type* Vddx, unsigned max_Ylm );
 
+#ifdef GAUXC_HAS_ONEDFT
   void pre_onedft_local_work_( const basis_type& basis, const value_type* Ps, int64_t ldps,
     const value_type* Pz, int64_t ldpz, value_type *N_EL, 
     const bool is_gga, const bool is_mgga, const bool needs_laplacian);
@@ -163,6 +172,7 @@ protected:
     value_type* VXCs, int64_t ldvxcs,
     value_type* VXCz, int64_t ldvxcz,
     const bool is_gga, const bool is_mgga, const bool needs_laplacian);
+#endif
 
 
 public:


### PR DESCRIPTION
This PR removes the unused `CUDAPluggableAllocator.h` include from `onedft_util.hpp`. It is only used by commented-out code.

This also guards 
- the compilation of `onedft_util.cxx` with `if(GAUXC_HAS_ONEDFT)` in CMakeLists.
- `#include ..._onedft.hpp` in host/device integrator `.cxx` files with `#ifdef GAUXC_HAS_ONEDFT`

This enables using this branch with`GAUXC_HAS_ONEDFT=OFF`.
