### PR TITLE
Add spin-summed RKS density setting

### DIFF
--- a/include/gauxc/xc_integrator_settings.hpp
+++ b/include/gauxc/xc_integrator_settings.hpp
@@ -23,6 +23,9 @@ struct IntegratorSettingsSNLinK : public IntegratorSettingsEXX {
 struct IntegratorSettingsXC { virtual ~IntegratorSettingsXC() noexcept = default; };
 struct IntegratorSettingsKS : public IntegratorSettingsXC {
   double gks_dtol = 1e-12;
+  // RKS density matrices are interpreted as one-spin densities by default.
+  // Set this when the caller provides the spin-summed closed-shell density.
+  bool rks_density_matrix_is_spin_summed = false;
 };
 
 struct IntegratorSettingsEXC_GRAD : public IntegratorSettingsKS {

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator.hpp
@@ -116,7 +116,8 @@ protected:
                             const value_type* Py, int64_t ldpy,
                             const value_type* Px, int64_t ldpx,
                             host_task_iterator task_begin, host_task_iterator task_end,
-                            XCDeviceData& device_data, bool do_vxc );
+                            XCDeviceData& device_data, bool do_vxc,
+                            const IntegratorSettingsXC& settings );
 
   void exc_vxc_local_work_( const basis_type& basis, const value_type* Ps, int64_t ldps,
                             const value_type* Pz, int64_t ldpz,
@@ -127,14 +128,14 @@ protected:
                             value_type* VXCy, int64_t ldvxcy,
                             value_type* VXCx, int64_t ldvxcx, value_type* EXC, value_type *N_EL,
                             host_task_iterator task_begin, host_task_iterator task_end,
-                            XCDeviceData& device_data );
+                            XCDeviceData& device_data, const IntegratorSettingsXC& settings );
 
   void fxc_contraction_local_work_( const basis_type& basis, const value_type* Ps, int64_t ldps,
                             const value_type* Pz, int64_t ldpz,
                             const value_type* tPs, int64_t ldtps,
                             const value_type* tPz, int64_t ldtpz,
                             host_task_iterator task_begin, host_task_iterator task_end,
-                            XCDeviceData& device_data);
+                            XCDeviceData& device_data, const IntegratorSettingsXC& settings);
 
   void fxc_contraction_local_work_( const basis_type& basis, const value_type* Ps, int64_t ldps,
                             const value_type* Pz, int64_t ldpz,
@@ -144,7 +145,7 @@ protected:
                             value_type* FXCs, int64_t ldfxcs,
                             value_type* FXCz, int64_t ldfxcz,
                             host_task_iterator task_begin, host_task_iterator task_end,
-                            XCDeviceData& device_data );
+                            XCDeviceData& device_data, const IntegratorSettingsXC& settings );
 
   void eval_exc_grad_local_work_( const basis_type& basis, const value_type* Ps, int64_t ldps, 
                                   const value_type* Pz, int64_t ldpz,

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc.hpp
@@ -59,7 +59,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
     exc_vxc_local_work_( basis, Ps, ldps, Pz, ldpz, Py, ldpy, Px, ldpx,
         // Passing nullptr for VXCs disables VXC entirely
         nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0, EXC, &N_EL,
-       tasks.begin(), tasks.end(), *device_data_ptr);
+       tasks.begin(), tasks.end(), *device_data_ptr, ks_settings);
   });
 
   GAUXC_MPI_CODE(
@@ -100,4 +100,3 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
 
 }
 }
