### PR TITLE
Fix MSVC C4996/C4242 warnings in C API

### DIFF
--- a/src/c-api/c_functional.cxx
+++ b/src/c-api/c_functional.cxx
@@ -19,6 +19,7 @@
 #include "c_functional.hpp"
 #include "c_status.hpp"
 
+#ifdef EXCHCXX_ENABLE_LIBXC
 namespace GauXC::detail {
 /**
  *  Splits a string into tokens  based on a delimiter
@@ -28,7 +29,7 @@ namespace GauXC::detail {
  *  \param [in]  str        std::string to split
  *  \param [in]  delimiters Delimiters on which to split str
  */
-static inline void split(std::vector<std::string>& tokens, 
+static inline void split(std::vector<std::string>& tokens,
   const std::string& str, const std::string& delimiters = " ") {
 
     tokens.clear();
@@ -47,6 +48,7 @@ static inline void split(std::vector<std::string>& tokens,
     }
 }; // split
 } // namespace GauXC::detail
+#endif
 
 namespace GauXC::C {
 extern "C" {

--- a/src/c-api/c_status.hpp
+++ b/src/c-api/c_status.hpp
@@ -34,8 +34,9 @@ static inline void gauxc_status_handle(C::GauXCStatus* status, int code, const c
      if (status->message != nullptr) {
        std::free(status->message);
      }
-     status->message = (char*)std::malloc(std::strlen(message) + 1);
-     std::strcpy(status->message, message);
+     const std::size_t len = std::strlen(message) + 1;
+     status->message = (char*)std::malloc(len);
+     std::memcpy(status->message, message, len);
    } else {
      GAUXC_GENERIC_EXCEPTION(message);
    }

--- a/src/c-api/c_xc_integrator.cxx
+++ b/src/c-api/c_xc_integrator.cxx
@@ -133,7 +133,8 @@ GauXCIntegrator gauxc_integrator_new(
 
     // Create Integrator instance
     auto input_type_ = std::string(integrator_input_type);
-    std::transform( input_type_.begin(), input_type_.end(), input_type_.begin(), ::toupper );
+    std::transform( input_type_.begin(), input_type_.end(), input_type_.begin(),
+                    [](unsigned char c) { return static_cast<char>(std::toupper(c)); } );
 
     if( input_type_ != "REPLICATED" ) GAUXC_GENERIC_EXCEPTION("INTEGRATOR TYPE NOT RECOGNIZED");
 


### PR DESCRIPTION
- c_status.hpp: replace std::strcpy with std::memcpy using the already computed length. Avoids C4996 (deprecation of strcpy) portably without resorting to _CRT_SECURE_NO_WARNINGS or the non-portable strcpy_s.
- c_xc_integrator.cxx: replace ::toupper passed to std::transform with a lambda that takes unsigned char and casts the result back to char. Fixes C4242 (int->char loss-of-data) and avoids UB when char is signed.