### PR TITLE
Support device-specific SKALA OneDFT model lookup

### DIFF
--- a/src/xc_integrator/integrator_util/onedft_util.cxx
+++ b/src/xc_integrator/integrator_util/onedft_util.cxx
@@ -52,8 +52,26 @@ std::string map_model(const std::string& model, torch::DeviceType device) {
     } else if (model == "LDA") {
         return model_path + "/lda.fun";
     } else if (model == "SKALA") {
-        GAUXC_GENERIC_EXCEPTION("To use the Skala functional, specify a local checkpoint path.");
+        const std::string install_path = std::string(GAUXC_ONEDFT_MODEL_PATH_INSTALL);
+        std::vector<std::string> search_paths;
+        search_paths.push_back(model_path);
+        if (std::filesystem::exists(install_path) && install_path != model_path) {
+            search_paths.push_back(install_path);
+        }
+        for (const auto& path : search_paths) {
+            if (device == torch::kCUDA && std::filesystem::exists(path + "/skala-1.1-cuda.fun")) {
+                return path + "/skala-1.1-cuda.fun";
+            }
+            if (std::filesystem::exists(path + "/skala-1.1.fun")) {
+                return path + "/skala-1.1.fun";
+            }
+        }
+        GAUXC_GENERIC_EXCEPTION("To use the Skala functional, install skala-1.1.fun or specify a local checkpoint path.");
     } else {
+        const std::string install_path = std::string(GAUXC_ONEDFT_MODEL_PATH_INSTALL);
+        if (std::filesystem::exists(install_path + "/" + model)) {
+            return install_path + "/" + model;
+        }
         GAUXC_GENERIC_EXCEPTION("Model " + model + " not found in " + model_path);
     }
 }


### PR DESCRIPTION
This draft PR makes the OneDFT model lookup handle SKALA as an installed model rather than requiring users to pass an explicit local checkpoint path.

For `MODEL SKALA`, GauXC now searches the configured source and install model directories. On CUDA it first prefers `skala-1.1-cuda.fun` when available, and otherwise falls back to `skala-1.1.fun`. Named models are also checked in the install model directory.

Motivation:
The current SKALA-1.1 TorchScript checkpoint can be loaded on CUDA, but its graph contains fixed CPU index tensors in the ragged-grid packing path. When the OneDFT feature tensors are on CUDA this causes a device mismatch. A CUDA-consistent SKALA checkpoint fixes the issue locally, and this patch provides the GauXC-side model selection needed to use such a checkpoint cleanly.

Tested with CP2K + GauXC on an NVIDIA GB10 system using CUDA 13.0 and PyTorch 2.12.0+cu130:

- GauXC PBE, device: `-2.176913831885182 Ha`
- OneDFT PBE, device: `-1.163121899608446 Ha`
- SKALA-1.1, device: `-1.170732895358496 Ha`
- SKALA-1.1, host: `-1.170732899047063 Ha`

The CUDA SKALA smoke used a GPU-consistent checkpoint derived from the local SKALA-1.1 checkpoint by replacing fixed TorchScript CPU index tensors with CUDA index tensors. This PR does not add that checkpoint. For upstream, the cleaner long-term solution is to export the SKALA checkpoint with device-aware tensor creation in the model code itself.