-

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc.hpp
@@ -59,7 +59,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
     exc_vxc_local_work_( basis, Ps, ldps, Pz, ldpz, Py, ldpy, Px, ldpx,
         // Passing nullptr for VXCs disables VXC entirely
         nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0, EXC, &N_EL,
-       tasks.begin(), tasks.end(), *device_data_ptr, ks_settings);
+       tasks.begin(), tasks.end(), *device_data_ptr, settings);
   });
 
   GAUXC_MPI_CODE(

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc_grad.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc_grad.hpp
@@ -168,6 +168,10 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
   IntegratorSettingsEXC_GRAD exc_grad_settings;
   if( auto* tmp = dynamic_cast<const IntegratorSettingsEXC_GRAD*>(&settings) ) {
     exc_grad_settings = *tmp;
+  } else if( auto* ks_tmp = dynamic_cast<const IntegratorSettingsKS*>(&settings) ) {
+    exc_grad_settings.gks_dtol = ks_tmp->gks_dtol;
+    exc_grad_settings.rks_density_matrix_is_spin_summed =
+      ks_tmp->rks_density_matrix_is_spin_summed;
   }
 
   // Check that Partition Weights have been calculated
@@ -221,7 +225,8 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
     else                         lwd->eval_collocation_gradient( &device_data );
 
     // Evaluate X matrix and V vars
-    const auto xmat_fac = is_rks ? 2.0 : 1.0;
+    const auto xmat_fac =
+      (is_rks and not exc_grad_settings.rks_density_matrix_is_spin_summed) ? 2.0 : 1.0;
     const auto need_lapl = func.needs_laplacian();
     const auto need_xmat_grad = not func.is_lda();
     auto do_xmat_vvar = [&](density_id den_id) {

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc_vxc.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_exc_vxc.hpp
@@ -110,8 +110,8 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
     // If we can do reductions on the device (e.g. NCCL)
     // Don't communicate data back to the host before reduction
     this->timer_.time_op("XCIntegrator.LocalWork_EXC_VXC", [&](){
-      exc_vxc_local_work_( basis, Ps, ldps, Pz, ldpz, Py, ldpy, Px, ldpx, tasks.begin(), tasks.end(), 
-        *device_data_ptr, true);
+      exc_vxc_local_work_( basis, Ps, ldps, Pz, ldpz, Py, ldpy, Px, ldpx, tasks.begin(), tasks.end(),
+        *device_data_ptr, true, settings);
     });
 
     GAUXC_MPI_CODE(
@@ -177,7 +177,7 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
     this->timer_.time_op("XCIntegrator.LocalWork_EXC_VXC", [&](){
       exc_vxc_local_work_( basis, Ps, ldps, Pz, ldpz, Py, ldpy, Px, ldpx,
                                 VXCs, ldvxcs, VXCz, ldvxcz, VXCy, ldvxcy, VXCx, ldvxcx, EXC, 
-                              &N_EL, tasks.begin(), tasks.end(), *device_data_ptr);
+                              &N_EL, tasks.begin(), tasks.end(), *device_data_ptr, settings);
     });
 
     GAUXC_MPI_CODE(
@@ -225,7 +225,8 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
                             const value_type* Py, int64_t ldpy,
                             const value_type* Px, int64_t ldpx,
                             host_task_iterator task_begin, host_task_iterator task_end,
-                            XCDeviceData& device_data, bool do_vxc ) {
+                            XCDeviceData& device_data, bool do_vxc,
+                            const IntegratorSettingsXC& settings ) {
   const bool is_gks = (Pz != nullptr) and (Py != nullptr) and (Px != nullptr);
   const bool is_uks = (Pz != nullptr) and (Py == nullptr) and (Px == nullptr);
   const bool is_rks = (Ps != nullptr) and (not is_uks and not is_gks);
@@ -242,6 +243,11 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
   const auto& mol   = this->load_balancer_->molecule();
 
   if( func.is_mgga() and is_gks ) GAUXC_GENERIC_EXCEPTION("GKS mGGAs NYI!");
+
+  IntegratorSettingsKS ks_settings;
+  if( auto* tmp = dynamic_cast<const IntegratorSettingsKS*>(&settings) ) {
+    ks_settings = *tmp;
+  }
 
   // Get basis map
   BasisSetMap basis_map(basis,mol);
@@ -312,7 +318,8 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
     else if( func.is_gga() ) lwd->eval_collocation_gradient( &device_data );
     else                     lwd->eval_collocation( &device_data );
       
-    const double xmat_fac = is_rks ? 2.0 : 1.0;
+    const double xmat_fac =
+      (is_rks and not ks_settings.rks_density_matrix_is_spin_summed) ? 2.0 : 1.0;
     const bool need_xmat_grad = func.is_mgga();
 
     // Evaluate X matrix and V vars
@@ -396,11 +403,12 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
                             value_type* VXCy, int64_t ldvxcy,
                             value_type* VXCx, int64_t ldvxcx, value_type* EXC, value_type *N_EL,
                             host_task_iterator task_begin, host_task_iterator task_end,
-                            XCDeviceData& device_data ) {
+                            XCDeviceData& device_data, const IntegratorSettingsXC& settings ) {
   
   // Get integrate and keep data on device
   const bool do_vxc = VXCs;
-  exc_vxc_local_work_( basis, Ps, ldps, Pz, ldpz, Py, ldpy, Px, ldpx, task_begin, task_end, device_data, do_vxc );
+  exc_vxc_local_work_( basis, Ps, ldps, Pz, ldpz, Py, ldpy, Px, ldpx,
+                       task_begin, task_end, device_data, do_vxc, settings );
   auto rt  = detail::as_device_runtime(this->load_balancer_->runtime());
   rt.device_backend()->master_queue_synchronize();
 
@@ -414,4 +422,3 @@ void IncoreReplicatedXCDeviceIntegrator<ValueType>::
 
 }
 }
-

--- a/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_fxc_contraction.hpp
+++ b/src/xc_integrator/replicated/device/incore_replicated_xc_device_integrator_fxc_contraction.hpp
@@ -85,7 +85,7 @@ namespace GauXC::detail {
       // Don't communicate data back to the host before reduction
       this->timer_.time_op("XCIntegrator.LocalWork_FXC", [&](){
         fxc_contraction_local_work_( basis, Ps, ldps, Pz, ldpz, tPs, ldtps, tPz, ldtpz,
-          tasks.begin(), tasks.end(), *device_data_ptr);
+          tasks.begin(), tasks.end(), *device_data_ptr, ks_settings);
       });
 
       GAUXC_MPI_CODE(
@@ -127,7 +127,8 @@ namespace GauXC::detail {
       // data from device 
       this->timer_.time_op("XCIntegrator.LocalWork_FXC", [&](){
         fxc_contraction_local_work_( basis, Ps, ldps, Pz, ldpz, tPs, ldtps, tPz, ldtpz, &N_EL, 
-                              FXCs, ldfxcs, FXCz, ldfxcz, tasks.begin(), tasks.end(), *device_data_ptr);
+                              FXCs, ldfxcs, FXCz, ldfxcz, tasks.begin(), tasks.end(), *device_data_ptr,
+                              ks_settings);
       });
 
       GAUXC_MPI_CODE(
@@ -160,7 +161,7 @@ namespace GauXC::detail {
                             const value_type* tPs, int64_t ldtps,
                             const value_type* tPz, int64_t ldtpz,
                             host_task_iterator task_begin, host_task_iterator task_end,
-                            XCDeviceData& device_data) {
+                            XCDeviceData& device_data, const IntegratorSettingsXC& settings) {
     const bool is_uks = (Pz != nullptr);
     const bool is_rks = !is_uks;
     if (not is_rks and not is_uks) {
@@ -174,6 +175,11 @@ namespace GauXC::detail {
     // Setup Aliases
     const auto& func  = *this->func_;
     const auto& mol   = this->load_balancer_->molecule();
+
+    IntegratorSettingsKS ks_settings;
+    if( auto* tmp = dynamic_cast<const IntegratorSettingsKS*>(&settings) ) {
+      ks_settings = *tmp;
+    }
 
     // Get basis map
     BasisSetMap basis_map(basis,mol);
@@ -243,7 +249,8 @@ namespace GauXC::detail {
       else if( func.is_gga() ) lwd->eval_collocation_gradient( &device_data );
       else                     lwd->eval_collocation( &device_data );
         
-      const double xmat_fac = is_rks ? 2.0 : 1.0;
+      const double xmat_fac =
+        (is_rks and not ks_settings.rks_density_matrix_is_spin_summed) ? 2.0 : 1.0;
       const bool need_xmat_grad = func.is_mgga();
 
       // Evaluate X matrix and V vars
@@ -327,11 +334,11 @@ namespace GauXC::detail {
                             value_type* FXCs, int64_t ldfxcs,
                             value_type* FXCz, int64_t ldfxcz,
                             host_task_iterator task_begin, host_task_iterator task_end,
-                            XCDeviceData& device_data ) {
+                            XCDeviceData& device_data, const IntegratorSettingsXC& settings ) {
     
     // Get integrate and keep data on device
     fxc_contraction_local_work_( basis, Ps, ldps, Pz, ldpz, tPs, ldtps, tPz, ldtpz, 
-                              task_begin, task_end, device_data);
+                              task_begin, task_end, device_data, settings);
     auto rt  = detail::as_device_runtime(this->load_balancer_->runtime());
     rt.device_backend()->master_queue_synchronize();
 

--- a/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_exc_grad.hpp
+++ b/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_exc_grad.hpp
@@ -126,6 +126,10 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
   IntegratorSettingsEXC_GRAD exc_grad_settings;
   if( auto* tmp = dynamic_cast<const IntegratorSettingsEXC_GRAD*>(&settings) ) {
     exc_grad_settings = *tmp;
+  } else if( auto* ks_tmp = dynamic_cast<const IntegratorSettingsKS*>(&settings) ) {
+    exc_grad_settings.gks_dtol = ks_tmp->gks_dtol;
+    exc_grad_settings.rks_density_matrix_is_spin_summed =
+      ks_tmp->rks_density_matrix_is_spin_summed;
   }
 
   // Get basis map
@@ -330,7 +334,8 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
 
     // Evaluate X matrix (2 * P * B/Bx/By/Bz) -> store in Z
     // XXX: This assumes that bfn + gradients are contiguous in memory
-    const auto xmat_fac = is_rks ? 2.0 : 1.0;
+    const auto xmat_fac =
+      (is_rks and not exc_grad_settings.rks_density_matrix_is_spin_summed) ? 2.0 : 1.0;
     const int  xmat_len = func.is_lda() ? 1 : 4;
     lwd->eval_xmat( xmat_len*npts, nbf, nbe, submat_map, xmat_fac, Ps, ldps, basis_eval, nbe,
                     xNmat, nbe, nbe_scr );

--- a/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_exc_vxc.hpp
+++ b/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_exc_vxc.hpp
@@ -385,7 +385,8 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
 
      
     // Evaluate X matrix (fac * P * B) -> store in Z
-    const auto xmat_fac = is_rks ? 2.0 : 1.0; // TODO Fix for spinor RKS input
+    const auto xmat_fac =
+      (is_rks and not ks_settings.rks_density_matrix_is_spin_summed) ? 2.0 : 1.0;
     lwd->eval_xmat( mgga_dim_scal * npts, nbf, nbe, submat_map, xmat_fac, Ps, ldps, basis_eval, nbe,
       zmat, nbe, nbe_scr );
 		

--- a/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_fxc_contraction.hpp
+++ b/src/xc_integrator/replicated/host/reference_replicated_xc_host_integrator_fxc_contraction.hpp
@@ -387,7 +387,8 @@ void ReferenceReplicatedXCHostIntegrator<ValueType>::
 
      
     // Evaluate X matrix (fac * P * B) -> store in Z
-    const auto xmat_fac = is_rks ? 2.0 : 1.0; // TODO Fix for spinor RKS input
+    const auto xmat_fac =
+      (is_rks and not ks_settings.rks_density_matrix_is_spin_summed) ? 2.0 : 1.0;
     lwd->eval_xmat( mgga_dim_scal * npts, nbf, nbe, submat_map, xmat_fac, Ps, ldps, basis_eval, nbe,
       zmat, nbe, nbe_scr );
     // X matrix for Pz

--- a/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator.hpp
+++ b/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator.hpp
@@ -133,7 +133,9 @@ protected:
                             value_type* VXCy, int64_t ldvxcy,
                             value_type* VXCx, int64_t ldvxcx,
                             value_type* EXC, value_type *N_EL,
-                            host_task_iterator task_begin, host_task_iterator task_end, incore_integrator_type& incore_integrator
+                            host_task_iterator task_begin, host_task_iterator task_end,
+                            incore_integrator_type& incore_integrator,
+                            const IntegratorSettingsXC& ks_settings
                              );
 
 
@@ -146,7 +148,9 @@ protected:
                            value_type* VXCz, int64_t ldvxcz,
                            value_type* VXCy, int64_t ldvxcy,
                            value_type* VXCx, int64_t ldvxcx,
-                           value_type* EXC, value_type* N_EL, incore_integrator_type& incore_integrator);
+                           value_type* EXC, value_type* N_EL,
+                           incore_integrator_type& incore_integrator,
+                           const IntegratorSettingsXC& ks_settings);
 public:
 
   template <typename... Args>

--- a/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_exc.hpp
+++ b/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_exc.hpp
@@ -38,7 +38,7 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
              const value_type* Pz, int64_t ldpz,
              const value_type* Py, int64_t ldpy,
              const value_type* Px, int64_t ldpx,
-             value_type* EXC, const IntegratorSettingsXC& /*ks_settings*/) {
+             value_type* EXC, const IntegratorSettingsXC& ks_settings) {
 
 
   const auto& basis = this->load_balancer_->basis();
@@ -84,7 +84,7 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
   this->timer_.time_op("XCIntegrator.LocalWork", [&](){
     exc_vxc_local_work_( basis, Ps, ldps, Pz, ldpz, Py, ldpy, Px, ldpx,
       nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0, EXC, 
-      &N_EL, tasks.begin(), tasks.end(), incore_integrator );
+      &N_EL, tasks.begin(), tasks.end(), incore_integrator, ks_settings );
   });
 
   // Release ownership of LWD back to this integrator instance
@@ -134,4 +134,3 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
 
 }
 }
-

--- a/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_exc_grad.hpp
+++ b/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_exc_grad.hpp
@@ -22,7 +22,7 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
   eval_exc_grad_( int64_t m, int64_t n, const value_type* P, int64_t ldp, value_type* EXC_GRAD, const IntegratorSettingsXC& settings ) { 
                  
   GAUXC_GENERIC_EXCEPTION("ShellBatched exc_grad NYI" );                 
-  util::unused(m,n,P,ldp,EXC_GRAD);
+  util::unused(m,n,P,ldp,EXC_GRAD,settings);
 }
 
 template <typename BaseIntegratorType, typename IncoreIntegratorType>
@@ -31,7 +31,7 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
                   const value_type* Pz, int64_t lpdz, value_type* EXC_GRAD, const IntegratorSettingsXC& settings ) { 
                  
   GAUXC_GENERIC_EXCEPTION("ShellBatched exc_grad NYI" );                 
-  util::unused(m,n,Ps,ldps,Pz,lpdz,EXC_GRAD);
+  util::unused(m,n,Ps,ldps,Pz,lpdz,EXC_GRAD,settings);
 }
 
 }

