### PR TITLE
Fix OpenMP linking condition in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,7 @@ target_link_libraries( gauxc PUBLIC
   ExchCXX::ExchCXX 
   IntegratorXX::IntegratorXX 
 )
-if( TARGET OpenMP::OpenMP_CXX )
+if( GAUXC_HAS_OPENMP AND TARGET OpenMP::OpenMP_CXX )
   target_link_libraries( gauxc PUBLIC OpenMP::OpenMP_CXX )
 else()
   find_package(Threads REQUIRED)


### PR DESCRIPTION
If OpenMP is found but `GAUX_ENABLE_OPENMP` was set to False, we should not link against it.