### PR TITLE
Fix Fortran compile error: Remove unnecessary parameter from binding

### DIFF
--- a/src/fortran-api/molecule.f90
+++ b/src/fortran-api/molecule.f90
@@ -108,7 +108,7 @@ module gauxc_molecule
 contains
 
   !> @brief Create a new Molecule instance from an array of Atoms
-  function gauxc_molecule_new_from_atoms(status, atoms, natoms) result(molecule)
+  function gauxc_molecule_new_from_atoms(status, atoms) result(molecule)
     !> @param status Status of the operation
     type(gauxc_status_type), intent(out) :: status
     !> @param atoms Pointer to an array of Atom objects


### PR DESCRIPTION
#### Note that this is NOT a PR to the master branch

The Fortran bindings on the Skala branch currently fail compiling:

```
/home/user/git-repos/cp2k/venv/GauXC/src/fortran-api/molecule.f90:111:62:

  111 |   function gauxc_molecule_new_from_atoms(status, atoms, natoms) result(molecule)
      |                                                              1
Error: Symbol 'natoms' at (1) has no IMPLICIT type; did you mean 'atoms'?
```

`natoms` is not used, the atom count is determined from the size of the `atoms` array.