--- a/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_exc_vxc.hpp
+++ b/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_exc_vxc.hpp
@@ -42,7 +42,7 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
                  value_type* VXCz, int64_t ldvxcz,
                  value_type* VXCy, int64_t ldvxcy,
                  value_type* VXCx, int64_t ldvxcx,
-                 value_type* EXC, const IntegratorSettingsXC& /*ks_settings*/) {
+                 value_type* EXC, const IntegratorSettingsXC& ks_settings) {
 
 
   const auto& basis = this->load_balancer_->basis();
@@ -98,7 +98,7 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
   this->timer_.time_op("XCIntegrator.LocalWork", [&](){
     exc_vxc_local_work_( basis, Ps, ldps, Pz, ldpz, Py, ldpy, Px, ldpx,
       VXCs, ldvxcs, VXCz, ldvxcz, VXCy, ldvxcy, VXCx, ldvxcx, EXC, 
-      &N_EL, tasks.begin(), tasks.end(), incore_integrator );
+      &N_EL, tasks.begin(), tasks.end(), incore_integrator, ks_settings );
   });
 
   // Release ownership of LWD back to this integrator instance
@@ -166,7 +166,8 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
                        value_type* VXCx, int64_t ldvxcx,
                        value_type* EXC, value_type *N_EL, 
                        host_task_iterator task_begin, host_task_iterator task_end,
