### PR TITLE
Trim output paths for HDF5 output

### DIFF
--- a/src/external/hdf5_write.f90
+++ b/src/external/hdf5_write.f90
@@ -76,9 +76,9 @@ contains
     character(kind=c_char), allocatable :: c_fname(:)
     character(kind=c_char), allocatable :: c_dset(:)
 
-    c_fname = transfer(fname // c_null_char, [character(kind=c_char) ::], &
+    c_fname = transfer(TRIM(fname) // c_null_char, [character(kind=c_char) ::], &
       & len(fname) + 1)
-    c_dset = transfer(dset // c_null_char, [character(kind=c_char) ::], &
+    c_dset = transfer(TRIM(dset) // c_null_char, [character(kind=c_char) ::], &
       & len(dset) + 1)
 
     call gauxc_molecule_write_hdf5_record_c(status, mol, c_fname, c_dset)
@@ -98,9 +98,9 @@ contains
     character(kind=c_char), allocatable :: c_fname(:)
     character(kind=c_char), allocatable :: c_dset(:)
 
-    c_fname = transfer(fname // c_null_char, [character(kind=c_char) ::], &
+    c_fname = transfer(TRIM(fname) // c_null_char, [character(kind=c_char) ::], &
       & len(fname) + 1)
-    c_dset = transfer(dset // c_null_char, [character(kind=c_char) ::], &
+    c_dset = transfer(TRIM(dset) // c_null_char, [character(kind=c_char) ::], &
       & len(dset) + 1)
 
     call gauxc_basisset_write_hdf5_record_c(status, basis, c_fname, c_dset)


### PR DESCRIPTION
This fixes error:

```
HDF5-DIAG: Error detected in HDF5 (2.1.0) MPI-process 0:
  #000: /build/hdf5-2.1.0/src/H5F.c line 647 in H5Fcreate(): unable to
	synchronously create file
    major: File accessibility
    minor: Unable to create file
  #001: /build/hdf5-2.1.0/src/H5F.c line 602 in
	H5F__create_api_common(): unable to create file
    major: File accessibility
    minor: Unable to open file
  #002: /build/hdf5-2.1.0/src/H5VLcallback.c line 3647 in
	H5VL_file_create(): file create failed
    major: Virtual Object Layer
    minor: Unable to create file
  #003: /build/hdf5-2.1.0/src/H5VLcallback.c line 3618 in
	H5VL__file_create(): file create failed
    major: Virtual Object Layer
    minor: Unable to create file
  #004: /build/hdf5-2.1.0/src/H5VLnative_file.c line 94 in
	H5VL__native_file_create(): unable to create file
    major: File accessibility
    minor: Unable to open file
  #005: /build/hdf5-2.1.0/src/H5Fint.c line 1924 in H5F_open(): can't
	try opening file
    major: File accessibility
    minor: Unable to open file
  #006: /build/hdf5-2.1.0/src/H5FD.c line 966 in H5FD_open(): can't open
	file
    major: Virtual File Layer
    minor: Unable to open file
  #007: /build/hdf5-2.1.0/src/H5FDsec2.c line 285 in H5FD__sec2_open():
	unable to open file: name = './molecule.h5

                                   ', errno = 36, error message = 'File
name too long', flags = 15, o_flags = c2
    major: File accessibility
    minor: Unable to open file
GauXC returned with status code 1
GauXC status message: [Unable to create file ./molecule.h5
]
```