### PR TITLE
Fix CUTLASS local work driver setup

### DIFF
--- a/cmake/gauxc-exchcxx.cmake
+++ b/cmake/gauxc-exchcxx.cmake
@@ -1,5 +1,5 @@
 find_package( ExchCXX QUIET )
-if( NOT ${ExchCXX_FOUND} )
+if( NOT ExchCXX_FOUND )
 
   include( gauxc-dep-versions )
 
@@ -19,6 +19,10 @@ if( NOT ${ExchCXX_FOUND} )
 
   FetchContent_MakeAvailable( exchcxx )
 
+  if( CMAKE_POSITION_INDEPENDENT_CODE AND TARGET exchcxx )
+    set_target_properties( exchcxx PROPERTIES POSITION_INDEPENDENT_CODE ON )
+  endif()
+
 
 else()
 
@@ -31,5 +35,3 @@ else()
   endif()
 
 endif()
-
-

--- a/cmake/gauxc-integratorxx.cmake
+++ b/cmake/gauxc-integratorxx.cmake
@@ -1,5 +1,5 @@
 find_package( IntegratorXX QUIET )
-if( NOT ${IntegratorXX_FOUND} )
+if( NOT IntegratorXX_FOUND )
 
   include( gauxc-dep-versions )
 
@@ -16,6 +16,8 @@ if( NOT ${IntegratorXX_FOUND} )
 
   FetchContent_MakeAvailable( integratorxx )
 
+  if( CMAKE_POSITION_INDEPENDENT_CODE AND TARGET integratorxx )
+    set_target_properties( integratorxx PROPERTIES POSITION_INDEPENDENT_CODE ON )
+  endif()
+
 endif()
-
-

--- a/src/xc_integrator/local_work_driver/factory.cxx
+++ b/src/xc_integrator/local_work_driver/factory.cxx
@@ -11,18 +11,31 @@
  */
 #include <gauxc/xc_integrator/local_work_driver.hpp>
 #include "host/reference_local_host_work_driver.hpp"
+#include <algorithm>
+#include <cctype>
 #ifdef GAUXC_HAS_DEVICE
 #include "device/cuda/cuda_aos_scheme1.hpp"
 #include "device/hip/hip_aos_scheme1.hpp"
 #endif
 
 namespace GauXC {
+namespace {
+
+void trim_and_uppercase(std::string& name) {
+  auto not_space = [](unsigned char c) { return !std::isspace(c); };
+  name.erase(name.begin(), std::find_if(name.begin(), name.end(), not_space));
+  name.erase(std::find_if(name.rbegin(), name.rend(), not_space).base(), name.end());
+  std::transform(name.begin(), name.end(), name.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+}
+
+}
 
 LocalWorkDriverFactory::ptr_return_t
   LocalWorkDriverFactory::make_local_work_driver( ExecutionSpace ex, 
     std::string name, LocalWorkSettings settings ) {
 
-  std::transform( name.begin(), name.end(), name.begin(), ::toupper );
+  trim_and_uppercase(name);
   (void)(settings);
 
   switch(ex) {


### PR DESCRIPTION
This PR fixes two small setup issues encountered when building and selecting the CUTLASS local work driver from downstream projects such as CP2K.

## Changes

- Use direct CMake boolean checks for fetched ExchCXX and IntegratorXX package discovery.
- Propagate `CMAKE_POSITION_INDEPENDENT_CODE` to fetched ExchCXX and IntegratorXX targets when they are built as GauXC subprojects.
- Normalize local work driver names by trimming whitespace and uppercasing via unsigned-character-safe `std::toupper` handling.

## Motivation

The PIC propagation avoids relocation/link issues when GauXC is built as part of a shared downstream library with fetched static dependencies. The local work driver normalization makes inputs such as `Scheme1-CUTLASS` robust against surrounding whitespace and avoids undefined behavior from passing signed chars directly to `std::toupper`.

## Validation

- `git diff --check`: OK
- Line-length check on touched files: OK
- `cmake -S . -B /tmp/gauxc-cutlass-build-fixes-configure -DGAUXC_ENABLE_MPI=OFF -DGAUXC_ENABLE_OPENMP=OFF -DGAUXC_ENABLE_TESTS=OFF -DGAUXC_ENABLE_HDF5=OFF -DGAUXC_ENABLE_ONEDFT=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON`: OK
- `cmake --build /tmp/gauxc-cutlass-build-fixes-configure -j 4`: OK