-                       incore_integrator_type& incore_integrator ) {
+                       incore_integrator_type& incore_integrator,
+                       const IntegratorSettingsXC& ks_settings ) {
 
   //incore_integrator.exc_vxc_local_work( basis, P, ldp, VXC, ldvxc, EXC, N_EL, task_begin, task_end, device_data );
   //return;
@@ -227,7 +228,7 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
     // Execute task
     execute_task_batch( next_task, basis, mol, Ps, ldps, Pz, ldpz,
       Py, ldpy, Px, ldpx, VXCs, ldvxcs, VXCz, ldvxcz, VXCy, ldvxcy,
-      VXCx, ldvxcx, EXC, N_EL, incore_integrator );
+      VXCx, ldvxcx, EXC, N_EL, incore_integrator, ks_settings );
   };
 
 
@@ -287,7 +288,8 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
                       value_type* VXCy, int64_t ldvxcy,
                       value_type* VXCx, int64_t ldvxcx,
                       value_type* EXC, value_type *N_EL, 
-                      incore_integrator_type& incore_integrator ) {
+                      incore_integrator_type& incore_integrator,
+                      const IntegratorSettingsXC& ks_settings ) {
 
 
   // Alias information
@@ -398,13 +400,13 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
     incore_integrator.exc_vxc_local_work( basis_subset, Ps_submat, nbe, 
       Pz_submat, nbe, Py_submat, nbe, Px_submat, nbe, VXCs_submat, nbe,
       VXCz_submat, nbe, VXCy_submat, nbe, VXCx_submat, nbe,
-      &EXC_tmp, &NEL_tmp, task_begin, task_end, *device_data_ptr_ );
+      &EXC_tmp, &NEL_tmp, task_begin, task_end, *device_data_ptr_, ks_settings );
   } else if constexpr (not IncoreIntegratorType::is_device) {
 #endif
     incore_integrator.exc_vxc_local_work( basis_subset, Ps_submat, nbe, 
       Pz_submat, nbe, Py_submat, nbe, Px_submat, nbe, VXCs_submat, nbe,
       VXCz_submat, nbe, VXCy_submat, nbe, VXCx_submat, nbe,
-      &EXC_tmp, &NEL_tmp, IntegratorSettingsKS{}, task_begin, task_end );
+      &EXC_tmp, &NEL_tmp, ks_settings, task_begin, task_end );
 #ifdef GAUXC_HAS_DEVICE
   }
 #endif
@@ -444,4 +446,3 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
 
 }
 }
-

--- a/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_fxc_contraction.hpp
+++ b/src/xc_integrator/shell_batched/shell_batched_replicated_xc_integrator_fxc_contraction.hpp
@@ -41,7 +41,7 @@ void ShellBatchedReplicatedXCIntegrator<BaseIntegratorType, IncoreIntegratorType
                         const IntegratorSettingsXC& ks_settings ) {
   GAUXC_GENERIC_EXCEPTION("ShellBatched FXC contraction NYI");            
   util::unused(m,n,Ps,ldps,Pz,ldpz,tPs,ldtps,tPz,ldtpz,
-                 FXCs,ldfxcs,FXCz,ldfxcz);
+                 FXCs,ldfxcs,FXCz,ldfxcz,ks_settings);
 
 }
 

--- a/tests/standalone_driver.cxx
+++ b/tests/standalone_driver.cxx
@@ -71,6 +71,7 @@ int main(int argc, char** argv) {
     bool integrate_vxc      = true;
     bool integrate_exx      = false;
     bool integrate_exc_grad = false;
+    bool rks_density_matrix_is_spin_summed = false;
     bool integrate_dd_psi   = false;
     bool integrate_dd_psi_potential  = false;
     bool integrate_fxc_contraction   = false;
@@ -111,6 +112,7 @@ int main(int argc, char** argv) {
     OPTIONAL_KEYWORD( "GAUXC.INTEGRATE_VXC",      integrate_vxc,      bool );
     OPTIONAL_KEYWORD( "GAUXC.INTEGRATE_EXX",      integrate_exx,      bool );
     OPTIONAL_KEYWORD( "GAUXC.INTEGRATE_EXC_GRAD", integrate_exc_grad, bool );
+    OPTIONAL_KEYWORD( "GAUXC.RKS_DENSITY_MATRIX_IS_SPIN_SUMMED", rks_density_matrix_is_spin_summed, bool );
     OPTIONAL_KEYWORD( "GAUXC.INTEGRATE_DD_PSI",   integrate_dd_psi,   bool );
     OPTIONAL_KEYWORD( "GAUXC.INTEGRATE_DD_PSI_POTENTIAL",   integrate_dd_psi_potential,   bool );
     OPTIONAL_KEYWORD( "GAUXC.INTEGRATE_FXC_CONTRACTION",   integrate_fxc_contraction,   bool );
@@ -469,7 +471,9 @@ int main(int argc, char** argv) {
 
     if( integrate_vxc ) {
       if( rks ) {
-        std::tie(EXC, VXC) = integrator.eval_exc_vxc( P );
+        IntegratorSettingsKS ks_settings;
+        ks_settings.rks_density_matrix_is_spin_summed = rks_density_matrix_is_spin_summed;
+        std::tie(EXC, VXC) = integrator.eval_exc_vxc( P, ks_settings );
       }
       else if ( uks ) {
         std::tie(EXC, VXC, VXCz) = integrator.eval_exc_vxc( P, Pz );
@@ -493,11 +497,13 @@ int main(int argc, char** argv) {
 
     std::vector<double> EXC_GRAD;
     if( integrate_exc_grad ) {
+      IntegratorSettingsEXC_GRAD exc_grad_settings;
+      exc_grad_settings.rks_density_matrix_is_spin_summed = rks_density_matrix_is_spin_summed;
       if( rks ) {
-        EXC_GRAD = integrator.eval_exc_grad( P );
+        EXC_GRAD = integrator.eval_exc_grad( P, exc_grad_settings );
       }
       else if( uks ) {
-        EXC_GRAD = integrator.eval_exc_grad( P, Pz );
+        EXC_GRAD = integrator.eval_exc_grad( P, Pz, exc_grad_settings );
       }
       else if( gks ) {
         std::cout << "Warning: eval_exc_grad + GKS NYI!" << std::endl;

--- a/tests/standalone_driver.cxx
+++ b/tests/standalone_driver.cxx
@@ -459,6 +459,10 @@ int main(int argc, char** argv) {
     double EXC, N_EL;
 
     std::cout << std::scientific << std::setprecision(12);
+    IntegratorSettingsKS ks_settings;
+    ks_settings.rks_density_matrix_is_spin_summed =
+      rks_density_matrix_is_spin_summed;
+
     if( integrate_den ) {
       if( (uks or gks) and !world_rank ) {
         std::cout << "Warning: integrate_den will only integrate the scalar density!" << std::endl;
@@ -471,8 +475,6 @@ int main(int argc, char** argv) {
 
     if( integrate_vxc ) {
       if( rks ) {
-        IntegratorSettingsKS ks_settings;
-        ks_settings.rks_density_matrix_is_spin_summed = rks_density_matrix_is_spin_summed;
         std::tie(EXC, VXC) = integrator.eval_exc_vxc( P, ks_settings );
       }
       else if ( uks ) {
@@ -583,7 +585,7 @@ int main(int argc, char** argv) {
       
       // Compute FXC contraction
       if( rks ) {
-        FXC = integrator.eval_fxc_contraction( P, tP, IntegratorSettingsXC{} );
+        FXC = integrator.eval_fxc_contraction( P, tP, ks_settings );
       } else if( uks ) {
         std::tie(FXC, FXCz) = integrator.eval_fxc_contraction( P, Pz, tP, tPz, IntegratorSettingsXC{} );
       } else if( gks ) {

--- a/tests/xc_integrator.cxx
+++ b/tests/xc_integrator.cxx
@@ -225,7 +225,8 @@ void test_xc_integrator( ExecutionSpace ex, const RuntimeEnvironment& rt,
       CHECK(EXC3 == Approx(EXC_ref));
       auto [ EXC4, VXC4 ] = integrator.eval_exc_vxc( P_spin_summed, spin_summed_settings );
       CHECK(EXC4 == Approx(EXC_ref));
-      (void)VXC4;
+      auto VXC4_diff_nrm = ( VXC4 - VXC_ref ).norm();
+      CHECK( VXC4_diff_nrm / basis.nbf() < 1e-10 );
     }
 
   } else if (uks) {

--- a/tests/xc_integrator.cxx
+++ b/tests/xc_integrator.cxx
@@ -215,6 +215,19 @@ void test_xc_integrator( ExecutionSpace ex, const RuntimeEnvironment& rt,
     auto EXC2 = integrator.eval_exc( P );
     CHECK(EXC2 == Approx(EXC));
 
+    if( func.is_lda() ) {
+      // External interfaces may provide the spin-summed closed-shell density
+      // instead of the one-spin density used by GauXC's default RKS convention.
+      matrix_type P_spin_summed = 2.0 * P;
+      IntegratorSettingsKS spin_summed_settings;
+      spin_summed_settings.rks_density_matrix_is_spin_summed = true;
+      auto EXC3 = integrator.eval_exc( P_spin_summed, spin_summed_settings );
+      CHECK(EXC3 == Approx(EXC_ref));
+      auto [ EXC4, VXC4 ] = integrator.eval_exc_vxc( P_spin_summed, spin_summed_settings );
+      CHECK(EXC4 == Approx(EXC_ref));
+      (void)VXC4;
+    }
+
   } else if (uks) {
     auto [ EXC, VXC, VXCz ] = integrator.eval_exc_vxc( P, Pz );
 


### PR DESCRIPTION
This separates the core GauXC part of the spin-summed RKS density-matrix handling from the Skala/Fortran-facing API exposure.

GauXC keeps the existing default RKS convention: an RKS density matrix is interpreted as a one-spin density and the closed-shell density is formed internally with the usual factor of two. Some external interfaces provide the already spin-summed closed-shell density matrix. This PR adds an explicit opt-in setting for that case without changing the default behavior.

Changes:

- add `IntegratorSettingsKS::rks_density_matrix_is_spin_summed`
- use the setting in the host and device RKS `xmat_fac` paths
- propagate settings through the shell-batched wrapper paths
- add a standalone-driver keyword for HDF5/reproducer workflows
- add a C++ regression check for spin-summed RKS density input on the stable LDA RKS reference path

No Skala, OneDFT, C API, or Fortran API exposure is included here; those belong in a follow-up change on the `skala` branch once this core convention is agreed.

Validation performed on Spark:

- configured and built host/HDF5 GauXC from this branch against `master`
- built `standalone_driver` and `gauxc_test`
- ran targeted `gauxc_test "XC Integrator" -c "Benzene / SVWN5 / cc-pVDZ" -c Host -c Reference --success` successfully
- ran the CP2K-generated H2O all-electron GAPW/QZVPP HDF5 reproducer with full spin-summed RKS density:
  - `N_EL = 9.999998605222`
  - `EXC = -9.247398490121`
  - EXC gradient rows:
    - ` 4.093047e-13  6.159873e-14 -4.648139e-01`
    - `-1.646459e-13  3.214351e-01  2.324069e-01`
    - `-2.447600e-13 -3.214351e-01  2.324069e-01`

The full serial GauXC test target was also tried, but existing MGGA reference sections fail in this environment independently of this focused RKS convention check.