### PR TITLE
Gau2grid: Ship version 2.0.9 by default

### DIFF
--- a/cmake/gauxc-dep-versions.cmake
+++ b/cmake/gauxc-dep-versions.cmake
@@ -11,7 +11,7 @@ set( GAUXC_EXCHCXX_REPOSITORY https://github.com/wavefunction91/ExchCXX.git )
 set( GAUXC_EXCHCXX_REVISION   67be5c6ebe1e5b1a32f2c3fd1c5bf4cbfe48f769 )
 
 set( GAUXC_GAU2GRID_REPOSITORY https://github.com/dgasmith/gau2grid.git )
-set( GAUXC_GAU2GRID_REVISION   v2.0.6 )
+set( GAUXC_GAU2GRID_REVISION   v2.0.9 )
 
 set( GAUXC_INTEGRATORXX_REPOSITORY https://github.com/wavefunction91/IntegratorXX.git )
 set( GAUXC_INTEGRATORXX_REVISION   619d26ae4ea421ed9b7a6f80eb0783f9da1ecf7a )

--- a/cmake/gauxc-dep-versions.cmake
+++ b/cmake/gauxc-dep-versions.cmake
@@ -10,7 +10,7 @@ set( GAUXC_CUTLASS_REVISION v2.10.0 )
 set( GAUXC_EXCHCXX_REPOSITORY https://github.com/wavefunction91/ExchCXX.git )
 set( GAUXC_EXCHCXX_REVISION   67be5c6ebe1e5b1a32f2c3fd1c5bf4cbfe48f769 )
 
-set( GAUXC_GAU2GRID_REPOSITORY https://github.com/dgasmith/gau2grid.git )
+set( GAUXC_GAU2GRID_REPOSITORY https://github.com/psi4/gau2grid.git )
 set( GAUXC_GAU2GRID_REVISION   v2.0.9 )
 
 set( GAUXC_INTEGRATORXX_REPOSITORY https://github.com/wavefunction91/IntegratorXX.git )

--- a/external/gau2grid/generated_source/gau2grid/gau2grid.h
+++ b/external/gau2grid/generated_source/gau2grid/gau2grid.h
@@ -1,23 +1,23 @@
 /*
  * BSD 3-Clause License
- * 
+ *
  * Copyright (c) 2017, Daniel Smith
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * * Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
- * 
+ *
  * * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
+ *
  * * Neither the name of the copyright holder nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -52,29 +52,60 @@ extern "C" {
 #define GG_CARTESIAN_CCA 400
 #define GG_CARTESIAN_MOLDEN 401
 // Information helpers
-int gg_max_L();
+int gg_max_L(void);
 
 int gg_ncomponents(const int L, const int spherical);
 
 // Fast transposers
-void gg_naive_transpose(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input, double* PRAGMA_RESTRICT output);
-void gg_fast_transpose(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input, double* PRAGMA_RESTRICT output);
+void gg_naive_transpose(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input,
+                        double* PRAGMA_RESTRICT output);
+void gg_fast_transpose(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input,
+                       double* PRAGMA_RESTRICT output);
 
 // Fast segment copiers
-void block_copy(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input, unsigned long is, double* PRAGMA_RESTRICT output, unsigned long os, const int trans);
-
+void block_copy(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input, unsigned long is,
+                double* PRAGMA_RESTRICT output, unsigned long os, const int trans);
 
 // Orbitals on a grid
-void gg_orbitals(int L, const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
+void gg_orbitals(int L, const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                 const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                 const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                 const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
 
 // Collocation matrix functions
-void gg_collocation(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
+void gg_collocation(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                    const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                    const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order,
+                    double* PRAGMA_RESTRICT phi_out);
 
-void gg_collocation_deriv1(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
+void gg_collocation_deriv1(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                           const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                           const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                           const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                           double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
 
-void gg_collocation_deriv2(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
+void gg_collocation_deriv2(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                           const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                           const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                           const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                           double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                           double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                           double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                           double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
 
-void gg_collocation_deriv3(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
+void gg_collocation_deriv3(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                           const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                           const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                           const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                           double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                           double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                           double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                           double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out,
+                           double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out,
+                           double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+                           double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out,
+                           double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out,
+                           double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
 
 #ifdef __cplusplus
 }

--- a/external/gau2grid/generated_source/gau2grid/gau2grid_pragma.h
+++ b/external/gau2grid/generated_source/gau2grid/gau2grid_pragma.h
@@ -34,7 +34,7 @@
     #define PRAGMA_RESTRICT                                  __restrict__
 
 #elif defined(__clang__) && defined(_MSC_VER)
-    // pragmas for clang-cl
+    // pragmas for MSVC
 
     #define ALIGNED_MALLOC(alignment, size)                  _aligned_malloc(size, alignment)
     #define ALIGNED_FREE(ptr)                                _aligned_free(ptr)

--- a/external/gau2grid/generated_source/gau2grid/gau2grid_utility.h
+++ b/external/gau2grid/generated_source/gau2grid/gau2grid_utility.h
@@ -6,192 +6,613 @@
  */
 
 // Spherical transformers
-void gg_cca_cart_to_spherical_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_sum_L0(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_sum_L0(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_sum_L1(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_sum_L1(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_sum_L2(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_sum_L2(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_sum_L3(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_sum_L3(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_sum_L4(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_sum_L4(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_sum_L5(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_sum_L5(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical);
 
-void gg_cca_cart_to_spherical_sum_L6(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_sum_L6(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_L7(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_sum_L0(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_sum_L7(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_L8(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_sum_L1(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_cca_cart_to_spherical_sum_L8(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_gaussian_cart_to_spherical_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_sum_L2(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_gaussian_cart_to_spherical_sum_L0(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_gaussian_cart_to_spherical_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_sum_L3(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_gaussian_cart_to_spherical_sum_L1(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_gaussian_cart_to_spherical_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_sum_L4(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_gaussian_cart_to_spherical_sum_L2(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_gaussian_cart_to_spherical_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_sum_L5(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_gaussian_cart_to_spherical_sum_L3(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical);
+void gg_gaussian_cart_to_spherical_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical);
 
-void gg_gaussian_cart_to_spherical_sum_L6(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical);
+void gg_gaussian_cart_to_spherical_sum_L4(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical);
 
-void gg_cca_cart_copy_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_gaussian_cart_to_spherical_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical);
 
-void gg_cca_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_gaussian_cart_to_spherical_sum_L5(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical);
 
-void gg_cca_cart_copy_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_gaussian_cart_to_spherical_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical);
 
-void gg_cca_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_gaussian_cart_to_spherical_sum_L6(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical);
 
-void gg_cca_cart_copy_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_gaussian_cart_to_spherical_L7(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical);
 
-void gg_cca_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_gaussian_cart_to_spherical_sum_L7(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical);
 
-void gg_cca_cart_copy_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_gaussian_cart_to_spherical_L8(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical);
 
-void gg_cca_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_gaussian_cart_to_spherical_sum_L8(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical);
 
-void gg_cca_cart_copy_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_copy_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out);
 
-void gg_cca_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
 
-void gg_cca_cart_copy_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_copy_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out);
 
-void gg_cca_cart_sum_L5(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
 
-void gg_cca_cart_copy_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_copy_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out);
 
-void gg_cca_cart_sum_L6(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
 
-void gg_molden_cart_copy_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_copy_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out);
 
-void gg_molden_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
 
-void gg_molden_cart_copy_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_copy_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out);
 
-void gg_molden_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
 
-void gg_molden_cart_copy_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_copy_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out);
 
-void gg_molden_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_sum_L5(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
 
-void gg_molden_cart_copy_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_copy_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out);
 
-void gg_molden_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_sum_L6(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
 
-void gg_molden_cart_copy_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_copy_L7(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out);
 
-void gg_molden_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_sum_L7(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
 
-void gg_molden_cart_copy_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_copy_L8(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out);
 
-void gg_molden_cart_sum_L5(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_cca_cart_sum_L8(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
 
-void gg_molden_cart_copy_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_molden_cart_copy_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out);
 
-void gg_molden_cart_sum_L6(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+void gg_molden_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
 
+void gg_molden_cart_copy_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out);
+
+void gg_molden_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+
+void gg_molden_cart_copy_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out);
+
+void gg_molden_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+
+void gg_molden_cart_copy_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out);
+
+void gg_molden_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+
+void gg_molden_cart_copy_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out);
+
+void gg_molden_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+
+void gg_molden_cart_copy_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out);
+
+void gg_molden_cart_sum_L5(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+
+void gg_molden_cart_copy_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out);
+
+void gg_molden_cart_sum_L6(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+
+void gg_molden_cart_copy_L7(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out);
+
+void gg_molden_cart_sum_L7(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
+
+void gg_molden_cart_copy_L8(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out);
+
+void gg_molden_cart_sum_L8(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out);
 
 // Fast matrix vector block sum
-void block_matrix_vector(unsigned long n, unsigned long m, const double* vector, const double* PRAGMA_RESTRICT input, unsigned long is, double* PRAGMA_RESTRICT output);
+void block_matrix_vector(unsigned long n, unsigned long m, const double* vector, const double* PRAGMA_RESTRICT input,
+                         unsigned long is, double* PRAGMA_RESTRICT output);
 // Orbital computers
-void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
+void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
 
-void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
+void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
 
-void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
+void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
 
-void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
+void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
 
-void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
+void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
 
-void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
+void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
 
-void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
+void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
+
+void gg_orbitals_L7(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
+
+void gg_orbitals_L8(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out);
 
 // Phi computers
-void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
+void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
 
-void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
+void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
 
-void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
+void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
 
-void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
+void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
 
-void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
+void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
 
-void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
+void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
 
-void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
+void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
+
+void gg_collocation_L7(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
+
+void gg_collocation_L8(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out);
 
 // Phi grad computers
-void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
+void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
 
-void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
+void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
 
-void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
+void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
 
-void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
+void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
 
-void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
+void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
 
-void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
+void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
 
-void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
+void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
+
+void gg_collocation_L7_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
+
+void gg_collocation_L8_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out);
 
 // Phi Hess computers
-void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
+void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
 
-void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
+void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
 
-void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
+void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
 
-void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
+void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
 
-void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
+void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
 
-void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
+void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
 
-void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
+void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
+
+void gg_collocation_L7_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
+
+void gg_collocation_L8_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out);
 
 // Phi Der3 computers
-void gg_collocation_L0_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
+void gg_collocation_L0_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
 
-void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
+void gg_collocation_L1_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
 
-void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
+void gg_collocation_L2_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
 
-void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
+void gg_collocation_L3_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
 
-void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
+void gg_collocation_L4_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
 
-void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
+void gg_collocation_L5_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
 
-void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
+void gg_collocation_L6_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
+
+void gg_collocation_L7_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);
+
+void gg_collocation_L8_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out);

--- a/external/gau2grid/generated_source/gau2grid_deriv1.c
+++ b/external/gau2grid/generated_source/gau2grid_deriv1.c
@@ -20,10 +20,11 @@
 #include "gau2grid/gau2grid_utility.h"
 #include "gau2grid/gau2grid_pragma.h"
 
-
-
-void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
-
+void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -33,12 +34,12 @@ void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 224 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -55,17 +56,17 @@ void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
 
     // Declare doubles
@@ -81,8 +82,6 @@ void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -107,8 +106,8 @@ void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_
                 S0[i] = 0.0;
                 S1[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -141,7 +140,6 @@ void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_
                 const double T2 = alpha_n2 * T1;
                 S1[i] += T2;
             }
-
         }
 
         // Combine blocks
@@ -170,11 +168,13 @@ void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_x_tmp);
     ALIGNED_FREE(phi_y_tmp);
     ALIGNED_FREE(phi_z_tmp);
-
 }
 
-void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
-
+void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -184,12 +184,12 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 224 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -206,17 +206,17 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
 
     // Declare doubles
@@ -232,8 +232,6 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -258,8 +256,8 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
                 S0[i] = 0.0;
                 S1[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -292,7 +290,6 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
                 const double T2 = alpha_n2 * T1;
                 S1[i] += T2;
             }
-
         }
 
         // Combine blocks
@@ -329,7 +326,6 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
             phi_y_tmp[64 + i] = SY * zc[i];
             phi_z_tmp[64 + i] = SZ * zc[i];
             phi_z_tmp[64 + i] += S0[i];
-
         }
 
         // Copy data back into outer temps
@@ -341,7 +337,7 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_to_spherical_L1(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_to_spherical_L1(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_to_spherical_L1(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -349,7 +345,7 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_gaussian_cart_to_spherical_L1(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_gaussian_cart_to_spherical_L1(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_gaussian_cart_to_spherical_L1(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -357,7 +353,7 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_copy_L1(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_copy_L1(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_copy_L1(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -366,7 +362,6 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_molden_cart_copy_L1(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_molden_cart_copy_L1(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -379,11 +374,13 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_x_tmp);
     ALIGNED_FREE(phi_y_tmp);
     ALIGNED_FREE(phi_z_tmp);
-
 }
 
-void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
-
+void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -393,12 +390,12 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 224 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -415,17 +412,17 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
 
     // Declare doubles
@@ -443,8 +440,6 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -469,8 +464,8 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
                 S0[i] = 0.0;
                 S1[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -503,7 +498,6 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
                 const double T2 = alpha_n2 * T1;
                 S1[i] += T2;
             }
-
         }
 
         // Combine blocks
@@ -518,7 +512,6 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
             const double zc_pow2 = zc[i] * zc[i];
-
 
             // Density AM=2 Component=XX
             phi_tmp[i] = S0[i] * xc_pow2;
@@ -582,7 +575,6 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
             phi_z_tmp[160 + i] = SZ * zc_pow2;
             AZ = 2.0 * zc[i];
             phi_z_tmp[160 + i] += S0[i] * AZ;
-
         }
 
         // Copy data back into outer temps
@@ -594,7 +586,7 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_to_spherical_L2(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_to_spherical_L2(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_to_spherical_L2(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -602,7 +594,7 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_gaussian_cart_to_spherical_L2(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_gaussian_cart_to_spherical_L2(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_gaussian_cart_to_spherical_L2(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -610,7 +602,7 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_copy_L2(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_copy_L2(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_copy_L2(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -619,7 +611,6 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_molden_cart_copy_L2(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_molden_cart_copy_L2(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -632,11 +623,13 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_x_tmp);
     ALIGNED_FREE(phi_y_tmp);
     ALIGNED_FREE(phi_z_tmp);
-
 }
 
-void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
-
+void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -646,12 +639,12 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 224 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -668,17 +661,17 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 320 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((320 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 320 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((320 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 320 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((320 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 320 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((320 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
 
     // Declare doubles
@@ -696,8 +689,6 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -722,8 +713,8 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
                 S0[i] = 0.0;
                 S1[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -756,7 +747,6 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
                 const double T2 = alpha_n2 * T1;
                 S1[i] += T2;
             }
-
         }
 
         // Combine blocks
@@ -775,7 +765,6 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
             const double xc_pow3 = xc_pow2 * xc[i];
             const double yc_pow3 = yc_pow2 * yc[i];
             const double zc_pow3 = zc_pow2 * zc[i];
-
 
             // Density AM=3 Component=XXX
             phi_tmp[i] = S0[i] * xc_pow3;
@@ -893,7 +882,6 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
             phi_z_tmp[288 + i] = SZ * zc_pow3;
             AZ = 3.0 * zc_pow2;
             phi_z_tmp[288 + i] += S0[i] * AZ;
-
         }
 
         // Copy data back into outer temps
@@ -905,7 +893,7 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_to_spherical_L3(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_to_spherical_L3(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_to_spherical_L3(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -913,7 +901,7 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_gaussian_cart_to_spherical_L3(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_gaussian_cart_to_spherical_L3(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_gaussian_cart_to_spherical_L3(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -921,7 +909,7 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_copy_L3(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_copy_L3(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_copy_L3(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -930,7 +918,6 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_molden_cart_copy_L3(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_molden_cart_copy_L3(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -943,11 +930,13 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_x_tmp);
     ALIGNED_FREE(phi_y_tmp);
     ALIGNED_FREE(phi_z_tmp);
-
 }
 
-void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
-
+void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -957,12 +946,12 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 224 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -979,17 +968,17 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 480 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((480 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 480 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((480 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 480 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((480 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 480 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((480 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
 
     // Declare doubles
@@ -1007,8 +996,6 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -1033,8 +1020,8 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
                 S0[i] = 0.0;
                 S1[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -1067,7 +1054,6 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
                 const double T2 = alpha_n2 * T1;
                 S1[i] += T2;
             }
-
         }
 
         // Combine blocks
@@ -1090,7 +1076,6 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
             const double xc_pow4 = xc_pow3 * xc[i];
             const double yc_pow4 = yc_pow3 * yc[i];
             const double zc_pow4 = zc_pow3 * zc[i];
-
 
             // Density AM=4 Component=XXXX
             phi_tmp[i] = S0[i] * xc_pow4;
@@ -1277,7 +1262,6 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
             phi_z_tmp[448 + i] = SZ * zc_pow4;
             AZ = 4.0 * zc_pow3;
             phi_z_tmp[448 + i] += S0[i] * AZ;
-
         }
 
         // Copy data back into outer temps
@@ -1289,7 +1273,7 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_to_spherical_L4(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_to_spherical_L4(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_to_spherical_L4(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -1297,7 +1281,7 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_gaussian_cart_to_spherical_L4(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_gaussian_cart_to_spherical_L4(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_gaussian_cart_to_spherical_L4(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -1305,7 +1289,7 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_copy_L4(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_copy_L4(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_copy_L4(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -1314,7 +1298,6 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_molden_cart_copy_L4(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_molden_cart_copy_L4(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -1327,11 +1310,13 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_x_tmp);
     ALIGNED_FREE(phi_y_tmp);
     ALIGNED_FREE(phi_z_tmp);
-
 }
 
-void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
-
+void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -1341,12 +1326,12 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 224 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -1363,17 +1348,17 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 672 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((672 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 672 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((672 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 672 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((672 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 672 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((672 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
 
     // Declare doubles
@@ -1391,8 +1376,6 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -1417,8 +1400,8 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
                 S0[i] = 0.0;
                 S1[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -1451,7 +1434,6 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
                 const double T2 = alpha_n2 * T1;
                 S1[i] += T2;
             }
-
         }
 
         // Combine blocks
@@ -1478,7 +1460,6 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
             const double xc_pow5 = xc_pow4 * xc[i];
             const double yc_pow5 = yc_pow4 * yc[i];
             const double zc_pow5 = zc_pow4 * zc[i];
-
 
             // Density AM=5 Component=XXXXX
             phi_tmp[i] = S0[i] * xc_pow5;
@@ -1749,7 +1730,6 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
             phi_z_tmp[640 + i] = SZ * zc_pow5;
             AZ = 5.0 * zc_pow4;
             phi_z_tmp[640 + i] += S0[i] * AZ;
-
         }
 
         // Copy data back into outer temps
@@ -1761,7 +1741,7 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_to_spherical_L5(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_to_spherical_L5(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_to_spherical_L5(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -1769,7 +1749,7 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_gaussian_cart_to_spherical_L5(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_gaussian_cart_to_spherical_L5(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_gaussian_cart_to_spherical_L5(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -1777,7 +1757,7 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_copy_L5(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_copy_L5(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_copy_L5(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -1786,7 +1766,6 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_molden_cart_copy_L5(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_molden_cart_copy_L5(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -1799,11 +1778,13 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_x_tmp);
     ALIGNED_FREE(phi_y_tmp);
     ALIGNED_FREE(phi_z_tmp);
-
 }
 
-void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
-
+void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -1813,12 +1794,12 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 224 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -1835,17 +1816,17 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 896 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((896 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 896 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((896 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 896 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((896 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 896 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((896 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
 
     // Declare doubles
@@ -1863,8 +1844,6 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -1889,8 +1868,8 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
                 S0[i] = 0.0;
                 S1[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -1923,7 +1902,6 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
                 const double T2 = alpha_n2 * T1;
                 S1[i] += T2;
             }
-
         }
 
         // Combine blocks
@@ -1954,7 +1932,6 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
             const double xc_pow6 = xc_pow5 * xc[i];
             const double yc_pow6 = yc_pow5 * yc[i];
             const double zc_pow6 = zc_pow5 * zc[i];
-
 
             // Density AM=6 Component=XXXXXX
             phi_tmp[i] = S0[i] * xc_pow6;
@@ -2324,7 +2301,6 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
             phi_z_tmp[864 + i] = SZ * zc_pow6;
             AZ = 6.0 * zc_pow5;
             phi_z_tmp[864 + i] += S0[i] * AZ;
-
         }
 
         // Copy data back into outer temps
@@ -2336,7 +2312,7 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_to_spherical_L6(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_to_spherical_L6(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_to_spherical_L6(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -2344,7 +2320,7 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_gaussian_cart_to_spherical_L6(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_gaussian_cart_to_spherical_L6(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_gaussian_cart_to_spherical_L6(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -2352,7 +2328,7 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_copy_L6(remain, phi_x_tmp, 32, (phi_x_out + start), npoints);
             gg_cca_cart_copy_L6(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_cca_cart_copy_L6(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -2361,7 +2337,6 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
             gg_molden_cart_copy_L6(remain, phi_y_tmp, 32, (phi_y_out + start), npoints);
             gg_molden_cart_copy_L6(remain, phi_z_tmp, 32, (phi_z_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -2374,5 +2349,1220 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_x_tmp);
     ALIGNED_FREE(phi_y_tmp);
     ALIGNED_FREE(phi_z_tmp);
+}
 
+void gg_collocation_L7_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
+    // Sizing
+    unsigned long nblocks = npoints / 32;
+    nblocks += (npoints % 32) ? 1 : 0;
+    const unsigned long ncart = 36;
+    const unsigned long nspherical = 15;
+    unsigned long nout;
+
+    if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
+        nout = nspherical;
+    } else {
+        nout = ncart;
+    }
+
+    // Allocate S temporaries, single block to stay on cache
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT xc = cache_data + 0;
+    ASSUME_ALIGNED(xc, 64);
+    double* PRAGMA_RESTRICT yc = cache_data + 32;
+    ASSUME_ALIGNED(yc, 64);
+    double* PRAGMA_RESTRICT zc = cache_data + 64;
+    ASSUME_ALIGNED(zc, 64);
+    double* PRAGMA_RESTRICT R2 = cache_data + 96;
+    ASSUME_ALIGNED(R2, 64);
+    double* PRAGMA_RESTRICT S0 = cache_data + 128;
+    ASSUME_ALIGNED(S0, 64);
+    double* PRAGMA_RESTRICT tmp1 = cache_data + 160;
+    ASSUME_ALIGNED(tmp1, 64);
+    double* PRAGMA_RESTRICT S1 = cache_data + 192;
+    ASSUME_ALIGNED(S1, 64);
+
+    // Allocate exponential temporaries
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+
+    // Allocate power temporaries
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(xc_pow, 64);
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(yc_pow, 64);
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(zc_pow, 64);
+
+    // Allocate output temporaries
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((1152 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(phi_tmp, 64);
+
+    // Declare doubles
+    const double center_x = center[0];
+    const double center_y = center[1];
+    const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+
+    // Build negative exponents
+    for (unsigned long i = 0; i < nprim; i++) {
+        expn1[i] = -1.0 * exponents[i];
+        expn2[i] = -2.0 * exponents[i];
+    }
+
+    // Start outer block loop
+    for (unsigned long block = 0; block < nblocks; block++) {
+        // Copy data into inner temps
+        const unsigned long start = block * 32;
+        const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
+
+        // Handle non-AM dependant temps
+        if (xyz_stride == 1) {
+            const double* PRAGMA_RESTRICT x = xyz + start;
+            const double* PRAGMA_RESTRICT y = xyz + npoints + start;
+            const double* PRAGMA_RESTRICT z = xyz + 2 * npoints + start;
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = x[i] - center_x;
+                yc[i] = y[i] - center_y;
+                zc[i] = z[i] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+            }
+        } else {
+            unsigned int start_shift = start * xyz_stride;
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = xyz[start_shift + i * xyz_stride] - center_x;
+                yc[i] = xyz[start_shift + i * xyz_stride + 1] - center_y;
+                zc[i] = xyz[start_shift + i * xyz_stride + 2] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+            }
+        }
+
+        // Start exponential block loop
+        for (unsigned long n = 0; n < nprim; n++) {
+            const double coef = coeffs[n];
+            const double alpha_n1 = expn1[n];
+            const double alpha_n2 = expn2[n];
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                const double width = alpha_n1 * R2[i];
+                const double T1 = coef * exp(width);
+                S0[i] += T1;
+                const double T2 = alpha_n2 * T1;
+                S1[i] += T2;
+            }
+        }
+
+        // Build powers
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            // Cartesian derivs
+            xc_pow[i] = xc[i] * xc[i];
+            yc_pow[i] = yc[i] * yc[i];
+            zc_pow[i] = zc[i] * zc[i];
+            xc_pow[32 + i] = xc_pow[i] * xc[i];
+            yc_pow[32 + i] = yc_pow[i] * yc[i];
+            zc_pow[32 + i] = zc_pow[i] * zc[i];
+            xc_pow[64 + i] = xc_pow[32 + i] * xc[i];
+            yc_pow[64 + i] = yc_pow[32 + i] * yc[i];
+            zc_pow[64 + i] = zc_pow[32 + i] * zc[i];
+            xc_pow[96 + i] = xc_pow[64 + i] * xc[i];
+            yc_pow[96 + i] = yc_pow[64 + i] * yc[i];
+            zc_pow[96 + i] = zc_pow[64 + i] * zc[i];
+            xc_pow[128 + i] = xc_pow[96 + i] * xc[i];
+            yc_pow[128 + i] = yc_pow[96 + i] * yc[i];
+            zc_pow[128 + i] = zc_pow[96 + i] * zc[i];
+            xc_pow[160 + i] = xc_pow[128 + i] * xc[i];
+            yc_pow[160 + i] = yc_pow[128 + i] * yc[i];
+            zc_pow[160 + i] = zc_pow[128 + i] * zc[i];
+        }
+        // Combine A blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            phi_tmp[i] = xc_pow[160 + i] * S0[i];
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * S0[i];
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * S0[i];
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * S0[i];
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * S0[i];
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * S0[i];
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * S0[i];
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[896 + i] = yc_pow[160 + i] * S0[i];
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * S0[i];
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * S0[i];
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[1120 + i] = zc_pow[160 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        }
+
+        // Combine X blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SX;
+            phi_tmp[i] += 7.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SX;
+            phi_tmp[480 + i] += 2.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[640 + i] += 2.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SX;
+            phi_tmp[672 + i] += yc_pow[128 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[864 + i] += zc_pow[128 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SX;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        }
+
+        // Combine Y blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += xc_pow[128 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SY;
+            phi_tmp[672 + i] += 6.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[832 + i] += xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SY;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        }
+
+        // Combine Z blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += xc_pow[128 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[864 + i] += 6.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        }
+    }
+
+    // Free S temporaries
+    ALIGNED_FREE(cache_data);
+    ALIGNED_FREE(expn1);
+    ALIGNED_FREE(expn2);
+
+    // Free Power temporaries
+    ALIGNED_FREE(xc_pow);
+    ALIGNED_FREE(yc_pow);
+    ALIGNED_FREE(zc_pow);
+
+    // Free inner temporaries
+    ALIGNED_FREE(phi_tmp);
+}
+
+void gg_collocation_L8_deriv1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
+    // Sizing
+    unsigned long nblocks = npoints / 32;
+    nblocks += (npoints % 32) ? 1 : 0;
+    const unsigned long ncart = 45;
+    const unsigned long nspherical = 17;
+    unsigned long nout;
+
+    if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
+        nout = nspherical;
+    } else {
+        nout = ncart;
+    }
+
+    // Allocate S temporaries, single block to stay on cache
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT xc = cache_data + 0;
+    ASSUME_ALIGNED(xc, 64);
+    double* PRAGMA_RESTRICT yc = cache_data + 32;
+    ASSUME_ALIGNED(yc, 64);
+    double* PRAGMA_RESTRICT zc = cache_data + 64;
+    ASSUME_ALIGNED(zc, 64);
+    double* PRAGMA_RESTRICT R2 = cache_data + 96;
+    ASSUME_ALIGNED(R2, 64);
+    double* PRAGMA_RESTRICT S0 = cache_data + 128;
+    ASSUME_ALIGNED(S0, 64);
+    double* PRAGMA_RESTRICT tmp1 = cache_data + 160;
+    ASSUME_ALIGNED(tmp1, 64);
+    double* PRAGMA_RESTRICT S1 = cache_data + 192;
+    ASSUME_ALIGNED(S1, 64);
+
+    // Allocate exponential temporaries
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+
+    // Allocate power temporaries
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(xc_pow, 64);
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(yc_pow, 64);
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(zc_pow, 64);
+
+    // Allocate output temporaries
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((1440 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(phi_tmp, 64);
+
+    // Declare doubles
+    const double center_x = center[0];
+    const double center_y = center[1];
+    const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+
+    // Build negative exponents
+    for (unsigned long i = 0; i < nprim; i++) {
+        expn1[i] = -1.0 * exponents[i];
+        expn2[i] = -2.0 * exponents[i];
+    }
+
+    // Start outer block loop
+    for (unsigned long block = 0; block < nblocks; block++) {
+        // Copy data into inner temps
+        const unsigned long start = block * 32;
+        const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
+
+        // Handle non-AM dependant temps
+        if (xyz_stride == 1) {
+            const double* PRAGMA_RESTRICT x = xyz + start;
+            const double* PRAGMA_RESTRICT y = xyz + npoints + start;
+            const double* PRAGMA_RESTRICT z = xyz + 2 * npoints + start;
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = x[i] - center_x;
+                yc[i] = y[i] - center_y;
+                zc[i] = z[i] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+            }
+        } else {
+            unsigned int start_shift = start * xyz_stride;
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = xyz[start_shift + i * xyz_stride] - center_x;
+                yc[i] = xyz[start_shift + i * xyz_stride + 1] - center_y;
+                zc[i] = xyz[start_shift + i * xyz_stride + 2] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+            }
+        }
+
+        // Start exponential block loop
+        for (unsigned long n = 0; n < nprim; n++) {
+            const double coef = coeffs[n];
+            const double alpha_n1 = expn1[n];
+            const double alpha_n2 = expn2[n];
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                const double width = alpha_n1 * R2[i];
+                const double T1 = coef * exp(width);
+                S0[i] += T1;
+                const double T2 = alpha_n2 * T1;
+                S1[i] += T2;
+            }
+        }
+
+        // Build powers
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            // Cartesian derivs
+            xc_pow[i] = xc[i] * xc[i];
+            yc_pow[i] = yc[i] * yc[i];
+            zc_pow[i] = zc[i] * zc[i];
+            xc_pow[32 + i] = xc_pow[i] * xc[i];
+            yc_pow[32 + i] = yc_pow[i] * yc[i];
+            zc_pow[32 + i] = zc_pow[i] * zc[i];
+            xc_pow[64 + i] = xc_pow[32 + i] * xc[i];
+            yc_pow[64 + i] = yc_pow[32 + i] * yc[i];
+            zc_pow[64 + i] = zc_pow[32 + i] * zc[i];
+            xc_pow[96 + i] = xc_pow[64 + i] * xc[i];
+            yc_pow[96 + i] = yc_pow[64 + i] * yc[i];
+            zc_pow[96 + i] = zc_pow[64 + i] * zc[i];
+            xc_pow[128 + i] = xc_pow[96 + i] * xc[i];
+            yc_pow[128 + i] = yc_pow[96 + i] * yc[i];
+            zc_pow[128 + i] = zc_pow[96 + i] * zc[i];
+            xc_pow[160 + i] = xc_pow[128 + i] * xc[i];
+            yc_pow[160 + i] = yc_pow[128 + i] * yc[i];
+            zc_pow[160 + i] = zc_pow[128 + i] * zc[i];
+            xc_pow[192 + i] = xc_pow[160 + i] * xc[i];
+            yc_pow[192 + i] = yc_pow[160 + i] * yc[i];
+            zc_pow[192 + i] = zc_pow[160 + i] * zc[i];
+        }
+        // Combine A blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            phi_tmp[i] = xc_pow[192 + i] * S0[i];
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * S0[i];
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * S0[i];
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * S0[i];
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * S0[i];
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * S0[i];
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * S0[i];
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * S0[i];
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * S0[i];
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * S0[i];
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * S0[i];
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * S0[i];
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * S0[i];
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * S0[i];
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * S0[i];
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * S0[i];
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * S0[i];
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * S0[i];
+            phi_tmp[1152 + i] = yc_pow[192 + i] * S0[i];
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * S0[i];
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * S0[i];
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * S0[i];
+            phi_tmp[1408 + i] = zc_pow[192 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        }
+
+        // Combine X blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SX;
+            phi_tmp[i] += 8.0 * xc_pow[160 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SX;
+            phi_tmp[480 + i] += 3.0 * xc_pow[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SX;
+            phi_tmp[640 + i] += 3.0 * xc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SX;
+            phi_tmp[672 + i] += 2.0 * xc[i] * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SX;
+            phi_tmp[864 + i] += 2.0 * xc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SX;
+            phi_tmp[896 + i] += yc_pow[160 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[928 + i] += yc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[960 + i] += yc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[992 + i] += yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[1024 + i] += yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[1056 + i] += yc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[1088 + i] += yc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SX;
+            phi_tmp[1120 + i] += zc_pow[160 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SX;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        }
+
+        // Combine Y blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += xc_pow[160 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[96 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += xc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SY;
+            phi_tmp[672 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[832 + i] += xc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SY;
+            phi_tmp[896 + i] += 7.0 * xc[i] * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1088 + i] += xc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SY;
+            phi_tmp[1152 + i] += 8.0 * yc_pow[160 + i] * S0[i];
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SY;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SY;
+            phi_tmp[1216 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1248 + i] += 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SY;
+            phi_tmp[1312 + i] += 3.0 * yc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1344 + i] += 2.0 * yc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SY;
+            phi_tmp[1376 + i] += zc_pow[160 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        }
+
+        // Combine Z blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += xc_pow[160 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += xc_pow[96 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += xc_pow[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[864 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += xc[i] * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SZ;
+            phi_tmp[1120 + i] += 7.0 * xc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SZ;
+            phi_tmp[1184 + i] += yc_pow[160 + i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1248 + i] += 3.0 * yc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1312 + i] += 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1344 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SZ;
+            phi_tmp[1376 + i] += 7.0 * yc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SZ;
+            phi_tmp[1408 + i] += 8.0 * zc_pow[160 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        }
+    }
+
+    // Free S temporaries
+    ALIGNED_FREE(cache_data);
+    ALIGNED_FREE(expn1);
+    ALIGNED_FREE(expn2);
+
+    // Free Power temporaries
+    ALIGNED_FREE(xc_pow);
+    ALIGNED_FREE(yc_pow);
+    ALIGNED_FREE(zc_pow);
+
+    // Free inner temporaries
+    ALIGNED_FREE(phi_tmp);
 }

--- a/external/gau2grid/generated_source/gau2grid_deriv1.c
+++ b/external/gau2grid/generated_source/gau2grid_deriv1.c
@@ -73,9 +73,11 @@ void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -127,7 +129,7 @@ void gg_collocation_L0_deriv1(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -223,9 +225,11 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -277,7 +281,7 @@ void gg_collocation_L1_deriv1(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -433,7 +437,7 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
     double AX, AY, AZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -485,7 +489,7 @@ void gg_collocation_L2_deriv1(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -682,7 +686,7 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
     double AX, AY, AZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -734,7 +738,7 @@ void gg_collocation_L3_deriv1(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -989,7 +993,7 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
     double AX, AY, AZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -1041,7 +1045,7 @@ void gg_collocation_L4_deriv1(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -1369,7 +1373,7 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
     double AX, AY, AZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -1421,7 +1425,7 @@ void gg_collocation_L5_deriv1(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -1837,7 +1841,7 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
     double AX, AY, AZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -1889,7 +1893,7 @@ void gg_collocation_L6_deriv1(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];

--- a/external/gau2grid/generated_source/gau2grid_deriv2.c
+++ b/external/gau2grid/generated_source/gau2grid_deriv2.c
@@ -20,10 +20,14 @@
 #include "gau2grid/gau2grid_utility.h"
 #include "gau2grid/gau2grid_pragma.h"
 
-
-
-void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
-
+void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -33,12 +37,12 @@ void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 256 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((256 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -57,29 +61,29 @@ void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S2, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xx_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xx_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xx_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xy_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xy_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yy_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yy_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_zz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_zz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_zz_tmp, 64);
 
     // Declare doubles
@@ -95,8 +99,6 @@ void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -122,8 +124,8 @@ void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_
                 S1[i] = 0.0;
                 S2[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -159,7 +161,6 @@ void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_
                 const double T3 = alpha_n2 * T2;
                 S2[i] += T3;
             }
-
         }
 
         // Combine blocks
@@ -210,11 +211,16 @@ void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_yy_tmp);
     ALIGNED_FREE(phi_yz_tmp);
     ALIGNED_FREE(phi_zz_tmp);
-
 }
 
-void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
-
+void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -224,12 +230,12 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 256 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((256 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -248,29 +254,29 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S2, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xx_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xx_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xx_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xy_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xy_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yy_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yy_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_zz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_zz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_zz_tmp, 64);
 
     // Declare doubles
@@ -286,8 +292,6 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -313,8 +317,8 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
                 S1[i] = 0.0;
                 S2[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -350,7 +354,6 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
                 const double T3 = alpha_n2 * T2;
                 S2[i] += T3;
             }
-
         }
 
         // Combine blocks
@@ -431,7 +434,6 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_xz_tmp[64 + i] += SX;
             phi_yz_tmp[64 + i] = SYZ * zc[i];
             phi_yz_tmp[64 + i] += SY;
-
         }
 
         // Copy data back into outer temps
@@ -451,7 +453,7 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_to_spherical_L1(remain, phi_yy_tmp, 32, (phi_yy_out + start), npoints);
             gg_cca_cart_to_spherical_L1(remain, phi_yz_tmp, 32, (phi_yz_out + start), npoints);
             gg_cca_cart_to_spherical_L1(remain, phi_zz_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -467,7 +469,7 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
             gg_gaussian_cart_to_spherical_L1(remain, phi_yy_tmp, 32, (phi_yy_out + start), npoints);
             gg_gaussian_cart_to_spherical_L1(remain, phi_yz_tmp, 32, (phi_yz_out + start), npoints);
             gg_gaussian_cart_to_spherical_L1(remain, phi_zz_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -483,7 +485,7 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_copy_L1(remain, phi_yy_tmp, 32, (phi_yy_out + start), npoints);
             gg_cca_cart_copy_L1(remain, phi_yz_tmp, 32, (phi_yz_out + start), npoints);
             gg_cca_cart_copy_L1(remain, phi_zz_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -500,7 +502,6 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
             gg_molden_cart_copy_L1(remain, phi_yz_tmp, 32, (phi_yz_out + start), npoints);
             gg_molden_cart_copy_L1(remain, phi_zz_tmp, 32, (phi_zz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -519,11 +520,16 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_yy_tmp);
     ALIGNED_FREE(phi_yz_tmp);
     ALIGNED_FREE(phi_zz_tmp);
-
 }
 
-void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
-
+void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -533,12 +539,12 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 256 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((256 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -557,29 +563,29 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S2, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xx_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xx_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xx_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xy_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xy_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xz_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xz_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yy_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yy_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yz_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yz_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_zz_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_zz_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_zz_tmp, 64);
 
     // Declare doubles
@@ -597,8 +603,6 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -624,8 +628,8 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
                 S1[i] = 0.0;
                 S2[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -661,7 +665,6 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
                 const double T3 = alpha_n2 * T2;
                 S2[i] += T3;
             }
-
         }
 
         // Combine blocks
@@ -684,7 +687,6 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
             const double zc_pow2 = zc[i] * zc[i];
-
 
             // Density AM=2 Component=XX
             phi_tmp[i] = S0[i] * xc_pow2;
@@ -838,7 +840,6 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_xz_tmp[160 + i] += SX * AZ;
             phi_yz_tmp[160 + i] = SYZ * zc_pow2;
             phi_yz_tmp[160 + i] += SY * AZ;
-
         }
 
         // Copy data back into outer temps
@@ -858,7 +859,7 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_to_spherical_L2(remain, phi_yy_tmp, 32, (phi_yy_out + start), npoints);
             gg_cca_cart_to_spherical_L2(remain, phi_yz_tmp, 32, (phi_yz_out + start), npoints);
             gg_cca_cart_to_spherical_L2(remain, phi_zz_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -874,7 +875,7 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
             gg_gaussian_cart_to_spherical_L2(remain, phi_yy_tmp, 32, (phi_yy_out + start), npoints);
             gg_gaussian_cart_to_spherical_L2(remain, phi_yz_tmp, 32, (phi_yz_out + start), npoints);
             gg_gaussian_cart_to_spherical_L2(remain, phi_zz_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -890,7 +891,7 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_copy_L2(remain, phi_yy_tmp, 32, (phi_yy_out + start), npoints);
             gg_cca_cart_copy_L2(remain, phi_yz_tmp, 32, (phi_yz_out + start), npoints);
             gg_cca_cart_copy_L2(remain, phi_zz_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -907,7 +908,6 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
             gg_molden_cart_copy_L2(remain, phi_yz_tmp, 32, (phi_yz_out + start), npoints);
             gg_molden_cart_copy_L2(remain, phi_zz_tmp, 32, (phi_zz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -926,11 +926,16 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_yy_tmp);
     ALIGNED_FREE(phi_yz_tmp);
     ALIGNED_FREE(phi_zz_tmp);
-
 }
 
-void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
-
+void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -940,12 +945,12 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 256 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((256 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -964,19 +969,19 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S2, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate power temporaries
-    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, 64 * sizeof(double));
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((64 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(xc_pow, 64);
-    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, 64 * sizeof(double));
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((64 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(yc_pow, 64);
-    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, 64 * sizeof(double));
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((64 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(zc_pow, 64);
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 320 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((320 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -992,8 +997,6 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -1019,8 +1022,8 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
                 S1[i] = 0.0;
                 S2[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -1056,13 +1059,11 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
                 const double T3 = alpha_n2 * T2;
                 S2[i] += T3;
             }
-
         }
 
         // Build powers
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             xc_pow[i] = xc[i] * xc[i];
             yc_pow[i] = yc[i] * yc[i];
@@ -1074,7 +1075,6 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
         // Combine A blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             phi_tmp[i] = xc_pow[32 + i] * S0[i];
             phi_tmp[32 + i] = xc_pow[i] * yc[i] * S0[i];
             phi_tmp[64 + i] = xc_pow[i] * zc[i] * S0[i];
@@ -1089,11 +1089,11 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
 
@@ -1127,16 +1127,15 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] = yc[i] * zc_pow[i] * SX;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_x_out + start), npoints);
         }
 
@@ -1170,16 +1169,15 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] += zc_pow[i] * S0[i];
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_y_out + start), npoints);
         }
 
@@ -1213,16 +1211,15 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SZ;
             phi_tmp[288 + i] += 3.0 * zc_pow[i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_z_out + start), npoints);
         }
 
@@ -1260,16 +1257,15 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] = yc[i] * zc_pow[i] * SXX;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
         }
 
@@ -1314,16 +1310,15 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] += zc_pow[i] * SX;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
         }
 
@@ -1368,16 +1363,15 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SXZ;
             phi_tmp[288 + i] += 3.0 * zc_pow[i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
         }
 
@@ -1415,16 +1409,15 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] += 2.0 * zc_pow[i] * SY;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
         }
 
@@ -1469,16 +1462,15 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SYZ;
             phi_tmp[288 + i] += 3.0 * zc_pow[i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
         }
 
@@ -1516,19 +1508,17 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[288 + i] = zc_pow[32 + i] * SZZ;
             phi_tmp[288 + i] += 6.0 * zc_pow[i] * SZ;
             phi_tmp[288 + i] += 6.0 * zc[i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -1543,11 +1533,16 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
-
+void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -1557,12 +1552,12 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 256 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((256 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -1581,19 +1576,19 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S2, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate power temporaries
-    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(xc_pow, 64);
-    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(yc_pow, 64);
-    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(zc_pow, 64);
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 480 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((480 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -1609,8 +1604,6 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -1636,8 +1629,8 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
                 S1[i] = 0.0;
                 S2[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -1673,13 +1666,11 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
                 const double T3 = alpha_n2 * T2;
                 S2[i] += T3;
             }
-
         }
 
         // Build powers
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             xc_pow[i] = xc[i] * xc[i];
             yc_pow[i] = yc[i] * yc[i];
@@ -1694,7 +1685,6 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
         // Combine A blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             phi_tmp[i] = xc_pow[64 + i] * S0[i];
             phi_tmp[32 + i] = xc_pow[32 + i] * yc[i] * S0[i];
             phi_tmp[64 + i] = xc_pow[32 + i] * zc[i] * S0[i];
@@ -1714,11 +1704,11 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
 
@@ -1766,16 +1756,15 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] = yc[i] * zc_pow[32 + i] * SX;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_x_out + start), npoints);
         }
 
@@ -1823,16 +1812,15 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] += zc_pow[32 + i] * S0[i];
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_y_out + start), npoints);
         }
 
@@ -1880,16 +1868,15 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SZ;
             phi_tmp[448 + i] += 4.0 * zc_pow[32 + i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_z_out + start), npoints);
         }
 
@@ -1944,16 +1931,15 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] = yc[i] * zc_pow[32 + i] * SXX;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
         }
 
@@ -2019,16 +2005,15 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] += zc_pow[32 + i] * SX;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
         }
 
@@ -2094,16 +2079,15 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SXZ;
             phi_tmp[448 + i] += 4.0 * zc_pow[32 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
         }
 
@@ -2158,16 +2142,15 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] += 2.0 * zc_pow[32 + i] * SY;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
         }
 
@@ -2233,16 +2216,15 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SYZ;
             phi_tmp[448 + i] += 4.0 * zc_pow[32 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
         }
 
@@ -2297,19 +2279,17 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[448 + i] = zc_pow[64 + i] * SZZ;
             phi_tmp[448 + i] += 8.0 * zc_pow[32 + i] * SZ;
             phi_tmp[448 + i] += 12.0 * zc_pow[i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -2324,11 +2304,16 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
-
+void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -2338,12 +2323,12 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 256 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((256 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -2362,19 +2347,19 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S2, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate power temporaries
-    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, 128 * sizeof(double));
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((128 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(xc_pow, 64);
-    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, 128 * sizeof(double));
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((128 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(yc_pow, 64);
-    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, 128 * sizeof(double));
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((128 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(zc_pow, 64);
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 672 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((672 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -2390,8 +2375,6 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -2417,8 +2400,8 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
                 S1[i] = 0.0;
                 S2[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -2454,13 +2437,11 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
                 const double T3 = alpha_n2 * T2;
                 S2[i] += T3;
             }
-
         }
 
         // Build powers
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             xc_pow[i] = xc[i] * xc[i];
             yc_pow[i] = yc[i] * yc[i];
@@ -2478,7 +2459,6 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
         // Combine A blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             phi_tmp[i] = xc_pow[96 + i] * S0[i];
             phi_tmp[32 + i] = xc_pow[64 + i] * yc[i] * S0[i];
             phi_tmp[64 + i] = xc_pow[64 + i] * zc[i] * S0[i];
@@ -2504,11 +2484,11 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
 
@@ -2573,16 +2553,15 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] = yc[i] * zc_pow[64 + i] * SX;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_x_out + start), npoints);
         }
 
@@ -2647,16 +2626,15 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] += zc_pow[64 + i] * S0[i];
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_y_out + start), npoints);
         }
 
@@ -2721,16 +2699,15 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SZ;
             phi_tmp[640 + i] += 5.0 * zc_pow[64 + i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_z_out + start), npoints);
         }
 
@@ -2806,16 +2783,15 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] = yc[i] * zc_pow[64 + i] * SXX;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
         }
 
@@ -2907,16 +2883,15 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] += zc_pow[64 + i] * SX;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
         }
 
@@ -3008,16 +2983,15 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SXZ;
             phi_tmp[640 + i] += 5.0 * zc_pow[64 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
         }
 
@@ -3093,16 +3067,15 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] += 2.0 * zc_pow[64 + i] * SY;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
         }
 
@@ -3194,16 +3167,15 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SYZ;
             phi_tmp[640 + i] += 5.0 * zc_pow[64 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
         }
 
@@ -3279,19 +3251,17 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[640 + i] = zc_pow[96 + i] * SZZ;
             phi_tmp[640 + i] += 10.0 * zc_pow[64 + i] * SZ;
             phi_tmp[640 + i] += 20.0 * zc_pow[32 + i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -3306,11 +3276,16 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
-
+void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -3320,12 +3295,12 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 256 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((256 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -3344,19 +3319,19 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S2, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate power temporaries
-    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, 160 * sizeof(double));
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((160 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(xc_pow, 64);
-    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, 160 * sizeof(double));
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((160 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(yc_pow, 64);
-    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, 160 * sizeof(double));
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((160 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(zc_pow, 64);
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 896 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((896 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -3372,8 +3347,6 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -3399,8 +3372,8 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
                 S1[i] = 0.0;
                 S2[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -3436,13 +3409,11 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
                 const double T3 = alpha_n2 * T2;
                 S2[i] += T3;
             }
-
         }
 
         // Build powers
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             xc_pow[i] = xc[i] * xc[i];
             yc_pow[i] = yc[i] * yc[i];
@@ -3463,7 +3434,6 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
         // Combine A blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             phi_tmp[i] = xc_pow[128 + i] * S0[i];
             phi_tmp[32 + i] = xc_pow[96 + i] * yc[i] * S0[i];
             phi_tmp[64 + i] = xc_pow[96 + i] * zc[i] * S0[i];
@@ -3496,11 +3466,11 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
 
@@ -3585,16 +3555,15 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] = yc[i] * zc_pow[96 + i] * SX;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_x_out + start), npoints);
         }
 
@@ -3679,16 +3648,15 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] += zc_pow[96 + i] * S0[i];
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_y_out + start), npoints);
         }
 
@@ -3773,16 +3741,15 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SZ;
             phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_z_out + start), npoints);
         }
 
@@ -3883,16 +3850,15 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] = yc[i] * zc_pow[96 + i] * SXX;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
         }
 
@@ -4015,16 +3981,15 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] += zc_pow[96 + i] * SX;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
         }
 
@@ -4147,16 +4112,15 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SXZ;
             phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
         }
 
@@ -4257,16 +4221,15 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] += 2.0 * zc_pow[96 + i] * SY;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
         }
 
@@ -4389,16 +4352,15 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SYZ;
             phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
         }
 
@@ -4499,19 +4461,17 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[864 + i] = zc_pow[128 + i] * SZZ;
             phi_tmp[864 + i] += 12.0 * zc_pow[96 + i] * SZ;
             phi_tmp[864 + i] += 30.0 * zc_pow[64 + i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -4526,5 +4486,3292 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
+}
 
+void gg_collocation_L7_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
+    // Sizing
+    unsigned long nblocks = npoints / 32;
+    nblocks += (npoints % 32) ? 1 : 0;
+    const unsigned long ncart = 36;
+    const unsigned long nspherical = 15;
+    unsigned long nout;
+
+    if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
+        nout = nspherical;
+    } else {
+        nout = ncart;
+    }
+
+    // Allocate S temporaries, single block to stay on cache
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((256 * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT xc = cache_data + 0;
+    ASSUME_ALIGNED(xc, 64);
+    double* PRAGMA_RESTRICT yc = cache_data + 32;
+    ASSUME_ALIGNED(yc, 64);
+    double* PRAGMA_RESTRICT zc = cache_data + 64;
+    ASSUME_ALIGNED(zc, 64);
+    double* PRAGMA_RESTRICT R2 = cache_data + 96;
+    ASSUME_ALIGNED(R2, 64);
+    double* PRAGMA_RESTRICT S0 = cache_data + 128;
+    ASSUME_ALIGNED(S0, 64);
+    double* PRAGMA_RESTRICT tmp1 = cache_data + 160;
+    ASSUME_ALIGNED(tmp1, 64);
+    double* PRAGMA_RESTRICT S1 = cache_data + 192;
+    ASSUME_ALIGNED(S1, 64);
+    double* PRAGMA_RESTRICT S2 = cache_data + 224;
+    ASSUME_ALIGNED(S2, 64);
+
+    // Allocate exponential temporaries
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+
+    // Allocate power temporaries
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(xc_pow, 64);
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(yc_pow, 64);
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(zc_pow, 64);
+
+    // Allocate output temporaries
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((1152 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(phi_tmp, 64);
+
+    // Declare doubles
+    const double center_x = center[0];
+    const double center_y = center[1];
+    const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
+
+    // Build negative exponents
+    for (unsigned long i = 0; i < nprim; i++) {
+        expn1[i] = -1.0 * exponents[i];
+        expn2[i] = -2.0 * exponents[i];
+    }
+
+    // Start outer block loop
+    for (unsigned long block = 0; block < nblocks; block++) {
+        // Copy data into inner temps
+        const unsigned long start = block * 32;
+        const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
+
+        // Handle non-AM dependant temps
+        if (xyz_stride == 1) {
+            const double* PRAGMA_RESTRICT x = xyz + start;
+            const double* PRAGMA_RESTRICT y = xyz + npoints + start;
+            const double* PRAGMA_RESTRICT z = xyz + 2 * npoints + start;
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = x[i] - center_x;
+                yc[i] = y[i] - center_y;
+                zc[i] = z[i] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+                S2[i] = 0.0;
+            }
+        } else {
+            unsigned int start_shift = start * xyz_stride;
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = xyz[start_shift + i * xyz_stride] - center_x;
+                yc[i] = xyz[start_shift + i * xyz_stride + 1] - center_y;
+                zc[i] = xyz[start_shift + i * xyz_stride + 2] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+                S2[i] = 0.0;
+            }
+        }
+
+        // Start exponential block loop
+        for (unsigned long n = 0; n < nprim; n++) {
+            const double coef = coeffs[n];
+            const double alpha_n1 = expn1[n];
+            const double alpha_n2 = expn2[n];
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                const double width = alpha_n1 * R2[i];
+                const double T1 = coef * exp(width);
+                S0[i] += T1;
+                const double T2 = alpha_n2 * T1;
+                S1[i] += T2;
+                const double T3 = alpha_n2 * T2;
+                S2[i] += T3;
+            }
+        }
+
+        // Build powers
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            // Cartesian derivs
+            xc_pow[i] = xc[i] * xc[i];
+            yc_pow[i] = yc[i] * yc[i];
+            zc_pow[i] = zc[i] * zc[i];
+            xc_pow[32 + i] = xc_pow[i] * xc[i];
+            yc_pow[32 + i] = yc_pow[i] * yc[i];
+            zc_pow[32 + i] = zc_pow[i] * zc[i];
+            xc_pow[64 + i] = xc_pow[32 + i] * xc[i];
+            yc_pow[64 + i] = yc_pow[32 + i] * yc[i];
+            zc_pow[64 + i] = zc_pow[32 + i] * zc[i];
+            xc_pow[96 + i] = xc_pow[64 + i] * xc[i];
+            yc_pow[96 + i] = yc_pow[64 + i] * yc[i];
+            zc_pow[96 + i] = zc_pow[64 + i] * zc[i];
+            xc_pow[128 + i] = xc_pow[96 + i] * xc[i];
+            yc_pow[128 + i] = yc_pow[96 + i] * yc[i];
+            zc_pow[128 + i] = zc_pow[96 + i] * zc[i];
+            xc_pow[160 + i] = xc_pow[128 + i] * xc[i];
+            yc_pow[160 + i] = yc_pow[128 + i] * yc[i];
+            zc_pow[160 + i] = zc_pow[128 + i] * zc[i];
+        }
+        // Combine A blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            phi_tmp[i] = xc_pow[160 + i] * S0[i];
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * S0[i];
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * S0[i];
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * S0[i];
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * S0[i];
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * S0[i];
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * S0[i];
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[896 + i] = yc_pow[160 + i] * S0[i];
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * S0[i];
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * S0[i];
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[1120 + i] = zc_pow[160 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        }
+
+        // Combine X blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SX;
+            phi_tmp[i] += 7.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SX;
+            phi_tmp[480 + i] += 2.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[640 + i] += 2.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SX;
+            phi_tmp[672 + i] += yc_pow[128 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[864 + i] += zc_pow[128 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SX;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        }
+
+        // Combine Y blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += xc_pow[128 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SY;
+            phi_tmp[672 + i] += 6.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[832 + i] += xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SY;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        }
+
+        // Combine Z blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += xc_pow[128 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[864 + i] += 6.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        }
+
+        // Combine XX blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SXX = S2[i] * xc[i] * xc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXX;
+            phi_tmp[i] += 14.0 * xc_pow[128 + i] * SX;
+            phi_tmp[i] += 42.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXX;
+            phi_tmp[32 + i] += 12.0 * xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 30.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXX;
+            phi_tmp[64 + i] += 12.0 * xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 30.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXX;
+            phi_tmp[96 + i] += 10.0 * xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 20.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXX;
+            phi_tmp[128 + i] += 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 20.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXX;
+            phi_tmp[160 + i] += 10.0 * xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 20.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXX;
+            phi_tmp[192 + i] += 8.0 * xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXX;
+            phi_tmp[224 + i] += 8.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXX;
+            phi_tmp[256 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[288 + i] += 8.0 * xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 12.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXX;
+            phi_tmp[320 + i] += 6.0 * xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 6.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXX;
+            phi_tmp[352 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXX;
+            phi_tmp[384 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[416 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 6.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXX;
+            phi_tmp[448 + i] += 6.0 * xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 6.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXX;
+            phi_tmp[480 + i] += 4.0 * xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[480 + i] += 2.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXX;
+            phi_tmp[512 + i] += 4.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 2.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXX;
+            phi_tmp[544 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 2.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[576 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 2.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[608 + i] += 4.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 2.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[640 + i] += 4.0 * xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[640 + i] += 2.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXX;
+            phi_tmp[672 + i] += 2.0 * yc_pow[128 + i] * SX;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXX;
+            phi_tmp[704 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXX;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[768 + i] += 2.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[800 + i] += 2.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[832 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXX;
+            phi_tmp[864 + i] += 2.0 * zc_pow[128 + i] * SX;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXX;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        }
+
+        // Combine XY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SY = S1[i] * yc[i];
+            const double SXY = S2[i] * xc[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXY;
+            phi_tmp[i] += 7.0 * xc_pow[128 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXY;
+            phi_tmp[32 + i] += xc_pow[128 + i] * SX;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[96 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 10.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXY;
+            phi_tmp[128 + i] += xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[160 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[192 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXY;
+            phi_tmp[256 + i] += xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[288 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[320 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[416 + i] += xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[448 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[480 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 10.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 4.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[608 + i] += xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += 2.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[640 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXY;
+            phi_tmp[672 + i] += 6.0 * xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[672 + i] += yc_pow[128 + i] * SY;
+            phi_tmp[672 + i] += 6.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 5.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 4.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 3.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[832 + i] += xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[832 + i] += zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[864 + i] += zc_pow[128 + i] * SY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXY;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * SX;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * SX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        }
+
+        // Combine XZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SXZ = S2[i] * xc[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXZ;
+            phi_tmp[i] += 7.0 * xc_pow[128 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXZ;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[64 + i] += xc_pow[128 + i] * SX;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXZ;
+            phi_tmp[96 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[160 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 10.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXZ;
+            phi_tmp[192 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXZ;
+            phi_tmp[224 + i] += xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[288 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 12.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXZ;
+            phi_tmp[320 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXZ;
+            phi_tmp[352 + i] += xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[384 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 9.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[448 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 12.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXZ;
+            phi_tmp[480 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXZ;
+            phi_tmp[512 + i] += xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[544 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[576 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[608 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 8.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[640 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 10.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXZ;
+            phi_tmp[672 + i] += yc_pow[128 + i] * SZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[704 + i] += xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[704 + i] += yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += yc_pow[96 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[736 + i] += yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[768 + i] += yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 3.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[800 + i] += yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 4.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[832 + i] += yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[864 + i] += 6.0 * xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[864 + i] += zc_pow[128 + i] * SZ;
+            phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * SX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        }
+
+        // Combine YY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SYY = S2[i] * yc[i] * yc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SYY;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SYY;
+            phi_tmp[32 + i] += 2.0 * xc_pow[128 + i] * SY;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SYY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SYY;
+            phi_tmp[96 + i] += 4.0 * xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SYY;
+            phi_tmp[128 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SYY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SYY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SYY;
+            phi_tmp[224 + i] += 4.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SYY;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SYY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SYY;
+            phi_tmp[320 + i] += 8.0 * xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[320 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYY;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[416 + i] += 2.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SYY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SYY;
+            phi_tmp[480 + i] += 10.0 * xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[480 + i] += 20.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SYY;
+            phi_tmp[512 + i] += 8.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[576 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[608 + i] += 2.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SYY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SYY;
+            phi_tmp[672 + i] += 12.0 * xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[672 + i] += 30.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SYY;
+            phi_tmp[704 + i] += 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 20.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SYY;
+            phi_tmp[736 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[832 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SYY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SYY;
+            phi_tmp[896 + i] += 14.0 * yc_pow[128 + i] * SY;
+            phi_tmp[896 + i] += 42.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SYY;
+            phi_tmp[928 + i] += 12.0 * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 30.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SYY;
+            phi_tmp[960 + i] += 10.0 * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 20.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[992 + i] += 8.0 * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 12.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1024 + i] += 6.0 * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 6.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1056 + i] += 4.0 * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SYY;
+            phi_tmp[1088 + i] += 2.0 * zc_pow[128 + i] * SY;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SYY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        }
+
+        // Combine YZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SYZ = S2[i] * yc[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SYZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SYZ;
+            phi_tmp[32 + i] += xc_pow[128 + i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[64 + i] += xc_pow[128 + i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SYZ;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SYZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SYZ;
+            phi_tmp[192 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SYZ;
+            phi_tmp[224 + i] += xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SYZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[256 + i] += xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SYZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYZ;
+            phi_tmp[352 + i] += xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[416 + i] += xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SYZ;
+            phi_tmp[480 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SYZ;
+            phi_tmp[512 + i] += xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[608 + i] += xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SYZ;
+            phi_tmp[672 + i] += 6.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[704 + i] += xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 9.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 8.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[832 + i] += xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[864 + i] += 6.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SYZ;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * SZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * SY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 10.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 12.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 12.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 10.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SYZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        }
+
+        // Combine ZZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+            const double SZZ = S2[i] * zc[i] * zc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SZZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SZZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[64 + i] += 2.0 * xc_pow[128 + i] * SZ;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SZZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SZZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[160 + i] += 4.0 * xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SZZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SZZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SZZ;
+            phi_tmp[256 + i] += 4.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SZZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZZ;
+            phi_tmp[352 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[448 + i] += 8.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[448 + i] += 12.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SZZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SZZ;
+            phi_tmp[512 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZZ;
+            phi_tmp[544 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[608 + i] += 8.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[640 + i] += 10.0 * xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[640 + i] += 20.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SZZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[800 + i] += 8.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[800 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[832 + i] += 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[832 + i] += 20.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[864 + i] += 12.0 * xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[864 + i] += 30.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SZZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[928 + i] += 2.0 * yc_pow[128 + i] * SZ;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[960 + i] += 4.0 * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[992 + i] += 6.0 * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[992 + i] += 6.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1024 + i] += 8.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1024 + i] += 12.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1056 + i] += 10.0 * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1056 + i] += 20.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[1088 + i] += 12.0 * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1088 + i] += 30.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SZZ;
+            phi_tmp[1120 + i] += 14.0 * zc_pow[128 + i] * SZ;
+            phi_tmp[1120 + i] += 42.0 * zc_pow[96 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        }
+    }
+
+    // Free S temporaries
+    ALIGNED_FREE(cache_data);
+    ALIGNED_FREE(expn1);
+    ALIGNED_FREE(expn2);
+
+    // Free Power temporaries
+    ALIGNED_FREE(xc_pow);
+    ALIGNED_FREE(yc_pow);
+    ALIGNED_FREE(zc_pow);
+
+    // Free inner temporaries
+    ALIGNED_FREE(phi_tmp);
+}
+
+void gg_collocation_L8_deriv2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                              const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                              const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                              const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                              double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                              double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                              double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                              double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
+    // Sizing
+    unsigned long nblocks = npoints / 32;
+    nblocks += (npoints % 32) ? 1 : 0;
+    const unsigned long ncart = 45;
+    const unsigned long nspherical = 17;
+    unsigned long nout;
+
+    if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
+        nout = nspherical;
+    } else {
+        nout = ncart;
+    }
+
+    // Allocate S temporaries, single block to stay on cache
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((256 * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT xc = cache_data + 0;
+    ASSUME_ALIGNED(xc, 64);
+    double* PRAGMA_RESTRICT yc = cache_data + 32;
+    ASSUME_ALIGNED(yc, 64);
+    double* PRAGMA_RESTRICT zc = cache_data + 64;
+    ASSUME_ALIGNED(zc, 64);
+    double* PRAGMA_RESTRICT R2 = cache_data + 96;
+    ASSUME_ALIGNED(R2, 64);
+    double* PRAGMA_RESTRICT S0 = cache_data + 128;
+    ASSUME_ALIGNED(S0, 64);
+    double* PRAGMA_RESTRICT tmp1 = cache_data + 160;
+    ASSUME_ALIGNED(tmp1, 64);
+    double* PRAGMA_RESTRICT S1 = cache_data + 192;
+    ASSUME_ALIGNED(S1, 64);
+    double* PRAGMA_RESTRICT S2 = cache_data + 224;
+    ASSUME_ALIGNED(S2, 64);
+
+    // Allocate exponential temporaries
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+
+    // Allocate power temporaries
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(xc_pow, 64);
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(yc_pow, 64);
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(zc_pow, 64);
+
+    // Allocate output temporaries
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((1440 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(phi_tmp, 64);
+
+    // Declare doubles
+    const double center_x = center[0];
+    const double center_y = center[1];
+    const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
+
+    // Build negative exponents
+    for (unsigned long i = 0; i < nprim; i++) {
+        expn1[i] = -1.0 * exponents[i];
+        expn2[i] = -2.0 * exponents[i];
+    }
+
+    // Start outer block loop
+    for (unsigned long block = 0; block < nblocks; block++) {
+        // Copy data into inner temps
+        const unsigned long start = block * 32;
+        const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
+
+        // Handle non-AM dependant temps
+        if (xyz_stride == 1) {
+            const double* PRAGMA_RESTRICT x = xyz + start;
+            const double* PRAGMA_RESTRICT y = xyz + npoints + start;
+            const double* PRAGMA_RESTRICT z = xyz + 2 * npoints + start;
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = x[i] - center_x;
+                yc[i] = y[i] - center_y;
+                zc[i] = z[i] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+                S2[i] = 0.0;
+            }
+        } else {
+            unsigned int start_shift = start * xyz_stride;
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = xyz[start_shift + i * xyz_stride] - center_x;
+                yc[i] = xyz[start_shift + i * xyz_stride + 1] - center_y;
+                zc[i] = xyz[start_shift + i * xyz_stride + 2] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+                S2[i] = 0.0;
+            }
+        }
+
+        // Start exponential block loop
+        for (unsigned long n = 0; n < nprim; n++) {
+            const double coef = coeffs[n];
+            const double alpha_n1 = expn1[n];
+            const double alpha_n2 = expn2[n];
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                const double width = alpha_n1 * R2[i];
+                const double T1 = coef * exp(width);
+                S0[i] += T1;
+                const double T2 = alpha_n2 * T1;
+                S1[i] += T2;
+                const double T3 = alpha_n2 * T2;
+                S2[i] += T3;
+            }
+        }
+
+        // Build powers
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            // Cartesian derivs
+            xc_pow[i] = xc[i] * xc[i];
+            yc_pow[i] = yc[i] * yc[i];
+            zc_pow[i] = zc[i] * zc[i];
+            xc_pow[32 + i] = xc_pow[i] * xc[i];
+            yc_pow[32 + i] = yc_pow[i] * yc[i];
+            zc_pow[32 + i] = zc_pow[i] * zc[i];
+            xc_pow[64 + i] = xc_pow[32 + i] * xc[i];
+            yc_pow[64 + i] = yc_pow[32 + i] * yc[i];
+            zc_pow[64 + i] = zc_pow[32 + i] * zc[i];
+            xc_pow[96 + i] = xc_pow[64 + i] * xc[i];
+            yc_pow[96 + i] = yc_pow[64 + i] * yc[i];
+            zc_pow[96 + i] = zc_pow[64 + i] * zc[i];
+            xc_pow[128 + i] = xc_pow[96 + i] * xc[i];
+            yc_pow[128 + i] = yc_pow[96 + i] * yc[i];
+            zc_pow[128 + i] = zc_pow[96 + i] * zc[i];
+            xc_pow[160 + i] = xc_pow[128 + i] * xc[i];
+            yc_pow[160 + i] = yc_pow[128 + i] * yc[i];
+            zc_pow[160 + i] = zc_pow[128 + i] * zc[i];
+            xc_pow[192 + i] = xc_pow[160 + i] * xc[i];
+            yc_pow[192 + i] = yc_pow[160 + i] * yc[i];
+            zc_pow[192 + i] = zc_pow[160 + i] * zc[i];
+        }
+        // Combine A blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            phi_tmp[i] = xc_pow[192 + i] * S0[i];
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * S0[i];
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * S0[i];
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * S0[i];
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * S0[i];
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * S0[i];
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * S0[i];
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * S0[i];
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * S0[i];
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * S0[i];
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * S0[i];
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * S0[i];
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * S0[i];
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * S0[i];
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * S0[i];
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * S0[i];
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * S0[i];
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * S0[i];
+            phi_tmp[1152 + i] = yc_pow[192 + i] * S0[i];
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * S0[i];
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * S0[i];
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * S0[i];
+            phi_tmp[1408 + i] = zc_pow[192 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        }
+
+        // Combine X blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SX;
+            phi_tmp[i] += 8.0 * xc_pow[160 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SX;
+            phi_tmp[480 + i] += 3.0 * xc_pow[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SX;
+            phi_tmp[640 + i] += 3.0 * xc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SX;
+            phi_tmp[672 + i] += 2.0 * xc[i] * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SX;
+            phi_tmp[864 + i] += 2.0 * xc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SX;
+            phi_tmp[896 + i] += yc_pow[160 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[928 + i] += yc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[960 + i] += yc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[992 + i] += yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[1024 + i] += yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[1056 + i] += yc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[1088 + i] += yc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SX;
+            phi_tmp[1120 + i] += zc_pow[160 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SX;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        }
+
+        // Combine Y blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += xc_pow[160 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[96 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += xc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SY;
+            phi_tmp[672 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[832 + i] += xc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SY;
+            phi_tmp[896 + i] += 7.0 * xc[i] * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1088 + i] += xc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SY;
+            phi_tmp[1152 + i] += 8.0 * yc_pow[160 + i] * S0[i];
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SY;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SY;
+            phi_tmp[1216 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1248 + i] += 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SY;
+            phi_tmp[1312 + i] += 3.0 * yc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1344 + i] += 2.0 * yc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SY;
+            phi_tmp[1376 + i] += zc_pow[160 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        }
+
+        // Combine Z blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += xc_pow[160 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += xc_pow[96 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += xc_pow[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[864 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += xc[i] * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SZ;
+            phi_tmp[1120 + i] += 7.0 * xc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SZ;
+            phi_tmp[1184 + i] += yc_pow[160 + i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1248 + i] += 3.0 * yc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1312 + i] += 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1344 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SZ;
+            phi_tmp[1376 + i] += 7.0 * yc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SZ;
+            phi_tmp[1408 + i] += 8.0 * zc_pow[160 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        }
+
+        // Combine XX blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SXX = S2[i] * xc[i] * xc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXX;
+            phi_tmp[i] += 16.0 * xc_pow[160 + i] * SX;
+            phi_tmp[i] += 56.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXX;
+            phi_tmp[32 + i] += 14.0 * xc_pow[128 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 42.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXX;
+            phi_tmp[64 + i] += 14.0 * xc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 42.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXX;
+            phi_tmp[96 + i] += 12.0 * xc_pow[96 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 30.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXX;
+            phi_tmp[128 + i] += 12.0 * xc_pow[96 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 30.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXX;
+            phi_tmp[160 + i] += 12.0 * xc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 30.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXX;
+            phi_tmp[192 + i] += 10.0 * xc_pow[64 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 20.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXX;
+            phi_tmp[224 + i] += 10.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 20.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXX;
+            phi_tmp[256 + i] += 10.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 20.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[288 + i] += 10.0 * xc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 20.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXX;
+            phi_tmp[320 + i] += 8.0 * xc_pow[32 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 12.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXX;
+            phi_tmp[352 + i] += 8.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXX;
+            phi_tmp[384 + i] += 8.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[416 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXX;
+            phi_tmp[448 + i] += 8.0 * xc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 12.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXX;
+            phi_tmp[480 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * SX;
+            phi_tmp[480 + i] += 6.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXX;
+            phi_tmp[512 + i] += 6.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 6.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXX;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[608 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 6.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXX;
+            phi_tmp[640 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[640 + i] += 6.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXX;
+            phi_tmp[672 + i] += 4.0 * xc[i] * yc_pow[128 + i] * SX;
+            phi_tmp[672 + i] += 2.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXX;
+            phi_tmp[704 + i] += 4.0 * xc[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += 2.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXX;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[768 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += 2.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += 2.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[832 + i] += 4.0 * xc[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXX;
+            phi_tmp[864 + i] += 4.0 * xc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[864 + i] += 2.0 * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXX;
+            phi_tmp[896 + i] += 2.0 * yc_pow[160 + i] * SX;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXX;
+            phi_tmp[928 + i] += 2.0 * yc_pow[128 + i] * zc[i] * SX;
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXX;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc_pow[i] * SX;
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[992 + i] += 2.0 * yc_pow[64 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXX;
+            phi_tmp[1024 + i] += 2.0 * yc_pow[32 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[1056 + i] += 2.0 * yc_pow[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXX;
+            phi_tmp[1088 + i] += 2.0 * yc[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXX;
+            phi_tmp[1120 + i] += 2.0 * zc_pow[160 + i] * SX;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXX;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        }
+
+        // Combine XY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SY = S1[i] * yc[i];
+            const double SXY = S2[i] * xc[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXY;
+            phi_tmp[i] += 8.0 * xc_pow[160 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXY;
+            phi_tmp[32 + i] += xc_pow[160 + i] * SX;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXY;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * yc[i] * SX;
+            phi_tmp[96 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 12.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXY;
+            phi_tmp[128 + i] += xc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXY;
+            phi_tmp[160 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[96 + i] * yc_pow[i] * SX;
+            phi_tmp[192 + i] += 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 15.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXY;
+            phi_tmp[256 + i] += xc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[288 + i] += 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 16.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[416 + i] += xc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[480 + i] += 3.0 * xc_pow[i] * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 15.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[608 + i] += xc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXY;
+            phi_tmp[640 + i] += 3.0 * xc_pow[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXY;
+            phi_tmp[672 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * SX;
+            phi_tmp[672 + i] += 2.0 * xc[i] * yc_pow[128 + i] * SY;
+            phi_tmp[672 + i] += 12.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[832 + i] += xc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[832 + i] += 2.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[864 + i] += 2.0 * xc[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXY;
+            phi_tmp[896 + i] += 7.0 * xc[i] * yc_pow[128 + i] * SX;
+            phi_tmp[896 + i] += yc_pow[160 + i] * SY;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[928 + i] += yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[960 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[960 + i] += yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[992 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[992 + i] += yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1024 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[1024 + i] += yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[1056 + i] += yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[1088 + i] += xc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[1088 + i] += yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXY;
+            phi_tmp[1120 + i] += zc_pow[160 + i] * SY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXY;
+            phi_tmp[1152 + i] += 8.0 * yc_pow[160 + i] * SX;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXY;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * zc[i] * SX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXY;
+            phi_tmp[1216 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[1248 + i] += 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1312 + i] += 3.0 * yc_pow[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[1344 + i] += 2.0 * yc[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXY;
+            phi_tmp[1376 + i] += zc_pow[160 + i] * SX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        }
+
+        // Combine XZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SXZ = S2[i] * xc[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXZ;
+            phi_tmp[i] += 8.0 * xc_pow[160 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXZ;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXZ;
+            phi_tmp[64 + i] += xc_pow[160 + i] * SX;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXZ;
+            phi_tmp[96 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * yc[i] * SX;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[160 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 12.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXZ;
+            phi_tmp[192 + i] += 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXZ;
+            phi_tmp[224 + i] += xc_pow[96 + i] * yc_pow[i] * SX;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[288 + i] += 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 15.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXZ;
+            phi_tmp[352 + i] += xc_pow[64 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 8.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 12.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 16.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXZ;
+            phi_tmp[480 + i] += 3.0 * xc_pow[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXZ;
+            phi_tmp[512 + i] += xc_pow[32 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[640 + i] += 3.0 * xc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 15.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXZ;
+            phi_tmp[672 + i] += 2.0 * xc[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[704 + i] += xc_pow[i] * yc_pow[96 + i] * SX;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[768 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 8.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[864 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[864 + i] += 2.0 * xc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[864 + i] += 12.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXZ;
+            phi_tmp[896 + i] += yc_pow[160 + i] * SZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[928 + i] += xc[i] * yc_pow[128 + i] * SX;
+            phi_tmp[928 + i] += yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[960 + i] += yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[992 + i] += 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[992 + i] += yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1024 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[1024 + i] += yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1056 + i] += 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[1056 + i] += yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[1088 + i] += yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXZ;
+            phi_tmp[1120 + i] += 7.0 * xc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[1120 + i] += zc_pow[160 + i] * SZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXZ;
+            phi_tmp[1184 + i] += yc_pow[160 + i] * SX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * zc[i] * SX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[1248 + i] += 3.0 * yc_pow[96 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1312 + i] += 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[1344 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXZ;
+            phi_tmp[1376 + i] += 7.0 * yc[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXZ;
+            phi_tmp[1408 + i] += 8.0 * zc_pow[160 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        }
+
+        // Combine YY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SYY = S2[i] * yc[i] * yc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SYY;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SYY;
+            phi_tmp[32 + i] += 2.0 * xc_pow[160 + i] * SY;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SYY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SYY;
+            phi_tmp[96 + i] += 4.0 * xc_pow[128 + i] * yc[i] * SY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SYY;
+            phi_tmp[128 + i] += 2.0 * xc_pow[128 + i] * zc[i] * SY;
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SYY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SYY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * SY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SYY;
+            phi_tmp[224 + i] += 4.0 * xc_pow[96 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SYY;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * zc_pow[i] * SY;
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SYY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SYY;
+            phi_tmp[320 + i] += 8.0 * xc_pow[64 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[320 + i] += 12.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SYY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SYY;
+            phi_tmp[384 + i] += 4.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[416 + i] += 2.0 * xc_pow[64 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SYY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SYY;
+            phi_tmp[480 + i] += 10.0 * xc_pow[32 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[480 + i] += 20.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SYY;
+            phi_tmp[512 + i] += 8.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SYY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[576 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[608 + i] += 2.0 * xc_pow[32 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SYY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SYY;
+            phi_tmp[672 + i] += 12.0 * xc_pow[i] * yc_pow[96 + i] * SY;
+            phi_tmp[672 + i] += 30.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SYY;
+            phi_tmp[704 + i] += 10.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 20.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SYY;
+            phi_tmp[736 + i] += 8.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[832 + i] += 2.0 * xc_pow[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SYY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SYY;
+            phi_tmp[896 + i] += 14.0 * xc[i] * yc_pow[128 + i] * SY;
+            phi_tmp[896 + i] += 42.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SYY;
+            phi_tmp[928 + i] += 12.0 * xc[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 30.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SYY;
+            phi_tmp[960 + i] += 10.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 20.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[992 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1024 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 6.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1056 + i] += 4.0 * xc[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SYY;
+            phi_tmp[1088 + i] += 2.0 * xc[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SYY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SYY;
+            phi_tmp[1152 + i] += 16.0 * yc_pow[160 + i] * SY;
+            phi_tmp[1152 + i] += 56.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SYY;
+            phi_tmp[1184 + i] += 14.0 * yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[1184 + i] += 42.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SYY;
+            phi_tmp[1216 + i] += 12.0 * yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[1216 + i] += 30.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[1248 + i] += 10.0 * yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1248 + i] += 20.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1280 + i] += 8.0 * yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1280 + i] += 12.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1312 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1312 + i] += 6.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SYY;
+            phi_tmp[1344 + i] += 4.0 * yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1344 + i] += 2.0 * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SYY;
+            phi_tmp[1376 + i] += 2.0 * zc_pow[160 + i] * SY;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SYY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        }
+
+        // Combine YZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SYZ = S2[i] * yc[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SYZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SYZ;
+            phi_tmp[32 + i] += xc_pow[160 + i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SYZ;
+            phi_tmp[64 + i] += xc_pow[160 + i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SYZ;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * yc[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SYZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * yc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SYZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * zc[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SYZ;
+            phi_tmp[192 + i] += 3.0 * xc_pow[96 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SYZ;
+            phi_tmp[224 + i] += xc_pow[96 + i] * yc_pow[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SYZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[256 + i] += xc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[96 + i] * zc_pow[i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SYZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SYZ;
+            phi_tmp[352 + i] += xc_pow[64 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SYZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[416 + i] += xc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SYZ;
+            phi_tmp[480 + i] += 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SYZ;
+            phi_tmp[512 + i] += xc_pow[32 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SYZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[608 + i] += xc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SYZ;
+            phi_tmp[672 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[704 + i] += xc_pow[i] * yc_pow[96 + i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 8.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 8.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[832 + i] += xc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[864 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SYZ;
+            phi_tmp[896 + i] += 7.0 * xc[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[928 + i] += xc[i] * yc_pow[128 + i] * SY;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[960 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[992 + i] += 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[992 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 12.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1024 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1056 + i] += 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1088 + i] += xc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SYZ;
+            phi_tmp[1120 + i] += 7.0 * xc[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SYZ;
+            phi_tmp[1152 + i] += 8.0 * yc_pow[160 + i] * SZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SYZ;
+            phi_tmp[1184 + i] += yc_pow[160 + i] * SY;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SYZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[1216 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[1216 + i] += 12.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[1248 + i] += 3.0 * yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[1248 + i] += 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1248 + i] += 15.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1280 + i] += 16.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1312 + i] += 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1312 + i] += 3.0 * yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1312 + i] += 15.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[1344 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1344 + i] += 2.0 * yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1344 + i] += 12.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SYZ;
+            phi_tmp[1376 + i] += 7.0 * yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1376 + i] += zc_pow[160 + i] * SZ;
+            phi_tmp[1376 + i] += 7.0 * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SYZ;
+            phi_tmp[1408 + i] += 8.0 * zc_pow[160 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        }
+
+        // Combine ZZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+            const double SZZ = S2[i] * zc[i] * zc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SZZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SZZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SZZ;
+            phi_tmp[64 + i] += 2.0 * xc_pow[160 + i] * SZ;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SZZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SZZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[128 + i] * yc[i] * SZ;
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SZZ;
+            phi_tmp[160 + i] += 4.0 * xc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SZZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SZZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SZZ;
+            phi_tmp[256 + i] += 4.0 * xc_pow[96 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SZZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SZZ;
+            phi_tmp[352 + i] += 2.0 * xc_pow[64 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SZZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[448 + i] += 8.0 * xc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[448 + i] += 12.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SZZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SZZ;
+            phi_tmp[512 + i] += 2.0 * xc_pow[32 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SZZ;
+            phi_tmp[544 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[608 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[640 + i] += 10.0 * xc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[640 + i] += 20.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SZZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[704 + i] += 2.0 * xc_pow[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[800 + i] += 8.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[800 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[832 + i] += 10.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[832 + i] += 20.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[864 + i] += 12.0 * xc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[864 + i] += 30.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SZZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[928 + i] += 2.0 * xc[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[960 + i] += 4.0 * xc[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[992 + i] += 6.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[992 + i] += 6.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1024 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1024 + i] += 12.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1056 + i] += 10.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1056 + i] += 20.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[1088 + i] += 12.0 * xc[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1088 + i] += 30.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SZZ;
+            phi_tmp[1120 + i] += 14.0 * xc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1120 + i] += 42.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SZZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SZZ;
+            phi_tmp[1184 + i] += 2.0 * yc_pow[160 + i] * SZ;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SZZ;
+            phi_tmp[1216 + i] += 4.0 * yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[1248 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[1248 + i] += 6.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1280 + i] += 8.0 * yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1280 + i] += 12.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1312 + i] += 10.0 * yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1312 + i] += 20.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[1344 + i] += 12.0 * yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1344 + i] += 30.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SZZ;
+            phi_tmp[1376 + i] += 14.0 * yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1376 + i] += 42.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SZZ;
+            phi_tmp[1408 + i] += 16.0 * zc_pow[160 + i] * SZ;
+            phi_tmp[1408 + i] += 56.0 * zc_pow[128 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        }
+    }
+
+    // Free S temporaries
+    ALIGNED_FREE(cache_data);
+    ALIGNED_FREE(expn1);
+    ALIGNED_FREE(expn2);
+
+    // Free Power temporaries
+    ALIGNED_FREE(xc_pow);
+    ALIGNED_FREE(yc_pow);
+    ALIGNED_FREE(zc_pow);
+
+    // Free inner temporaries
+    ALIGNED_FREE(phi_tmp);
 }

--- a/external/gau2grid/generated_source/gau2grid_deriv2.c
+++ b/external/gau2grid/generated_source/gau2grid_deriv2.c
@@ -90,9 +90,12 @@ void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -146,7 +149,7 @@ void gg_collocation_L0_deriv2(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -283,9 +286,12 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -339,7 +345,7 @@ void gg_collocation_L1_deriv2(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -594,9 +600,10 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
     const double center_z = center[2];
     double A;
     double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -650,7 +657,7 @@ void gg_collocation_L2_deriv2(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -988,9 +995,12 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -1044,7 +1054,7 @@ void gg_collocation_L3_deriv2(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -1595,9 +1605,12 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -1651,7 +1664,7 @@ void gg_collocation_L4_deriv2(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -2366,9 +2379,12 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -2422,7 +2438,7 @@ void gg_collocation_L5_deriv2(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -3338,9 +3354,12 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -3394,7 +3413,7 @@ void gg_collocation_L6_deriv2(const unsigned long npoints, const double* PRAGMA_
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];

--- a/external/gau2grid/generated_source/gau2grid_deriv3.c
+++ b/external/gau2grid/generated_source/gau2grid_deriv3.c
@@ -114,9 +114,13 @@ void gg_collocation_L0_deriv3(
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
+    double AXXX, XXY, XXZ, XYY, XYZ, XZZ, YYY, YYZ, YZZ, ZZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -172,7 +176,7 @@ void gg_collocation_L0_deriv3(
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -369,9 +373,13 @@ void gg_collocation_L1_deriv3(
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
+    double AXXX, XXY, XXZ, XYY, XYZ, XZZ, YYY, YYZ, YZZ, ZZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -427,7 +435,7 @@ void gg_collocation_L1_deriv3(
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -786,9 +794,13 @@ void gg_collocation_L2_deriv3(
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
+    double AXXX, XXY, XXZ, XYY, XYZ, XZZ, YYY, YYZ, YZZ, ZZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -844,7 +856,7 @@ void gg_collocation_L2_deriv3(
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -1662,9 +1674,13 @@ void gg_collocation_L3_deriv3(
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
+    double AXXX, XXY, XXZ, XYY, XYZ, XZZ, YYY, YYZ, YZZ, ZZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -1720,7 +1736,7 @@ void gg_collocation_L3_deriv3(
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -2845,9 +2861,13 @@ void gg_collocation_L4_deriv3(
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
+    double AXXX, XXY, XXZ, XYY, XYZ, XZZ, YYY, YYZ, YZZ, ZZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -2903,7 +2923,7 @@ void gg_collocation_L4_deriv3(
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -4438,9 +4458,13 @@ void gg_collocation_L5_deriv3(
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
+    double AXXX, XXY, XXZ, XYY, XYZ, XZZ, YYY, YYZ, YZZ, ZZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -4496,7 +4520,7 @@ void gg_collocation_L5_deriv3(
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];
@@ -6544,9 +6568,13 @@ void gg_collocation_L6_deriv3(
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
+    double AXXX, XXY, XXZ, XYY, XYZ, XZZ, YYY, YYZ, YZZ, ZZZ;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
         expn2[i] = -2.0 * exponents[i];
     }
@@ -6602,7 +6630,7 @@ void gg_collocation_L6_deriv3(
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
             const double alpha_n2 = expn2[n];

--- a/external/gau2grid/generated_source/gau2grid_deriv3.c
+++ b/external/gau2grid/generated_source/gau2grid_deriv3.c
@@ -20,10 +20,16 @@
 #include "gau2grid/gau2grid_utility.h"
 #include "gau2grid/gau2grid_pragma.h"
 
-
-
-void gg_collocation_L0_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
-
+void gg_collocation_L0_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -33,12 +39,12 @@ void gg_collocation_L0_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 288 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((288 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -59,49 +65,49 @@ void gg_collocation_L0_deriv3(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S3, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xx_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xx_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xx_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xy_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xy_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yy_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yy_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_zz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_zz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_zz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xxx_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xxx_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xxx_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xxy_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xxy_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xxy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xxz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xxz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xxz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xyy_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xyy_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xyy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xyz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xyz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xyz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xzz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xzz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xzz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yyy_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yyy_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yyy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yyz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yyz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yyz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yzz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yzz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yzz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_zzz_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_zzz_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_zzz_tmp, 64);
 
     // Declare doubles
@@ -117,8 +123,6 @@ void gg_collocation_L0_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -145,8 +149,8 @@ void gg_collocation_L0_deriv3(const unsigned long npoints, const double* PRAGMA_
                 S2[i] = 0.0;
                 S3[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -185,7 +189,6 @@ void gg_collocation_L0_deriv3(const unsigned long npoints, const double* PRAGMA_
                 const double T4 = alpha_n2 * T3;
                 S3[i] += T4;
             }
-
         }
 
         // Combine blocks
@@ -270,11 +273,18 @@ void gg_collocation_L0_deriv3(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_yyz_tmp);
     ALIGNED_FREE(phi_yzz_tmp);
     ALIGNED_FREE(phi_zzz_tmp);
-
 }
 
-void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
-
+void gg_collocation_L1_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -284,12 +294,12 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 288 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((288 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -310,49 +320,49 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S3, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
-    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_x_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_x_tmp, 64);
-    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_y_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_y_tmp, 64);
-    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_z_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_z_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xx_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xx_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xx_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xy_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xy_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yy_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yy_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_zz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_zz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_zz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xxx_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xxx_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xxx_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xxy_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xxy_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xxy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xxz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xxz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xxz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xyy_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xyy_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xyy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xyz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xyz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xyz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_xzz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_xzz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_xzz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yyy_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yyy_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yyy_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yyz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yyz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yyz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_yzz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_yzz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_yzz_tmp, 64);
-    double* PRAGMA_RESTRICT phi_zzz_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_zzz_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_zzz_tmp, 64);
 
     // Declare doubles
@@ -368,8 +378,6 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -396,8 +404,8 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
                 S2[i] = 0.0;
                 S3[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -436,7 +444,6 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
                 const double T4 = alpha_n2 * T3;
                 S3[i] += T4;
             }
-
         }
 
         // Combine blocks
@@ -504,7 +511,6 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_yyy_tmp[i] = SYYY * xc[i];
             phi_zzz_tmp[i] = SZZZ * xc[i];
 
-
             // Density AM=1 Component=Y
             phi_tmp[32 + i] = S0[i] * yc[i];
 
@@ -542,7 +548,6 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_yyy_tmp[32 + i] += 3.0 * SYY;
             phi_zzz_tmp[32 + i] = SZZZ * yc[i];
 
-
             // Density AM=1 Component=Z
             phi_tmp[64 + i] = S0[i] * zc[i];
 
@@ -579,8 +584,6 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_yyy_tmp[64 + i] = SYYY * zc[i];
             phi_zzz_tmp[64 + i] = SZZZ * zc[i];
             phi_zzz_tmp[64 + i] += 3.0 * SZZ;
-
-
         }
 
         // Copy data back into outer temps
@@ -610,7 +613,7 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_to_spherical_L1(remain, phi_yyz_tmp, 32, (phi_yyz_out + start), npoints);
             gg_cca_cart_to_spherical_L1(remain, phi_yzz_tmp, 32, (phi_yzz_out + start), npoints);
             gg_cca_cart_to_spherical_L1(remain, phi_zzz_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -636,7 +639,7 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
             gg_gaussian_cart_to_spherical_L1(remain, phi_yyz_tmp, 32, (phi_yyz_out + start), npoints);
             gg_gaussian_cart_to_spherical_L1(remain, phi_yzz_tmp, 32, (phi_yzz_out + start), npoints);
             gg_gaussian_cart_to_spherical_L1(remain, phi_zzz_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -662,7 +665,7 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
             gg_cca_cart_copy_L1(remain, phi_yyz_tmp, 32, (phi_yyz_out + start), npoints);
             gg_cca_cart_copy_L1(remain, phi_yzz_tmp, 32, (phi_yzz_out + start), npoints);
             gg_cca_cart_copy_L1(remain, phi_zzz_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
 
@@ -689,7 +692,6 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
             gg_molden_cart_copy_L1(remain, phi_yzz_tmp, 32, (phi_yzz_out + start), npoints);
             gg_molden_cart_copy_L1(remain, phi_zzz_tmp, 32, (phi_zzz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -718,11 +720,18 @@ void gg_collocation_L1_deriv3(const unsigned long npoints, const double* PRAGMA_
     ALIGNED_FREE(phi_yyz_tmp);
     ALIGNED_FREE(phi_yzz_tmp);
     ALIGNED_FREE(phi_zzz_tmp);
-
 }
 
-void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
-
+void gg_collocation_L2_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -732,12 +741,12 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 288 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((288 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -758,19 +767,19 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S3, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate power temporaries
-    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(xc_pow, 64);
-    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(yc_pow, 64);
-    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(zc_pow, 64);
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -786,8 +795,6 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -814,8 +821,8 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
                 S2[i] = 0.0;
                 S3[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -854,23 +861,19 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
                 const double T4 = alpha_n2 * T3;
                 S3[i] += T4;
             }
-
         }
 
         // Build powers
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             xc_pow[i] = xc[i] * xc[i];
             yc_pow[i] = yc[i] * yc[i];
             zc_pow[i] = zc[i] * zc[i];
-
         }
         // Combine A blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             phi_tmp[i] = xc_pow[i] * S0[i];
             phi_tmp[32 + i] = xc[i] * yc[i] * S0[i];
             phi_tmp[64 + i] = xc[i] * zc[i] * S0[i];
@@ -881,11 +884,11 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
 
@@ -908,16 +911,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] = yc[i] * zc[i] * SX;
 
             phi_tmp[160 + i] = zc_pow[i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_x_out + start), npoints);
         }
 
@@ -940,16 +942,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] += zc[i] * S0[i];
 
             phi_tmp[160 + i] = zc_pow[i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_y_out + start), npoints);
         }
 
@@ -972,16 +973,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[160 + i] = zc_pow[i] * SZ;
             phi_tmp[160 + i] += 2.0 * zc[i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_z_out + start), npoints);
         }
 
@@ -1006,16 +1006,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] = yc[i] * zc[i] * SXX;
 
             phi_tmp[160 + i] = zc_pow[i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
         }
 
@@ -1032,7 +1031,7 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[32 + i] = xc[i] * yc[i] * SXY;
             phi_tmp[32 + i] += xc[i] * SX;
             phi_tmp[32 + i] += yc[i] * SY;
-            phi_tmp[32 + i] +=  1 * S0[i];
+            phi_tmp[32 + i] += 1 * S0[i];
 
             phi_tmp[64 + i] = xc[i] * zc[i] * SXY;
             phi_tmp[64 + i] += zc[i] * SY;
@@ -1044,16 +1043,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] += zc[i] * SX;
 
             phi_tmp[160 + i] = zc_pow[i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
         }
 
@@ -1073,7 +1071,7 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[64 + i] = xc[i] * zc[i] * SXZ;
             phi_tmp[64 + i] += xc[i] * SX;
             phi_tmp[64 + i] += zc[i] * SZ;
-            phi_tmp[64 + i] +=  1 * S0[i];
+            phi_tmp[64 + i] += 1 * S0[i];
 
             phi_tmp[96 + i] = yc_pow[i] * SXZ;
 
@@ -1082,16 +1080,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[160 + i] = zc_pow[i] * SXZ;
             phi_tmp[160 + i] += 2.0 * zc[i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
         }
 
@@ -1116,16 +1113,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] += 2.0 * zc[i] * SY;
 
             phi_tmp[160 + i] = zc_pow[i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
         }
 
@@ -1150,20 +1146,19 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] = yc[i] * zc[i] * SYZ;
             phi_tmp[128 + i] += yc[i] * SY;
             phi_tmp[128 + i] += zc[i] * SZ;
-            phi_tmp[128 + i] +=  1 * S0[i];
+            phi_tmp[128 + i] += 1 * S0[i];
 
             phi_tmp[160 + i] = zc_pow[i] * SYZ;
             phi_tmp[160 + i] += 2.0 * zc[i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
         }
 
@@ -1188,16 +1183,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[160 + i] = zc_pow[i] * SZZ;
             phi_tmp[160 + i] += 4.0 * zc[i] * SZ;
             phi_tmp[160 + i] += 2.0 * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
         }
 
@@ -1223,16 +1217,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] = yc[i] * zc[i] * SXXX;
 
             phi_tmp[160 + i] = zc_pow[i] * SXXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
         }
 
@@ -1252,7 +1245,7 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[32 + i] = xc[i] * yc[i] * SXXY;
             phi_tmp[32 + i] += 2.0 * yc[i] * SXY;
             phi_tmp[32 + i] += xc[i] * SXX;
-            phi_tmp[32 + i] += 2.0 *  1 * SX;
+            phi_tmp[32 + i] += 2.0 * 1 * SX;
 
             phi_tmp[64 + i] = xc[i] * zc[i] * SXXY;
             phi_tmp[64 + i] += 2.0 * zc[i] * SXY;
@@ -1264,16 +1257,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] += zc[i] * SXX;
 
             phi_tmp[160 + i] = zc_pow[i] * SXXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
         }
 
@@ -1296,7 +1288,7 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[64 + i] = xc[i] * zc[i] * SXXZ;
             phi_tmp[64 + i] += 2.0 * zc[i] * SXZ;
             phi_tmp[64 + i] += xc[i] * SXX;
-            phi_tmp[64 + i] += 2.0 *  1 * SX;
+            phi_tmp[64 + i] += 2.0 * 1 * SX;
 
             phi_tmp[96 + i] = yc_pow[i] * SXXZ;
 
@@ -1305,16 +1297,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[160 + i] = zc_pow[i] * SXXZ;
             phi_tmp[160 + i] += 2.0 * zc[i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
         }
 
@@ -1333,7 +1324,7 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[32 + i] = xc[i] * yc[i] * SXYY;
             phi_tmp[32 + i] += 2.0 * xc[i] * SXY;
             phi_tmp[32 + i] += yc[i] * SYY;
-            phi_tmp[32 + i] += 2.0 *  1 * SY;
+            phi_tmp[32 + i] += 2.0 * 1 * SY;
 
             phi_tmp[64 + i] = xc[i] * zc[i] * SXYY;
             phi_tmp[64 + i] += zc[i] * SYY;
@@ -1346,16 +1337,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] += 2.0 * zc[i] * SXY;
 
             phi_tmp[160 + i] = zc_pow[i] * SXYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
         }
 
@@ -1376,12 +1366,12 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[32 + i] = xc[i] * yc[i] * SXYZ;
             phi_tmp[32 + i] += yc[i] * SYZ;
             phi_tmp[32 + i] += xc[i] * SXZ;
-            phi_tmp[32 + i] +=  1 * SZ;
+            phi_tmp[32 + i] += 1 * SZ;
 
             phi_tmp[64 + i] = xc[i] * zc[i] * SXYZ;
             phi_tmp[64 + i] += zc[i] * SYZ;
             phi_tmp[64 + i] += xc[i] * SXY;
-            phi_tmp[64 + i] +=  1 * SY;
+            phi_tmp[64 + i] += 1 * SY;
 
             phi_tmp[96 + i] = yc_pow[i] * SXYZ;
             phi_tmp[96 + i] += 2.0 * yc[i] * SXZ;
@@ -1389,20 +1379,19 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] = yc[i] * zc[i] * SXYZ;
             phi_tmp[128 + i] += zc[i] * SXZ;
             phi_tmp[128 + i] += yc[i] * SXY;
-            phi_tmp[128 + i] +=  1 * SX;
+            phi_tmp[128 + i] += 1 * SX;
 
             phi_tmp[160 + i] = zc_pow[i] * SXYZ;
             phi_tmp[160 + i] += 2.0 * zc[i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
         }
 
@@ -1424,7 +1413,7 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[64 + i] = xc[i] * zc[i] * SXZZ;
             phi_tmp[64 + i] += 2.0 * xc[i] * SXZ;
             phi_tmp[64 + i] += zc[i] * SZZ;
-            phi_tmp[64 + i] += 2.0 *  1 * SZ;
+            phi_tmp[64 + i] += 2.0 * 1 * SZ;
 
             phi_tmp[96 + i] = yc_pow[i] * SXZZ;
 
@@ -1434,16 +1423,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[160 + i] = zc_pow[i] * SXZZ;
             phi_tmp[160 + i] += 2.0 * 2.0 * zc[i] * SXZ;
             phi_tmp[160 + i] += 2.0 * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
         }
 
@@ -1469,16 +1457,15 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] += 3.0 * zc[i] * SYY;
 
             phi_tmp[160 + i] = zc_pow[i] * SYYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
         }
 
@@ -1506,20 +1493,19 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] = yc[i] * zc[i] * SYYZ;
             phi_tmp[128 + i] += 2.0 * zc[i] * SYZ;
             phi_tmp[128 + i] += yc[i] * SYY;
-            phi_tmp[128 + i] += 2.0 *  1 * SY;
+            phi_tmp[128 + i] += 2.0 * 1 * SY;
 
             phi_tmp[160 + i] = zc_pow[i] * SYYZ;
             phi_tmp[160 + i] += 2.0 * zc[i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
         }
 
@@ -1546,21 +1532,20 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] = yc[i] * zc[i] * SYZZ;
             phi_tmp[128 + i] += 2.0 * yc[i] * SYZ;
             phi_tmp[128 + i] += zc[i] * SZZ;
-            phi_tmp[128 + i] += 2.0 *  1 * SZ;
+            phi_tmp[128 + i] += 2.0 * 1 * SZ;
 
             phi_tmp[160 + i] = zc_pow[i] * SYZZ;
             phi_tmp[160 + i] += 2.0 * 2.0 * zc[i] * SYZ;
             phi_tmp[160 + i] += 2.0 * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
         }
 
@@ -1586,19 +1571,17 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[160 + i] = zc_pow[i] * SZZZ;
             phi_tmp[160 + i] += 3.0 * 2.0 * zc[i] * SZZ;
             phi_tmp[160 + i] += 3.0 * 2.0 * SZ;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -1613,11 +1596,18 @@ void gg_collocation_L2_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
-
+void gg_collocation_L3_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -1627,12 +1617,12 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 288 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((288 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -1653,19 +1643,19 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S3, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate power temporaries
-    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, 64 * sizeof(double));
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((64 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(xc_pow, 64);
-    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, 64 * sizeof(double));
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((64 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(yc_pow, 64);
-    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, 64 * sizeof(double));
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((64 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(zc_pow, 64);
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 320 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((320 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -1681,8 +1671,6 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -1709,8 +1697,8 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
                 S2[i] = 0.0;
                 S3[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -1749,13 +1737,11 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
                 const double T4 = alpha_n2 * T3;
                 S3[i] += T4;
             }
-
         }
 
         // Build powers
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             xc_pow[i] = xc[i] * xc[i];
             yc_pow[i] = yc[i] * yc[i];
@@ -1767,7 +1753,6 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
         // Combine A blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             phi_tmp[i] = xc_pow[32 + i] * S0[i];
             phi_tmp[32 + i] = xc_pow[i] * yc[i] * S0[i];
             phi_tmp[64 + i] = xc_pow[i] * zc[i] * S0[i];
@@ -1782,11 +1767,11 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
 
@@ -1820,16 +1805,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] = yc[i] * zc_pow[i] * SX;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_x_out + start), npoints);
         }
 
@@ -1863,16 +1847,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] += zc_pow[i] * S0[i];
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_y_out + start), npoints);
         }
 
@@ -1906,16 +1889,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SZ;
             phi_tmp[288 + i] += 3.0 * zc_pow[i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_z_out + start), npoints);
         }
 
@@ -1953,16 +1935,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] = yc[i] * zc_pow[i] * SXX;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
         }
 
@@ -2007,16 +1988,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] += zc_pow[i] * SX;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
         }
 
@@ -2061,16 +2041,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SXZ;
             phi_tmp[288 + i] += 3.0 * zc_pow[i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
         }
 
@@ -2108,16 +2087,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] += 2.0 * zc_pow[i] * SY;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
         }
 
@@ -2162,16 +2140,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SYZ;
             phi_tmp[288 + i] += 3.0 * zc_pow[i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
         }
 
@@ -2209,16 +2186,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[288 + i] = zc_pow[32 + i] * SZZ;
             phi_tmp[288 + i] += 6.0 * zc_pow[i] * SZ;
             phi_tmp[288 + i] += 6.0 * zc[i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
         }
 
@@ -2258,16 +2234,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] = yc[i] * zc_pow[i] * SXXX;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SXXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
         }
 
@@ -2318,16 +2293,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] += zc_pow[i] * SXX;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SXXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
         }
 
@@ -2378,16 +2352,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SXXZ;
             phi_tmp[288 + i] += 3.0 * zc_pow[i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
         }
 
@@ -2438,16 +2411,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] += 2.0 * zc_pow[i] * SXY;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SXYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
         }
 
@@ -2487,7 +2459,7 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[128 + i] += zc[i] * SZ;
             phi_tmp[128 + i] += yc[i] * SY;
             phi_tmp[128 + i] += xc[i] * SX;
-            phi_tmp[128 + i] +=  1 * S0[i];
+            phi_tmp[128 + i] += 1 * S0[i];
 
             phi_tmp[160 + i] = xc[i] * zc_pow[i] * SXYZ;
             phi_tmp[160 + i] += zc_pow[i] * SYZ;
@@ -2509,16 +2481,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SXYZ;
             phi_tmp[288 + i] += 3.0 * zc_pow[i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
         }
 
@@ -2569,16 +2540,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[288 + i] = zc_pow[32 + i] * SXZZ;
             phi_tmp[288 + i] += 2.0 * 3.0 * zc_pow[i] * SXZ;
             phi_tmp[288 + i] += 6.0 * zc[i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
         }
 
@@ -2618,16 +2588,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[256 + i] += 3.0 * zc_pow[i] * SYY;
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SYYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
         }
 
@@ -2678,16 +2647,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[288 + i] = zc_pow[32 + i] * SYYZ;
             phi_tmp[288 + i] += 3.0 * zc_pow[i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
         }
 
@@ -2738,16 +2706,15 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[288 + i] = zc_pow[32 + i] * SYZZ;
             phi_tmp[288 + i] += 2.0 * 3.0 * zc_pow[i] * SYZ;
             phi_tmp[288 + i] += 6.0 * zc[i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
         }
 
@@ -2787,19 +2754,17 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[288 + i] += 3.0 * 3.0 * zc_pow[i] * SZZ;
             phi_tmp[288 + i] += 3.0 * 6.0 * zc[i] * SZ;
             phi_tmp[288 + i] += 6.0 * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -2814,11 +2779,18 @@ void gg_collocation_L3_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
-
+void gg_collocation_L4_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -2828,12 +2800,12 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 288 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((288 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -2854,19 +2826,19 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S3, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate power temporaries
-    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(xc_pow, 64);
-    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(yc_pow, 64);
-    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(zc_pow, 64);
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 480 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((480 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -2882,8 +2854,6 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -2910,8 +2880,8 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
                 S2[i] = 0.0;
                 S3[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -2950,13 +2920,11 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
                 const double T4 = alpha_n2 * T3;
                 S3[i] += T4;
             }
-
         }
 
         // Build powers
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             xc_pow[i] = xc[i] * xc[i];
             yc_pow[i] = yc[i] * yc[i];
@@ -2971,7 +2939,6 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
         // Combine A blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             phi_tmp[i] = xc_pow[64 + i] * S0[i];
             phi_tmp[32 + i] = xc_pow[32 + i] * yc[i] * S0[i];
             phi_tmp[64 + i] = xc_pow[32 + i] * zc[i] * S0[i];
@@ -2991,11 +2958,11 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
 
@@ -3043,16 +3010,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] = yc[i] * zc_pow[32 + i] * SX;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_x_out + start), npoints);
         }
 
@@ -3100,16 +3066,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] += zc_pow[32 + i] * S0[i];
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_y_out + start), npoints);
         }
 
@@ -3157,16 +3122,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SZ;
             phi_tmp[448 + i] += 4.0 * zc_pow[32 + i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_z_out + start), npoints);
         }
 
@@ -3221,16 +3185,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] = yc[i] * zc_pow[32 + i] * SXX;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
         }
 
@@ -3296,16 +3259,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] += zc_pow[32 + i] * SX;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
         }
 
@@ -3371,16 +3333,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SXZ;
             phi_tmp[448 + i] += 4.0 * zc_pow[32 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
         }
 
@@ -3435,16 +3396,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] += 2.0 * zc_pow[32 + i] * SY;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
         }
 
@@ -3510,16 +3470,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SYZ;
             phi_tmp[448 + i] += 4.0 * zc_pow[32 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
         }
 
@@ -3574,16 +3533,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[448 + i] = zc_pow[64 + i] * SZZ;
             phi_tmp[448 + i] += 8.0 * zc_pow[32 + i] * SZ;
             phi_tmp[448 + i] += 12.0 * zc_pow[i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
         }
 
@@ -3642,16 +3600,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] = yc[i] * zc_pow[32 + i] * SXXX;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SXXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
         }
 
@@ -3728,16 +3685,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] += zc_pow[32 + i] * SXX;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SXXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
         }
 
@@ -3814,16 +3770,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SXXZ;
             phi_tmp[448 + i] += 4.0 * zc_pow[32 + i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
         }
 
@@ -3900,16 +3855,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] += 2.0 * zc_pow[32 + i] * SXY;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SXYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
         }
 
@@ -4004,16 +3958,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SXYZ;
             phi_tmp[448 + i] += 4.0 * zc_pow[32 + i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
         }
 
@@ -4090,16 +4043,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[448 + i] = zc_pow[64 + i] * SXZZ;
             phi_tmp[448 + i] += 2.0 * 4.0 * zc_pow[32 + i] * SXZ;
             phi_tmp[448 + i] += 12.0 * zc_pow[i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
         }
 
@@ -4158,16 +4110,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[416 + i] += 3.0 * zc_pow[32 + i] * SYY;
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SYYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
         }
 
@@ -4244,16 +4195,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[448 + i] = zc_pow[64 + i] * SYYZ;
             phi_tmp[448 + i] += 4.0 * zc_pow[32 + i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
         }
 
@@ -4330,16 +4280,15 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[448 + i] = zc_pow[64 + i] * SYZZ;
             phi_tmp[448 + i] += 2.0 * 4.0 * zc_pow[32 + i] * SYZ;
             phi_tmp[448 + i] += 12.0 * zc_pow[i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
         }
 
@@ -4398,19 +4347,17 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[448 + i] += 3.0 * 4.0 * zc_pow[32 + i] * SZZ;
             phi_tmp[448 + i] += 3.0 * 12.0 * zc_pow[i] * SZ;
             phi_tmp[448 + i] += 24.0 * zc[i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -4425,11 +4372,18 @@ void gg_collocation_L4_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
-
+void gg_collocation_L5_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -4439,12 +4393,12 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 288 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((288 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -4465,19 +4419,19 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S3, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate power temporaries
-    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, 128 * sizeof(double));
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((128 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(xc_pow, 64);
-    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, 128 * sizeof(double));
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((128 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(yc_pow, 64);
-    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, 128 * sizeof(double));
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((128 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(zc_pow, 64);
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 672 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((672 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -4493,8 +4447,6 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -4521,8 +4473,8 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
                 S2[i] = 0.0;
                 S3[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -4561,13 +4513,11 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
                 const double T4 = alpha_n2 * T3;
                 S3[i] += T4;
             }
-
         }
 
         // Build powers
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             xc_pow[i] = xc[i] * xc[i];
             yc_pow[i] = yc[i] * yc[i];
@@ -4585,7 +4535,6 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
         // Combine A blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             phi_tmp[i] = xc_pow[96 + i] * S0[i];
             phi_tmp[32 + i] = xc_pow[64 + i] * yc[i] * S0[i];
             phi_tmp[64 + i] = xc_pow[64 + i] * zc[i] * S0[i];
@@ -4611,11 +4560,11 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
 
@@ -4680,16 +4629,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] = yc[i] * zc_pow[64 + i] * SX;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_x_out + start), npoints);
         }
 
@@ -4754,16 +4702,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] += zc_pow[64 + i] * S0[i];
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_y_out + start), npoints);
         }
 
@@ -4828,16 +4775,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SZ;
             phi_tmp[640 + i] += 5.0 * zc_pow[64 + i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_z_out + start), npoints);
         }
 
@@ -4913,16 +4859,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] = yc[i] * zc_pow[64 + i] * SXX;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
         }
 
@@ -5014,16 +4959,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] += zc_pow[64 + i] * SX;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
         }
 
@@ -5115,16 +5059,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SXZ;
             phi_tmp[640 + i] += 5.0 * zc_pow[64 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
         }
 
@@ -5200,16 +5143,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] += 2.0 * zc_pow[64 + i] * SY;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
         }
 
@@ -5301,16 +5243,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SYZ;
             phi_tmp[640 + i] += 5.0 * zc_pow[64 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
         }
 
@@ -5386,16 +5327,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[640 + i] = zc_pow[96 + i] * SZZ;
             phi_tmp[640 + i] += 10.0 * zc_pow[64 + i] * SZ;
             phi_tmp[640 + i] += 20.0 * zc_pow[32 + i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
         }
 
@@ -5478,16 +5418,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] = yc[i] * zc_pow[64 + i] * SXXX;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SXXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
         }
 
@@ -5597,16 +5536,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] += zc_pow[64 + i] * SXX;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SXXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
         }
 
@@ -5716,16 +5654,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SXXZ;
             phi_tmp[640 + i] += 5.0 * zc_pow[64 + i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
         }
 
@@ -5835,16 +5772,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] += 2.0 * zc_pow[64 + i] * SXY;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SXYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
         }
 
@@ -5981,16 +5917,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SXYZ;
             phi_tmp[640 + i] += 5.0 * zc_pow[64 + i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
         }
 
@@ -6100,16 +6035,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[640 + i] = zc_pow[96 + i] * SXZZ;
             phi_tmp[640 + i] += 2.0 * 5.0 * zc_pow[64 + i] * SXZ;
             phi_tmp[640 + i] += 20.0 * zc_pow[32 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
         }
 
@@ -6192,16 +6126,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[608 + i] += 3.0 * zc_pow[64 + i] * SYY;
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SYYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
         }
 
@@ -6311,16 +6244,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[640 + i] = zc_pow[96 + i] * SYYZ;
             phi_tmp[640 + i] += 5.0 * zc_pow[64 + i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
         }
 
@@ -6430,16 +6362,15 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[640 + i] = zc_pow[96 + i] * SYZZ;
             phi_tmp[640 + i] += 2.0 * 5.0 * zc_pow[64 + i] * SYZ;
             phi_tmp[640 + i] += 20.0 * zc_pow[32 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
         }
 
@@ -6522,19 +6453,17 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[640 + i] += 3.0 * 5.0 * zc_pow[64 + i] * SZZ;
             phi_tmp[640 + i] += 3.0 * 20.0 * zc_pow[32 + i] * SZ;
             phi_tmp[640 + i] += 60.0 * zc_pow[i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -6549,11 +6478,18 @@ void gg_collocation_L5_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
-
+void gg_collocation_L6_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -6563,12 +6499,12 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 288 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((288 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -6589,19 +6525,19 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
     ASSUME_ALIGNED(S3, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
-    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate power temporaries
-    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, 160 * sizeof(double));
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((160 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(xc_pow, 64);
-    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, 160 * sizeof(double));
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((160 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(yc_pow, 64);
-    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, 160 * sizeof(double));
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((160 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(zc_pow, 64);
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 896 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((896 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -6617,8 +6553,6 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -6645,8 +6579,8 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
                 S2[i] = 0.0;
                 S3[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -6685,13 +6619,11 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
                 const double T4 = alpha_n2 * T3;
                 S3[i] += T4;
             }
-
         }
 
         // Build powers
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             xc_pow[i] = xc[i] * xc[i];
             yc_pow[i] = yc[i] * yc[i];
@@ -6712,7 +6644,6 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
         // Combine A blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             phi_tmp[i] = xc_pow[128 + i] * S0[i];
             phi_tmp[32 + i] = xc_pow[96 + i] * yc[i] * S0[i];
             phi_tmp[64 + i] = xc_pow[96 + i] * zc[i] * S0[i];
@@ -6745,11 +6676,11 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
 
@@ -6834,16 +6765,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] = yc[i] * zc_pow[96 + i] * SX;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_x_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_x_out + start), npoints);
         }
 
@@ -6928,16 +6858,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] += zc_pow[96 + i] * S0[i];
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_y_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_y_out + start), npoints);
         }
 
@@ -7022,16 +6951,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SZ;
             phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_z_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_z_out + start), npoints);
         }
 
@@ -7132,16 +7060,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] = yc[i] * zc_pow[96 + i] * SXX;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
         }
 
@@ -7264,16 +7191,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] += zc_pow[96 + i] * SX;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
         }
 
@@ -7396,16 +7322,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SXZ;
             phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
         }
 
@@ -7506,16 +7431,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] += 2.0 * zc_pow[96 + i] * SY;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
         }
 
@@ -7638,16 +7562,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SYZ;
             phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
         }
 
@@ -7748,16 +7671,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[864 + i] = zc_pow[128 + i] * SZZ;
             phi_tmp[864 + i] += 12.0 * zc_pow[96 + i] * SZ;
             phi_tmp[864 + i] += 30.0 * zc_pow[64 + i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
         }
 
@@ -7869,16 +7791,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] = yc[i] * zc_pow[96 + i] * SXXX;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SXXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
         }
 
@@ -8028,16 +7949,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] += zc_pow[96 + i] * SXX;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SXXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
         }
 
@@ -8187,16 +8107,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SXXZ;
             phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * SXX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
         }
 
@@ -8346,16 +8265,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] += 2.0 * zc_pow[96 + i] * SXY;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SXYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
         }
 
@@ -8543,16 +8461,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SXYZ;
             phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * SXY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
         }
 
@@ -8702,16 +8619,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[864 + i] = zc_pow[128 + i] * SXZZ;
             phi_tmp[864 + i] += 2.0 * 6.0 * zc_pow[96 + i] * SXZ;
             phi_tmp[864 + i] += 30.0 * zc_pow[64 + i] * SX;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
         }
 
@@ -8823,16 +8739,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[832 + i] += 3.0 * zc_pow[96 + i] * SYY;
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SYYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
         }
 
@@ -8982,16 +8897,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
 
             phi_tmp[864 + i] = zc_pow[128 + i] * SYYZ;
             phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * SYY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
         }
 
@@ -9141,16 +9055,15 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[864 + i] = zc_pow[128 + i] * SYZZ;
             phi_tmp[864 + i] += 2.0 * 6.0 * zc_pow[96 + i] * SYZ;
             phi_tmp[864 + i] += 30.0 * zc_pow[64 + i] * SY;
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
         }
 
@@ -9262,19 +9175,17 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
             phi_tmp[864 + i] += 3.0 * 6.0 * zc_pow[96 + i] * SZZ;
             phi_tmp[864 + i] += 3.0 * 30.0 * zc_pow[64 + i] * SZ;
             phi_tmp[864 + i] += 120.0 * zc_pow[32 + i] * S0[i];
-
         }
 
         if (order == GG_SPHERICAL_CCA) {
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -9289,5 +9200,7716 @@ void gg_collocation_L6_deriv3(const unsigned long npoints, const double* PRAGMA_
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
+}
 
+void gg_collocation_L7_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
+    // Sizing
+    unsigned long nblocks = npoints / 32;
+    nblocks += (npoints % 32) ? 1 : 0;
+    const unsigned long ncart = 36;
+    const unsigned long nspherical = 15;
+    unsigned long nout;
+
+    if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
+        nout = nspherical;
+    } else {
+        nout = ncart;
+    }
+
+    // Allocate S temporaries, single block to stay on cache
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((288 * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT xc = cache_data + 0;
+    ASSUME_ALIGNED(xc, 64);
+    double* PRAGMA_RESTRICT yc = cache_data + 32;
+    ASSUME_ALIGNED(yc, 64);
+    double* PRAGMA_RESTRICT zc = cache_data + 64;
+    ASSUME_ALIGNED(zc, 64);
+    double* PRAGMA_RESTRICT R2 = cache_data + 96;
+    ASSUME_ALIGNED(R2, 64);
+    double* PRAGMA_RESTRICT S0 = cache_data + 128;
+    ASSUME_ALIGNED(S0, 64);
+    double* PRAGMA_RESTRICT tmp1 = cache_data + 160;
+    ASSUME_ALIGNED(tmp1, 64);
+    double* PRAGMA_RESTRICT S1 = cache_data + 192;
+    ASSUME_ALIGNED(S1, 64);
+    double* PRAGMA_RESTRICT S2 = cache_data + 224;
+    ASSUME_ALIGNED(S2, 64);
+    double* PRAGMA_RESTRICT S3 = cache_data + 256;
+    ASSUME_ALIGNED(S3, 64);
+
+    // Allocate exponential temporaries
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+
+    // Allocate power temporaries
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(xc_pow, 64);
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(yc_pow, 64);
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(zc_pow, 64);
+
+    // Allocate output temporaries
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((1152 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(phi_tmp, 64);
+
+    // Declare doubles
+    const double center_x = center[0];
+    const double center_y = center[1];
+    const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
+    double AXXX, XXY, XXZ, XYY, XYZ, XZZ, YYY, YYZ, YZZ, ZZZ;
+
+    // Build negative exponents
+    for (unsigned long i = 0; i < nprim; i++) {
+        expn1[i] = -1.0 * exponents[i];
+        expn2[i] = -2.0 * exponents[i];
+    }
+
+    // Start outer block loop
+    for (unsigned long block = 0; block < nblocks; block++) {
+        // Copy data into inner temps
+        const unsigned long start = block * 32;
+        const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
+
+        // Handle non-AM dependant temps
+        if (xyz_stride == 1) {
+            const double* PRAGMA_RESTRICT x = xyz + start;
+            const double* PRAGMA_RESTRICT y = xyz + npoints + start;
+            const double* PRAGMA_RESTRICT z = xyz + 2 * npoints + start;
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = x[i] - center_x;
+                yc[i] = y[i] - center_y;
+                zc[i] = z[i] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+                S2[i] = 0.0;
+                S3[i] = 0.0;
+            }
+        } else {
+            unsigned int start_shift = start * xyz_stride;
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = xyz[start_shift + i * xyz_stride] - center_x;
+                yc[i] = xyz[start_shift + i * xyz_stride + 1] - center_y;
+                zc[i] = xyz[start_shift + i * xyz_stride + 2] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+                S2[i] = 0.0;
+                S3[i] = 0.0;
+            }
+        }
+
+        // Start exponential block loop
+        for (unsigned long n = 0; n < nprim; n++) {
+            const double coef = coeffs[n];
+            const double alpha_n1 = expn1[n];
+            const double alpha_n2 = expn2[n];
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                const double width = alpha_n1 * R2[i];
+                const double T1 = coef * exp(width);
+                S0[i] += T1;
+                const double T2 = alpha_n2 * T1;
+                S1[i] += T2;
+                const double T3 = alpha_n2 * T2;
+                S2[i] += T3;
+                const double T4 = alpha_n2 * T3;
+                S3[i] += T4;
+            }
+        }
+
+        // Build powers
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            // Cartesian derivs
+            xc_pow[i] = xc[i] * xc[i];
+            yc_pow[i] = yc[i] * yc[i];
+            zc_pow[i] = zc[i] * zc[i];
+            xc_pow[32 + i] = xc_pow[i] * xc[i];
+            yc_pow[32 + i] = yc_pow[i] * yc[i];
+            zc_pow[32 + i] = zc_pow[i] * zc[i];
+            xc_pow[64 + i] = xc_pow[32 + i] * xc[i];
+            yc_pow[64 + i] = yc_pow[32 + i] * yc[i];
+            zc_pow[64 + i] = zc_pow[32 + i] * zc[i];
+            xc_pow[96 + i] = xc_pow[64 + i] * xc[i];
+            yc_pow[96 + i] = yc_pow[64 + i] * yc[i];
+            zc_pow[96 + i] = zc_pow[64 + i] * zc[i];
+            xc_pow[128 + i] = xc_pow[96 + i] * xc[i];
+            yc_pow[128 + i] = yc_pow[96 + i] * yc[i];
+            zc_pow[128 + i] = zc_pow[96 + i] * zc[i];
+            xc_pow[160 + i] = xc_pow[128 + i] * xc[i];
+            yc_pow[160 + i] = yc_pow[128 + i] * yc[i];
+            zc_pow[160 + i] = zc_pow[128 + i] * zc[i];
+        }
+        // Combine A blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            phi_tmp[i] = xc_pow[160 + i] * S0[i];
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * S0[i];
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * S0[i];
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * S0[i];
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * S0[i];
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * S0[i];
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * S0[i];
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[896 + i] = yc_pow[160 + i] * S0[i];
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * S0[i];
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * S0[i];
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[1120 + i] = zc_pow[160 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        }
+
+        // Combine X blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SX;
+            phi_tmp[i] += 7.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SX;
+            phi_tmp[480 + i] += 2.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[640 + i] += 2.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SX;
+            phi_tmp[672 + i] += yc_pow[128 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[864 + i] += zc_pow[128 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SX;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        }
+
+        // Combine Y blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += xc_pow[128 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SY;
+            phi_tmp[672 + i] += 6.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[832 + i] += xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SY;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        }
+
+        // Combine Z blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += xc_pow[128 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[864 + i] += 6.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        }
+
+        // Combine XX blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SXX = S2[i] * xc[i] * xc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXX;
+            phi_tmp[i] += 14.0 * xc_pow[128 + i] * SX;
+            phi_tmp[i] += 42.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXX;
+            phi_tmp[32 + i] += 12.0 * xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 30.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXX;
+            phi_tmp[64 + i] += 12.0 * xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 30.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXX;
+            phi_tmp[96 + i] += 10.0 * xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 20.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXX;
+            phi_tmp[128 + i] += 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 20.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXX;
+            phi_tmp[160 + i] += 10.0 * xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 20.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXX;
+            phi_tmp[192 + i] += 8.0 * xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXX;
+            phi_tmp[224 + i] += 8.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXX;
+            phi_tmp[256 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[288 + i] += 8.0 * xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 12.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXX;
+            phi_tmp[320 + i] += 6.0 * xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 6.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXX;
+            phi_tmp[352 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXX;
+            phi_tmp[384 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[416 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 6.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXX;
+            phi_tmp[448 + i] += 6.0 * xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 6.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXX;
+            phi_tmp[480 + i] += 4.0 * xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[480 + i] += 2.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXX;
+            phi_tmp[512 + i] += 4.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 2.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXX;
+            phi_tmp[544 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 2.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[576 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 2.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[608 + i] += 4.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 2.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[640 + i] += 4.0 * xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[640 + i] += 2.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXX;
+            phi_tmp[672 + i] += 2.0 * yc_pow[128 + i] * SX;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXX;
+            phi_tmp[704 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXX;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[768 + i] += 2.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[800 + i] += 2.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[832 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXX;
+            phi_tmp[864 + i] += 2.0 * zc_pow[128 + i] * SX;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXX;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        }
+
+        // Combine XY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SY = S1[i] * yc[i];
+            const double SXY = S2[i] * xc[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXY;
+            phi_tmp[i] += 7.0 * xc_pow[128 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXY;
+            phi_tmp[32 + i] += xc_pow[128 + i] * SX;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[96 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 10.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXY;
+            phi_tmp[128 + i] += xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[160 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[192 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXY;
+            phi_tmp[256 + i] += xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[288 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[320 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[416 + i] += xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[448 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[480 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 10.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 4.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[608 + i] += xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += 2.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[640 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXY;
+            phi_tmp[672 + i] += 6.0 * xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[672 + i] += yc_pow[128 + i] * SY;
+            phi_tmp[672 + i] += 6.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 5.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 4.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 3.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[832 + i] += xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[832 + i] += zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[864 + i] += zc_pow[128 + i] * SY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXY;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * SX;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * SX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        }
+
+        // Combine XZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SXZ = S2[i] * xc[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXZ;
+            phi_tmp[i] += 7.0 * xc_pow[128 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXZ;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[64 + i] += xc_pow[128 + i] * SX;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXZ;
+            phi_tmp[96 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[160 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 10.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXZ;
+            phi_tmp[192 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXZ;
+            phi_tmp[224 + i] += xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[288 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 12.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXZ;
+            phi_tmp[320 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXZ;
+            phi_tmp[352 + i] += xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[384 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 9.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[448 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 12.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXZ;
+            phi_tmp[480 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXZ;
+            phi_tmp[512 + i] += xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[544 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[576 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[608 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 8.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[640 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 10.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXZ;
+            phi_tmp[672 + i] += yc_pow[128 + i] * SZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[704 + i] += xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[704 + i] += yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += yc_pow[96 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[736 + i] += yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[768 + i] += yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 3.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[800 + i] += yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 4.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[832 + i] += yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[864 + i] += 6.0 * xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[864 + i] += zc_pow[128 + i] * SZ;
+            phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * SX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        }
+
+        // Combine YY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SYY = S2[i] * yc[i] * yc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SYY;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SYY;
+            phi_tmp[32 + i] += 2.0 * xc_pow[128 + i] * SY;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SYY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SYY;
+            phi_tmp[96 + i] += 4.0 * xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SYY;
+            phi_tmp[128 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SYY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SYY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SYY;
+            phi_tmp[224 + i] += 4.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SYY;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SYY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SYY;
+            phi_tmp[320 + i] += 8.0 * xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[320 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYY;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[416 + i] += 2.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SYY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SYY;
+            phi_tmp[480 + i] += 10.0 * xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[480 + i] += 20.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SYY;
+            phi_tmp[512 + i] += 8.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[576 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[608 + i] += 2.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SYY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SYY;
+            phi_tmp[672 + i] += 12.0 * xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[672 + i] += 30.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SYY;
+            phi_tmp[704 + i] += 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 20.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SYY;
+            phi_tmp[736 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[832 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SYY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SYY;
+            phi_tmp[896 + i] += 14.0 * yc_pow[128 + i] * SY;
+            phi_tmp[896 + i] += 42.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SYY;
+            phi_tmp[928 + i] += 12.0 * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 30.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SYY;
+            phi_tmp[960 + i] += 10.0 * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 20.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[992 + i] += 8.0 * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 12.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1024 + i] += 6.0 * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 6.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1056 + i] += 4.0 * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SYY;
+            phi_tmp[1088 + i] += 2.0 * zc_pow[128 + i] * SY;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SYY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        }
+
+        // Combine YZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SYZ = S2[i] * yc[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SYZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SYZ;
+            phi_tmp[32 + i] += xc_pow[128 + i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[64 + i] += xc_pow[128 + i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SYZ;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SYZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SYZ;
+            phi_tmp[192 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SYZ;
+            phi_tmp[224 + i] += xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SYZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[256 + i] += xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SYZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYZ;
+            phi_tmp[352 + i] += xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[416 + i] += xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SYZ;
+            phi_tmp[480 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SYZ;
+            phi_tmp[512 + i] += xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[608 + i] += xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SYZ;
+            phi_tmp[672 + i] += 6.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[704 + i] += xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 9.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 8.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[832 + i] += xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[864 + i] += 6.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SYZ;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * SZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * SY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 10.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 12.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 12.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 10.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SYZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        }
+
+        // Combine ZZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+            const double SZZ = S2[i] * zc[i] * zc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SZZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SZZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[64 + i] += 2.0 * xc_pow[128 + i] * SZ;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SZZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SZZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[160 + i] += 4.0 * xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SZZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SZZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SZZ;
+            phi_tmp[256 + i] += 4.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SZZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZZ;
+            phi_tmp[352 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[448 + i] += 8.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[448 + i] += 12.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SZZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SZZ;
+            phi_tmp[512 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZZ;
+            phi_tmp[544 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[608 + i] += 8.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[640 + i] += 10.0 * xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[640 + i] += 20.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SZZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[800 + i] += 8.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[800 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[832 + i] += 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[832 + i] += 20.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[864 + i] += 12.0 * xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[864 + i] += 30.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SZZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[928 + i] += 2.0 * yc_pow[128 + i] * SZ;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[960 + i] += 4.0 * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[992 + i] += 6.0 * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[992 + i] += 6.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1024 + i] += 8.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1024 + i] += 12.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1056 + i] += 10.0 * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1056 + i] += 20.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[1088 + i] += 12.0 * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1088 + i] += 30.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SZZ;
+            phi_tmp[1120 + i] += 14.0 * zc_pow[128 + i] * SZ;
+            phi_tmp[1120 + i] += 42.0 * zc_pow[96 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        }
+
+        // Combine XXX blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SXX = S2[i] * xc[i] * xc[i] + S1[i];
+            const double SXXX = S3[i] * xc[i] * xc[i] * xc[i] + 3 * xc[i] * S2[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXXX;
+            phi_tmp[i] += 3.0 * 7.0 * xc_pow[128 + i] * SXX;
+            phi_tmp[i] += 3.0 * 42.0 * xc_pow[96 + i] * SX;
+            phi_tmp[i] += 210.0 * xc_pow[64 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXXX;
+            phi_tmp[32 + i] += 3.0 * 6.0 * xc_pow[96 + i] * yc[i] * SXX;
+            phi_tmp[32 + i] += 3.0 * 30.0 * xc_pow[64 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 120.0 * xc_pow[32 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXXX;
+            phi_tmp[64 + i] += 3.0 * 6.0 * xc_pow[96 + i] * zc[i] * SXX;
+            phi_tmp[64 + i] += 3.0 * 30.0 * xc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 120.0 * xc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXXX;
+            phi_tmp[96 + i] += 3.0 * 5.0 * xc_pow[64 + i] * yc_pow[i] * SXX;
+            phi_tmp[96 + i] += 3.0 * 20.0 * xc_pow[32 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 60.0 * xc_pow[i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXXX;
+            phi_tmp[128 + i] += 3.0 * 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * SXX;
+            phi_tmp[128 + i] += 3.0 * 20.0 * xc_pow[32 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 60.0 * xc_pow[i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXXX;
+            phi_tmp[160 + i] += 3.0 * 5.0 * xc_pow[64 + i] * zc_pow[i] * SXX;
+            phi_tmp[160 + i] += 3.0 * 20.0 * xc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 60.0 * xc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXXX;
+            phi_tmp[192 + i] += 3.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SXX;
+            phi_tmp[192 + i] += 3.0 * 12.0 * xc_pow[i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 24.0 * xc[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXXX;
+            phi_tmp[224 + i] += 3.0 * 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SXX;
+            phi_tmp[224 + i] += 3.0 * 12.0 * xc_pow[i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 24.0 * xc[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXXX;
+            phi_tmp[256 + i] += 3.0 * 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SXX;
+            phi_tmp[256 + i] += 3.0 * 12.0 * xc_pow[i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 24.0 * xc[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXXX;
+            phi_tmp[288 + i] += 3.0 * 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[288 + i] += 3.0 * 12.0 * xc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 24.0 * xc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXXX;
+            phi_tmp[320 + i] += 3.0 * 3.0 * xc_pow[i] * yc_pow[64 + i] * SXX;
+            phi_tmp[320 + i] += 3.0 * 6.0 * xc[i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 6.0 * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXXX;
+            phi_tmp[352 + i] += 3.0 * 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SXX;
+            phi_tmp[352 + i] += 3.0 * 6.0 * xc[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 6.0 * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXXX;
+            phi_tmp[384 + i] += 3.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SXX;
+            phi_tmp[384 + i] += 3.0 * 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 6.0 * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXXX;
+            phi_tmp[416 + i] += 3.0 * 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[416 + i] += 3.0 * 6.0 * xc[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 6.0 * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXXX;
+            phi_tmp[448 + i] += 3.0 * 3.0 * xc_pow[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[448 + i] += 3.0 * 6.0 * xc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 6.0 * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXXX;
+            phi_tmp[480 + i] += 3.0 * 2.0 * xc[i] * yc_pow[96 + i] * SXX;
+            phi_tmp[480 + i] += 3.0 * 2.0 * yc_pow[96 + i] * SX;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXXX;
+            phi_tmp[512 + i] += 3.0 * 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SXX;
+            phi_tmp[512 + i] += 3.0 * 2.0 * yc_pow[64 + i] * zc[i] * SX;
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXXX;
+            phi_tmp[544 + i] += 3.0 * 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SXX;
+            phi_tmp[544 + i] += 3.0 * 2.0 * yc_pow[32 + i] * zc_pow[i] * SX;
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXXX;
+            phi_tmp[576 + i] += 3.0 * 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[576 + i] += 3.0 * 2.0 * yc_pow[i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXXX;
+            phi_tmp[608 + i] += 3.0 * 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[608 + i] += 3.0 * 2.0 * yc[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXXX;
+            phi_tmp[640 + i] += 3.0 * 2.0 * xc[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[640 + i] += 3.0 * 2.0 * zc_pow[96 + i] * SX;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXXX;
+            phi_tmp[672 + i] += 3.0 * yc_pow[128 + i] * SXX;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXXX;
+            phi_tmp[704 + i] += 3.0 * yc_pow[96 + i] * zc[i] * SXX;
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXXX;
+            phi_tmp[736 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * SXX;
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXXX;
+            phi_tmp[768 + i] += 3.0 * yc_pow[32 + i] * zc_pow[32 + i] * SXX;
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXXX;
+            phi_tmp[800 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * SXX;
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXXX;
+            phi_tmp[832 + i] += 3.0 * yc[i] * zc_pow[96 + i] * SXX;
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXXX;
+            phi_tmp[864 + i] += 3.0 * zc_pow[128 + i] * SXX;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXXX;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXXX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXXX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXXX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXXX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXXX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXXX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXXX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
+        }
+
+        // Combine XXY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SY = S1[i] * yc[i];
+            const double SXY = S2[i] * xc[i] * yc[i];
+            const double SXX = S2[i] * xc[i] * xc[i] + S1[i];
+            const double SXXY = S3[i] * xc[i] * xc[i] * yc[i] + S2[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXXY;
+            phi_tmp[i] += 2.0 * 7.0 * xc_pow[128 + i] * SXY;
+            phi_tmp[i] += 42.0 * xc_pow[96 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXXY;
+            phi_tmp[32 + i] += 2.0 * 6.0 * xc_pow[96 + i] * yc[i] * SXY;
+            phi_tmp[32 + i] += xc_pow[128 + i] * SXX;
+            phi_tmp[32 + i] += 30.0 * xc_pow[64 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += 2.0 * 6.0 * xc_pow[96 + i] * SX;
+            phi_tmp[32 + i] += 30.0 * xc_pow[64 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXXY;
+            phi_tmp[64 + i] += 2.0 * 6.0 * xc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[64 + i] += 30.0 * xc_pow[64 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXXY;
+            phi_tmp[96 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc_pow[i] * SXY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SXX;
+            phi_tmp[96 + i] += 20.0 * xc_pow[32 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 2.0 * 10.0 * xc_pow[64 + i] * yc[i] * SX;
+            phi_tmp[96 + i] += 40.0 * xc_pow[32 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXXY;
+            phi_tmp[128 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * SXY;
+            phi_tmp[128 + i] += xc_pow[96 + i] * zc[i] * SXX;
+            phi_tmp[128 + i] += 20.0 * xc_pow[32 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += 2.0 * 5.0 * xc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[128 + i] += 20.0 * xc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXXY;
+            phi_tmp[160 + i] += 2.0 * 5.0 * xc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[160 + i] += 20.0 * xc_pow[32 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXXY;
+            phi_tmp[192 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SXY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * SXX;
+            phi_tmp[192 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 2.0 * 12.0 * xc_pow[32 + i] * yc_pow[i] * SX;
+            phi_tmp[192 + i] += 36.0 * xc_pow[i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXXY;
+            phi_tmp[224 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SXY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SXX;
+            phi_tmp[224 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * 8.0 * xc_pow[32 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 24.0 * xc_pow[i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXXY;
+            phi_tmp[256 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SXY;
+            phi_tmp[256 + i] += xc_pow[64 + i] * zc_pow[i] * SXX;
+            phi_tmp[256 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 12.0 * xc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXXY;
+            phi_tmp[288 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[288 + i] += 12.0 * xc_pow[i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXXY;
+            phi_tmp[320 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[64 + i] * SXY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SXX;
+            phi_tmp[320 + i] += 6.0 * xc[i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 2.0 * 12.0 * xc_pow[i] * yc_pow[32 + i] * SX;
+            phi_tmp[320 + i] += 24.0 * xc[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXXY;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SXY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SXX;
+            phi_tmp[352 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 2.0 * 9.0 * xc_pow[i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[352 + i] += 18.0 * xc[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXXY;
+            phi_tmp[384 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SXY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SXX;
+            phi_tmp[384 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 12.0 * xc[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXXY;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[416 + i] += xc_pow[32 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[416 + i] += 6.0 * xc[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 6.0 * xc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXXY;
+            phi_tmp[448 + i] += 2.0 * 3.0 * xc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[448 + i] += 6.0 * xc[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXXY;
+            phi_tmp[480 + i] += 2.0 * 2.0 * xc[i] * yc_pow[96 + i] * SXY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * SXX;
+            phi_tmp[480 + i] += 2.0 * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 2.0 * 10.0 * xc[i] * yc_pow[64 + i] * SX;
+            phi_tmp[480 + i] += 10.0 * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXXY;
+            phi_tmp[512 + i] += 2.0 * 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SXY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SXX;
+            phi_tmp[512 + i] += 2.0 * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 2.0 * 8.0 * xc[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 8.0 * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXXY;
+            phi_tmp[544 + i] += 2.0 * 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SXY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SXX;
+            phi_tmp[544 + i] += 2.0 * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 2.0 * 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 6.0 * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXXY;
+            phi_tmp[576 + i] += 2.0 * 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[576 + i] += 2.0 * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * 4.0 * xc[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 4.0 * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXXY;
+            phi_tmp[608 + i] += 2.0 * 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[608 + i] += xc_pow[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[608 + i] += 2.0 * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += 2.0 * 2.0 * xc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 2.0 * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXXY;
+            phi_tmp[640 + i] += 2.0 * 2.0 * xc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[640 + i] += 2.0 * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXXY;
+            phi_tmp[672 + i] += 2.0 * yc_pow[128 + i] * SXY;
+            phi_tmp[672 + i] += 6.0 * xc[i] * yc_pow[96 + i] * SXX;
+            phi_tmp[672 + i] += 2.0 * 6.0 * yc_pow[96 + i] * SX;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXXY;
+            phi_tmp[704 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * SXX;
+            phi_tmp[704 + i] += 2.0 * 5.0 * yc_pow[64 + i] * zc[i] * SX;
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXXY;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SXX;
+            phi_tmp[736 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[i] * SX;
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXXY;
+            phi_tmp[768 + i] += 2.0 * yc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[768 + i] += 2.0 * 3.0 * yc_pow[i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXXY;
+            phi_tmp[800 + i] += 2.0 * yc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[800 + i] += 2.0 * 2.0 * yc[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXXY;
+            phi_tmp[832 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[832 + i] += xc[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[832 + i] += 2.0 * zc_pow[96 + i] * SX;
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXXY;
+            phi_tmp[864 + i] += 2.0 * zc_pow[128 + i] * SXY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXXY;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * SXX;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXXY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * SXX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXXY;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * SXX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXXY;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SXX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXXY;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * SXX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXXY;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SXX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXXY;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * SXX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXXY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
+        }
+
+        // Combine XXZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SXZ = S2[i] * xc[i] * zc[i];
+            const double SXX = S2[i] * xc[i] * xc[i] + S1[i];
+            const double SXXZ = S3[i] * xc[i] * xc[i] * zc[i] + S2[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXXZ;
+            phi_tmp[i] += 2.0 * 7.0 * xc_pow[128 + i] * SXZ;
+            phi_tmp[i] += 42.0 * xc_pow[96 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXXZ;
+            phi_tmp[32 + i] += 2.0 * 6.0 * xc_pow[96 + i] * yc[i] * SXZ;
+            phi_tmp[32 + i] += 30.0 * xc_pow[64 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXXZ;
+            phi_tmp[64 + i] += 2.0 * 6.0 * xc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[64 + i] += xc_pow[128 + i] * SXX;
+            phi_tmp[64 + i] += 30.0 * xc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += 2.0 * 6.0 * xc_pow[96 + i] * SX;
+            phi_tmp[64 + i] += 30.0 * xc_pow[64 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXXZ;
+            phi_tmp[96 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc_pow[i] * SXZ;
+            phi_tmp[96 + i] += 20.0 * xc_pow[32 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXXZ;
+            phi_tmp[128 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * SXZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * yc[i] * SXX;
+            phi_tmp[128 + i] += 20.0 * xc_pow[32 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc[i] * SX;
+            phi_tmp[128 + i] += 20.0 * xc_pow[32 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXXZ;
+            phi_tmp[160 + i] += 2.0 * 5.0 * xc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SXX;
+            phi_tmp[160 + i] += 20.0 * xc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * 10.0 * xc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[160 + i] += 40.0 * xc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXXZ;
+            phi_tmp[192 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SXZ;
+            phi_tmp[192 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXXZ;
+            phi_tmp[224 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SXZ;
+            phi_tmp[224 + i] += xc_pow[64 + i] * yc_pow[i] * SXX;
+            phi_tmp[224 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[i] * SX;
+            phi_tmp[224 + i] += 12.0 * xc_pow[i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXXZ;
+            phi_tmp[256 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SXZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SXX;
+            phi_tmp[256 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * 8.0 * xc_pow[32 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[256 + i] += 24.0 * xc_pow[i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXXZ;
+            phi_tmp[288 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * SXX;
+            phi_tmp[288 + i] += 12.0 * xc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 2.0 * 12.0 * xc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[288 + i] += 36.0 * xc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXXZ;
+            phi_tmp[320 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[64 + i] * SXZ;
+            phi_tmp[320 + i] += 6.0 * xc[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXXZ;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SXZ;
+            phi_tmp[352 + i] += xc_pow[32 + i] * yc_pow[32 + i] * SXX;
+            phi_tmp[352 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[32 + i] * SX;
+            phi_tmp[352 + i] += 6.0 * xc[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXXZ;
+            phi_tmp[384 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SXZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SXX;
+            phi_tmp[384 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[384 + i] += 12.0 * xc[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXXZ;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SXX;
+            phi_tmp[416 + i] += 6.0 * xc[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 2.0 * 9.0 * xc_pow[i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[416 + i] += 18.0 * xc[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXXZ;
+            phi_tmp[448 + i] += 2.0 * 3.0 * xc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[448 + i] += 6.0 * xc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 2.0 * 12.0 * xc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[448 + i] += 24.0 * xc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXXZ;
+            phi_tmp[480 + i] += 2.0 * 2.0 * xc[i] * yc_pow[96 + i] * SXZ;
+            phi_tmp[480 + i] += 2.0 * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXXZ;
+            phi_tmp[512 + i] += 2.0 * 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SXZ;
+            phi_tmp[512 + i] += xc_pow[i] * yc_pow[64 + i] * SXX;
+            phi_tmp[512 + i] += 2.0 * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 2.0 * 2.0 * xc[i] * yc_pow[64 + i] * SX;
+            phi_tmp[512 + i] += 2.0 * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXXZ;
+            phi_tmp[544 + i] += 2.0 * 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SXZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SXX;
+            phi_tmp[544 + i] += 2.0 * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * 4.0 * xc[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[544 + i] += 4.0 * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXXZ;
+            phi_tmp[576 + i] += 2.0 * 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SXX;
+            phi_tmp[576 + i] += 2.0 * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 2.0 * 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[576 + i] += 6.0 * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXXZ;
+            phi_tmp[608 + i] += 2.0 * 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[608 + i] += 2.0 * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 2.0 * 8.0 * xc[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[608 + i] += 8.0 * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXXZ;
+            phi_tmp[640 + i] += 2.0 * 2.0 * xc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[640 + i] += 2.0 * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 2.0 * 10.0 * xc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[640 + i] += 10.0 * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXXZ;
+            phi_tmp[672 + i] += 2.0 * yc_pow[128 + i] * SXZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXXZ;
+            phi_tmp[704 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[704 + i] += xc[i] * yc_pow[96 + i] * SXX;
+            phi_tmp[704 + i] += 2.0 * yc_pow[96 + i] * SX;
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXXZ;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SXX;
+            phi_tmp[736 + i] += 2.0 * 2.0 * yc_pow[64 + i] * zc[i] * SX;
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXXZ;
+            phi_tmp[768 + i] += 2.0 * yc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SXX;
+            phi_tmp[768 + i] += 2.0 * 3.0 * yc_pow[32 + i] * zc_pow[i] * SX;
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXXZ;
+            phi_tmp[800 + i] += 2.0 * yc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[800 + i] += 2.0 * 4.0 * yc_pow[i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXXZ;
+            phi_tmp[832 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[832 + i] += 2.0 * 5.0 * yc[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXXZ;
+            phi_tmp[864 + i] += 2.0 * zc_pow[128 + i] * SXZ;
+            phi_tmp[864 + i] += 6.0 * xc[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[864 + i] += 2.0 * 6.0 * zc_pow[96 + i] * SX;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXXZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXXZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * SXX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXXZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SXX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXXZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * SXX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXXZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SXX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXXZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * SXX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXXZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * SXX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXXZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * SXX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
+        }
+
+        // Combine XYY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SY = S1[i] * yc[i];
+            const double SXY = S2[i] * xc[i] * yc[i];
+            const double SYY = S2[i] * yc[i] * yc[i] + S1[i];
+            const double SXYY = S3[i] * xc[i] * yc[i] * yc[i] + S2[i] * xc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXYY;
+            phi_tmp[i] += 7.0 * xc_pow[128 + i] * SYY;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXYY;
+            phi_tmp[32 + i] += 2.0 * xc_pow[128 + i] * SXY;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * yc[i] * SYY;
+            phi_tmp[32 + i] += 2.0 * 6.0 * xc_pow[96 + i] * SY;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXYY;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * zc[i] * SYY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXYY;
+            phi_tmp[96 + i] += 2.0 * 2.0 * xc_pow[96 + i] * yc[i] * SXY;
+            phi_tmp[96 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * SYY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * SX;
+            phi_tmp[96 + i] += 2.0 * 10.0 * xc_pow[64 + i] * yc[i] * SY;
+            phi_tmp[96 + i] += 10.0 * xc_pow[64 + i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXYY;
+            phi_tmp[128 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * SYY;
+            phi_tmp[128 + i] += 2.0 * 5.0 * xc_pow[64 + i] * zc[i] * SY;
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXYY;
+            phi_tmp[160 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * SYY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXYY;
+            phi_tmp[192 + i] += 2.0 * 3.0 * xc_pow[64 + i] * yc_pow[i] * SXY;
+            phi_tmp[192 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SYY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[64 + i] * yc[i] * SX;
+            phi_tmp[192 + i] += 2.0 * 12.0 * xc_pow[32 + i] * yc_pow[i] * SY;
+            phi_tmp[192 + i] += 24.0 * xc_pow[32 + i] * yc[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXYY;
+            phi_tmp[224 + i] += 2.0 * 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SXY;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SYY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[224 + i] += 2.0 * 8.0 * xc_pow[32 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 8.0 * xc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXYY;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SYY;
+            phi_tmp[256 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[i] * SY;
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXYY;
+            phi_tmp[288 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SYY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXYY;
+            phi_tmp[320 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SXY;
+            phi_tmp[320 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * SYY;
+            phi_tmp[320 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * SX;
+            phi_tmp[320 + i] += 2.0 * 12.0 * xc_pow[i] * yc_pow[32 + i] * SY;
+            phi_tmp[320 + i] += 36.0 * xc_pow[i] * yc_pow[i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXYY;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SXY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SYY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[352 + i] += 2.0 * 9.0 * xc_pow[i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[352 + i] += 18.0 * xc_pow[i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXYY;
+            phi_tmp[384 + i] += 2.0 * 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SXY;
+            phi_tmp[384 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SYY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 2.0 * 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 6.0 * xc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXYY;
+            phi_tmp[416 + i] += 2.0 * xc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXYY;
+            phi_tmp[448 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * SYY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXYY;
+            phi_tmp[480 + i] += 2.0 * 5.0 * xc_pow[i] * yc_pow[64 + i] * SXY;
+            phi_tmp[480 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SYY;
+            phi_tmp[480 + i] += 20.0 * xc_pow[i] * yc_pow[32 + i] * SX;
+            phi_tmp[480 + i] += 2.0 * 10.0 * xc[i] * yc_pow[64 + i] * SY;
+            phi_tmp[480 + i] += 40.0 * xc[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXYY;
+            phi_tmp[512 + i] += 2.0 * 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SXY;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SYY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[512 + i] += 2.0 * 8.0 * xc[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 24.0 * xc[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXYY;
+            phi_tmp[544 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SXY;
+            phi_tmp[544 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SYY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 2.0 * 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 12.0 * xc[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXYY;
+            phi_tmp[576 + i] += 2.0 * 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[576 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 2.0 * 4.0 * xc[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 4.0 * xc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXYY;
+            phi_tmp[608 + i] += 2.0 * xc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[608 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[608 + i] += 2.0 * 2.0 * xc[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXYY;
+            phi_tmp[640 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SYY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXYY;
+            phi_tmp[672 + i] += 2.0 * 6.0 * xc[i] * yc_pow[96 + i] * SXY;
+            phi_tmp[672 + i] += yc_pow[128 + i] * SYY;
+            phi_tmp[672 + i] += 30.0 * xc[i] * yc_pow[64 + i] * SX;
+            phi_tmp[672 + i] += 2.0 * 6.0 * yc_pow[96 + i] * SY;
+            phi_tmp[672 + i] += 30.0 * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXYY;
+            phi_tmp[704 + i] += 2.0 * 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * SXY;
+            phi_tmp[704 + i] += yc_pow[96 + i] * zc[i] * SYY;
+            phi_tmp[704 + i] += 20.0 * xc[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += 2.0 * 5.0 * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 20.0 * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXYY;
+            phi_tmp[736 + i] += 2.0 * 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SXY;
+            phi_tmp[736 + i] += yc_pow[64 + i] * zc_pow[i] * SYY;
+            phi_tmp[736 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 12.0 * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXYY;
+            phi_tmp[768 + i] += 2.0 * 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[768 + i] += yc_pow[32 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += 2.0 * 3.0 * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 6.0 * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXYY;
+            phi_tmp[800 + i] += 2.0 * 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[800 + i] += yc_pow[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += 2.0 * 2.0 * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXYY;
+            phi_tmp[832 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[832 + i] += yc[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[832 + i] += 2.0 * zc_pow[96 + i] * SY;
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXYY;
+            phi_tmp[864 + i] += zc_pow[128 + i] * SYY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXYY;
+            phi_tmp[896 + i] += 2.0 * 7.0 * yc_pow[128 + i] * SXY;
+            phi_tmp[896 + i] += 42.0 * yc_pow[96 + i] * SX;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXYY;
+            phi_tmp[928 + i] += 2.0 * 6.0 * yc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[928 + i] += 30.0 * yc_pow[64 + i] * zc[i] * SX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXYY;
+            phi_tmp[960 + i] += 2.0 * 5.0 * yc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[960 + i] += 20.0 * yc_pow[32 + i] * zc_pow[i] * SX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXYY;
+            phi_tmp[992 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[992 + i] += 12.0 * yc_pow[i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXYY;
+            phi_tmp[1024 + i] += 2.0 * 3.0 * yc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1024 + i] += 6.0 * yc[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXYY;
+            phi_tmp[1056 + i] += 2.0 * 2.0 * yc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1056 + i] += 2.0 * zc_pow[96 + i] * SX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXYY;
+            phi_tmp[1088 + i] += 2.0 * zc_pow[128 + i] * SXY;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXYY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
+        }
+
+        // Combine XYZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SY = S1[i] * yc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SXY = S2[i] * xc[i] * yc[i];
+            const double SXZ = S2[i] * xc[i] * zc[i];
+            const double SYZ = S2[i] * yc[i] * zc[i];
+            const double SXYZ = S3[i] * xc[i] * yc[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXYZ;
+            phi_tmp[i] += 7.0 * xc_pow[128 + i] * SYZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXYZ;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * yc[i] * SYZ;
+            phi_tmp[32 + i] += xc_pow[128 + i] * SXZ;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXYZ;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[64 + i] += xc_pow[128 + i] * SXY;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXYZ;
+            phi_tmp[96 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * SYZ;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SXZ;
+            phi_tmp[96 + i] += 10.0 * xc_pow[64 + i] * yc[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXYZ;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * SYZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * yc[i] * SXY;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[96 + i] * SX;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXYZ;
+            phi_tmp[160 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[160 + i] += 10.0 * xc_pow[64 + i] * zc[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXYZ;
+            phi_tmp[192 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SYZ;
+            phi_tmp[192 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * SXZ;
+            phi_tmp[192 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXYZ;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SYZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SXZ;
+            phi_tmp[224 + i] += xc_pow[64 + i] * yc_pow[i] * SXY;
+            phi_tmp[224 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * SX;
+            phi_tmp[224 + i] += 16.0 * xc_pow[32 + i] * yc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXYZ;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SYZ;
+            phi_tmp[256 + i] += xc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SXY;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXYZ;
+            phi_tmp[288 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[288 + i] += 12.0 * xc_pow[32 + i] * zc_pow[i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXYZ;
+            phi_tmp[320 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * SYZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SXZ;
+            phi_tmp[320 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXYZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SYZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SXZ;
+            phi_tmp[352 + i] += xc_pow[32 + i] * yc_pow[32 + i] * SXY;
+            phi_tmp[352 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * SX;
+            phi_tmp[352 + i] += 27.0 * xc_pow[i] * yc_pow[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXYZ;
+            phi_tmp[384 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SYZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SXZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SXY;
+            phi_tmp[384 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[384 + i] += 12.0 * xc_pow[i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXYZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[416 + i] += xc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SXY;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 9.0 * xc_pow[i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXYZ;
+            phi_tmp[448 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[448 + i] += 12.0 * xc_pow[i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXYZ;
+            phi_tmp[480 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SYZ;
+            phi_tmp[480 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * SXZ;
+            phi_tmp[480 + i] += 10.0 * xc[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXYZ;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SYZ;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SXZ;
+            phi_tmp[512 + i] += xc_pow[i] * yc_pow[64 + i] * SXY;
+            phi_tmp[512 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * SX;
+            phi_tmp[512 + i] += 32.0 * xc[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXYZ;
+            phi_tmp[544 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SYZ;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SXZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SXY;
+            phi_tmp[544 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[544 + i] += 18.0 * xc[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXYZ;
+            phi_tmp[576 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SXY;
+            phi_tmp[576 + i] += 4.0 * xc[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[576 + i] += 8.0 * xc[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXYZ;
+            phi_tmp[608 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[608 + i] += xc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[608 + i] += 2.0 * xc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 8.0 * xc[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[608 + i] += 2.0 * xc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXYZ;
+            phi_tmp[640 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[640 + i] += 10.0 * xc[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXYZ;
+            phi_tmp[672 + i] += yc_pow[128 + i] * SYZ;
+            phi_tmp[672 + i] += 6.0 * xc[i] * yc_pow[96 + i] * SXZ;
+            phi_tmp[672 + i] += 6.0 * yc_pow[96 + i] * SZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXYZ;
+            phi_tmp[704 + i] += yc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * SXZ;
+            phi_tmp[704 + i] += xc[i] * yc_pow[96 + i] * SXY;
+            phi_tmp[704 + i] += 5.0 * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += yc_pow[96 + i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * SX;
+            phi_tmp[704 + i] += 25.0 * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXYZ;
+            phi_tmp[736 + i] += yc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SXZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SXY;
+            phi_tmp[736 + i] += 4.0 * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[736 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[736 + i] += 16.0 * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXYZ;
+            phi_tmp[768 + i] += yc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SXY;
+            phi_tmp[768 + i] += 3.0 * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 3.0 * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[768 + i] += 9.0 * xc[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[768 + i] += 9.0 * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXYZ;
+            phi_tmp[800 + i] += yc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[800 + i] += 2.0 * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 4.0 * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[800 + i] += 8.0 * xc[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[800 + i] += 4.0 * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXYZ;
+            phi_tmp[832 + i] += yc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[832 + i] += xc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[832 + i] += zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[832 + i] += 5.0 * xc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[832 + i] += zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXYZ;
+            phi_tmp[864 + i] += zc_pow[128 + i] * SYZ;
+            phi_tmp[864 + i] += 6.0 * xc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[864 + i] += 6.0 * zc_pow[96 + i] * SY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXYZ;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * SXZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXYZ;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * SXY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * SX;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXYZ;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[960 + i] += 10.0 * yc_pow[64 + i] * zc[i] * SX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXYZ;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[992 + i] += 12.0 * yc_pow[32 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXYZ;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[1024 + i] += 12.0 * yc_pow[i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXYZ;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1056 + i] += 10.0 * yc[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXYZ;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * SXZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1088 + i] += 6.0 * zc_pow[96 + i] * SX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXYZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * SXY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
+        }
+
+        // Combine XZZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SXZ = S2[i] * xc[i] * zc[i];
+            const double SZZ = S2[i] * zc[i] * zc[i] + S1[i];
+            const double SXZZ = S3[i] * xc[i] * zc[i] * zc[i] + S2[i] * xc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SXZZ;
+            phi_tmp[i] += 7.0 * xc_pow[128 + i] * SZZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SXZZ;
+            phi_tmp[32 + i] += 6.0 * xc_pow[96 + i] * yc[i] * SZZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SXZZ;
+            phi_tmp[64 + i] += 2.0 * xc_pow[128 + i] * SXZ;
+            phi_tmp[64 + i] += 6.0 * xc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[64 + i] += 2.0 * 6.0 * xc_pow[96 + i] * SZ;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SXZZ;
+            phi_tmp[96 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * SZZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SXZZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SXZ;
+            phi_tmp[128 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZZ;
+            phi_tmp[128 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc[i] * SZ;
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SXZZ;
+            phi_tmp[160 + i] += 2.0 * 2.0 * xc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[160 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * SX;
+            phi_tmp[160 + i] += 2.0 * 10.0 * xc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[160 + i] += 10.0 * xc_pow[64 + i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SXZZ;
+            phi_tmp[192 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SXZZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * SXZ;
+            phi_tmp[224 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZZ;
+            phi_tmp[224 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SXZZ;
+            phi_tmp[256 + i] += 2.0 * 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SXZ;
+            phi_tmp[256 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * SX;
+            phi_tmp[256 + i] += 2.0 * 8.0 * xc_pow[32 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[256 + i] += 8.0 * xc_pow[32 + i] * yc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SXZZ;
+            phi_tmp[288 + i] += 2.0 * 3.0 * xc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[288 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[288 + i] += 2.0 * 12.0 * xc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[288 + i] += 24.0 * xc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SXZZ;
+            phi_tmp[320 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * SZZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXZZ;
+            phi_tmp[352 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * SXZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZZ;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXZZ;
+            phi_tmp[384 + i] += 2.0 * 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SXZ;
+            phi_tmp[384 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * SX;
+            phi_tmp[384 + i] += 2.0 * 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[384 + i] += 6.0 * xc_pow[i] * yc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXZZ;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SXZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[416 + i] += 2.0 * 9.0 * xc_pow[i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[416 + i] += 18.0 * xc_pow[i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SXZZ;
+            phi_tmp[448 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[448 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[448 + i] += 12.0 * xc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[448 + i] += 2.0 * 12.0 * xc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[448 + i] += 36.0 * xc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SXZZ;
+            phi_tmp[480 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SZZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SXZZ;
+            phi_tmp[512 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * SXZ;
+            phi_tmp[512 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZZ;
+            phi_tmp[512 + i] += 2.0 * 2.0 * xc[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXZZ;
+            phi_tmp[544 + i] += 2.0 * 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SXZ;
+            phi_tmp[544 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * SX;
+            phi_tmp[544 + i] += 2.0 * 4.0 * xc[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[544 + i] += 4.0 * xc[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXZZ;
+            phi_tmp[576 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SXZ;
+            phi_tmp[576 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[576 + i] += 2.0 * 6.0 * xc[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[576 + i] += 12.0 * xc[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SXZZ;
+            phi_tmp[608 + i] += 2.0 * 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[608 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[608 + i] += 2.0 * 8.0 * xc[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[608 + i] += 24.0 * xc[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SXZZ;
+            phi_tmp[640 + i] += 2.0 * 5.0 * xc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[640 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[640 + i] += 20.0 * xc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[640 + i] += 2.0 * 10.0 * xc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[640 + i] += 40.0 * xc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SXZZ;
+            phi_tmp[672 + i] += yc_pow[128 + i] * SZZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SXZZ;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SXZ;
+            phi_tmp[704 + i] += yc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[704 + i] += 2.0 * yc_pow[96 + i] * SZ;
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SXZZ;
+            phi_tmp[736 + i] += 2.0 * 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SXZ;
+            phi_tmp[736 + i] += yc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * SX;
+            phi_tmp[736 + i] += 2.0 * 2.0 * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXZZ;
+            phi_tmp[768 + i] += 2.0 * 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SXZ;
+            phi_tmp[768 + i] += yc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[768 + i] += 2.0 * 3.0 * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[768 + i] += 6.0 * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SXZZ;
+            phi_tmp[800 + i] += 2.0 * 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[800 + i] += yc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[800 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[800 + i] += 2.0 * 4.0 * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[800 + i] += 12.0 * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SXZZ;
+            phi_tmp[832 + i] += 2.0 * 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[832 + i] += yc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[832 + i] += 20.0 * xc[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * 5.0 * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[832 + i] += 20.0 * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SXZZ;
+            phi_tmp[864 + i] += 2.0 * 6.0 * xc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[864 + i] += zc_pow[128 + i] * SZZ;
+            phi_tmp[864 + i] += 30.0 * xc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[864 + i] += 2.0 * 6.0 * zc_pow[96 + i] * SZ;
+            phi_tmp[864 + i] += 30.0 * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SXZZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SXZZ;
+            phi_tmp[928 + i] += 2.0 * yc_pow[128 + i] * SXZ;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SXZZ;
+            phi_tmp[960 + i] += 2.0 * 2.0 * yc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * SX;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SXZZ;
+            phi_tmp[992 + i] += 2.0 * 3.0 * yc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[992 + i] += 6.0 * yc_pow[64 + i] * zc[i] * SX;
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SXZZ;
+            phi_tmp[1024 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[1024 + i] += 12.0 * yc_pow[32 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SXZZ;
+            phi_tmp[1056 + i] += 2.0 * 5.0 * yc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1056 + i] += 20.0 * yc_pow[i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SXZZ;
+            phi_tmp[1088 + i] += 2.0 * 6.0 * yc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1088 + i] += 30.0 * yc[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SXZZ;
+            phi_tmp[1120 + i] += 2.0 * 7.0 * zc_pow[128 + i] * SXZ;
+            phi_tmp[1120 + i] += 42.0 * zc_pow[96 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
+        }
+
+        // Combine YYY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SYY = S2[i] * yc[i] * yc[i] + S1[i];
+            const double SYYY = S3[i] * yc[i] * yc[i] * yc[i] + 3 * yc[i] * S2[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SYYY;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SYYY;
+            phi_tmp[32 + i] += 3.0 * xc_pow[128 + i] * SYY;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SYYY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SYYY;
+            phi_tmp[96 + i] += 3.0 * 2.0 * xc_pow[96 + i] * yc[i] * SYY;
+            phi_tmp[96 + i] += 3.0 * 2.0 * xc_pow[96 + i] * SY;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SYYY;
+            phi_tmp[128 + i] += 3.0 * xc_pow[96 + i] * zc[i] * SYY;
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SYYY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SYYY;
+            phi_tmp[192 + i] += 3.0 * 3.0 * xc_pow[64 + i] * yc_pow[i] * SYY;
+            phi_tmp[192 + i] += 3.0 * 6.0 * xc_pow[64 + i] * yc[i] * SY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[64 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SYYY;
+            phi_tmp[224 + i] += 3.0 * 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SYY;
+            phi_tmp[224 + i] += 3.0 * 2.0 * xc_pow[64 + i] * zc[i] * SY;
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SYYY;
+            phi_tmp[256 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * SYY;
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SYYY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SYYY;
+            phi_tmp[320 + i] += 3.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SYY;
+            phi_tmp[320 + i] += 3.0 * 12.0 * xc_pow[32 + i] * yc_pow[i] * SY;
+            phi_tmp[320 + i] += 24.0 * xc_pow[32 + i] * yc[i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYYY;
+            phi_tmp[352 + i] += 3.0 * 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SYY;
+            phi_tmp[352 + i] += 3.0 * 6.0 * xc_pow[32 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYYY;
+            phi_tmp[384 + i] += 3.0 * 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SYY;
+            phi_tmp[384 + i] += 3.0 * 2.0 * xc_pow[32 + i] * zc_pow[i] * SY;
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYYY;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * zc_pow[32 + i] * SYY;
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SYYY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SYYY;
+            phi_tmp[480 + i] += 3.0 * 5.0 * xc_pow[i] * yc_pow[64 + i] * SYY;
+            phi_tmp[480 + i] += 3.0 * 20.0 * xc_pow[i] * yc_pow[32 + i] * SY;
+            phi_tmp[480 + i] += 60.0 * xc_pow[i] * yc_pow[i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SYYY;
+            phi_tmp[512 + i] += 3.0 * 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SYY;
+            phi_tmp[512 + i] += 3.0 * 12.0 * xc_pow[i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[512 + i] += 24.0 * xc_pow[i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYYY;
+            phi_tmp[544 + i] += 3.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SYY;
+            phi_tmp[544 + i] += 3.0 * 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYYY;
+            phi_tmp[576 + i] += 3.0 * 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[576 + i] += 3.0 * 2.0 * xc_pow[i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SYYY;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * SYY;
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SYYY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SYYY;
+            phi_tmp[672 + i] += 3.0 * 6.0 * xc[i] * yc_pow[96 + i] * SYY;
+            phi_tmp[672 + i] += 3.0 * 30.0 * xc[i] * yc_pow[64 + i] * SY;
+            phi_tmp[672 + i] += 120.0 * xc[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SYYY;
+            phi_tmp[704 + i] += 3.0 * 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * SYY;
+            phi_tmp[704 + i] += 3.0 * 20.0 * xc[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 60.0 * xc[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SYYY;
+            phi_tmp[736 + i] += 3.0 * 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SYY;
+            phi_tmp[736 + i] += 3.0 * 12.0 * xc[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 24.0 * xc[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYYY;
+            phi_tmp[768 + i] += 3.0 * 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[768 + i] += 3.0 * 6.0 * xc[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 6.0 * xc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SYYY;
+            phi_tmp[800 + i] += 3.0 * 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[800 + i] += 3.0 * 2.0 * xc[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SYYY;
+            phi_tmp[832 + i] += 3.0 * xc[i] * zc_pow[96 + i] * SYY;
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SYYY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SYYY;
+            phi_tmp[896 + i] += 3.0 * 7.0 * yc_pow[128 + i] * SYY;
+            phi_tmp[896 + i] += 3.0 * 42.0 * yc_pow[96 + i] * SY;
+            phi_tmp[896 + i] += 210.0 * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SYYY;
+            phi_tmp[928 + i] += 3.0 * 6.0 * yc_pow[96 + i] * zc[i] * SYY;
+            phi_tmp[928 + i] += 3.0 * 30.0 * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 120.0 * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SYYY;
+            phi_tmp[960 + i] += 3.0 * 5.0 * yc_pow[64 + i] * zc_pow[i] * SYY;
+            phi_tmp[960 + i] += 3.0 * 20.0 * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 60.0 * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SYYY;
+            phi_tmp[992 + i] += 3.0 * 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[992 + i] += 3.0 * 12.0 * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 24.0 * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SYYY;
+            phi_tmp[1024 + i] += 3.0 * 3.0 * yc_pow[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1024 + i] += 3.0 * 6.0 * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 6.0 * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SYYY;
+            phi_tmp[1056 + i] += 3.0 * 2.0 * yc[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1056 + i] += 3.0 * 2.0 * zc_pow[96 + i] * SY;
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SYYY;
+            phi_tmp[1088 + i] += 3.0 * zc_pow[128 + i] * SYY;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SYYY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
+        }
+
+        // Combine YYZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SYZ = S2[i] * yc[i] * zc[i];
+            const double SYY = S2[i] * yc[i] * yc[i] + S1[i];
+            const double SYYZ = S3[i] * yc[i] * yc[i] * zc[i] + S2[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SYYZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SYYZ;
+            phi_tmp[32 + i] += 2.0 * xc_pow[128 + i] * SYZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SYYZ;
+            phi_tmp[64 + i] += xc_pow[128 + i] * SYY;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SYYZ;
+            phi_tmp[96 + i] += 2.0 * 2.0 * xc_pow[96 + i] * yc[i] * SYZ;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SYYZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * yc[i] * SYY;
+            phi_tmp[128 + i] += 2.0 * xc_pow[96 + i] * SY;
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SYYZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SYY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SYYZ;
+            phi_tmp[192 + i] += 2.0 * 3.0 * xc_pow[64 + i] * yc_pow[i] * SYZ;
+            phi_tmp[192 + i] += 6.0 * xc_pow[64 + i] * yc[i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SYYZ;
+            phi_tmp[224 + i] += 2.0 * 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SYZ;
+            phi_tmp[224 + i] += xc_pow[64 + i] * yc_pow[i] * SYY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 2.0 * 2.0 * xc_pow[64 + i] * yc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SYYZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SYY;
+            phi_tmp[256 + i] += 2.0 * 2.0 * xc_pow[64 + i] * zc[i] * SY;
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SYYZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * SYY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SYYZ;
+            phi_tmp[320 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SYZ;
+            phi_tmp[320 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYYZ;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SYZ;
+            phi_tmp[352 + i] += xc_pow[32 + i] * yc_pow[32 + i] * SYY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[32 + i] * yc_pow[i] * SY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[32 + i] * yc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYYZ;
+            phi_tmp[384 + i] += 2.0 * 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SYZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SYY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYYZ;
+            phi_tmp[416 + i] += 2.0 * xc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SYY;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[32 + i] * zc_pow[i] * SY;
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SYYZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SYY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SYYZ;
+            phi_tmp[480 + i] += 2.0 * 5.0 * xc_pow[i] * yc_pow[64 + i] * SYZ;
+            phi_tmp[480 + i] += 20.0 * xc_pow[i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SYYZ;
+            phi_tmp[512 + i] += 2.0 * 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SYZ;
+            phi_tmp[512 + i] += xc_pow[i] * yc_pow[64 + i] * SYY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 2.0 * 4.0 * xc_pow[i] * yc_pow[32 + i] * SY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[i] * yc_pow[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYYZ;
+            phi_tmp[544 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SYZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SYY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[544 + i] += 12.0 * xc_pow[i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYYZ;
+            phi_tmp[576 + i] += 2.0 * 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SYY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 2.0 * 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SYYZ;
+            phi_tmp[608 + i] += 2.0 * xc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[608 + i] += 2.0 * 4.0 * xc_pow[i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SYYZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * SYY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SYYZ;
+            phi_tmp[672 + i] += 2.0 * 6.0 * xc[i] * yc_pow[96 + i] * SYZ;
+            phi_tmp[672 + i] += 30.0 * xc[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SYYZ;
+            phi_tmp[704 + i] += 2.0 * 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * SYZ;
+            phi_tmp[704 + i] += xc[i] * yc_pow[96 + i] * SYY;
+            phi_tmp[704 + i] += 20.0 * xc[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += 2.0 * 5.0 * xc[i] * yc_pow[64 + i] * SY;
+            phi_tmp[704 + i] += 20.0 * xc[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SYYZ;
+            phi_tmp[736 + i] += 2.0 * 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SYZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SYY;
+            phi_tmp[736 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * 8.0 * xc[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[736 + i] += 24.0 * xc[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYYZ;
+            phi_tmp[768 + i] += 2.0 * 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SYY;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 2.0 * 9.0 * xc[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[768 + i] += 18.0 * xc[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SYYZ;
+            phi_tmp[800 + i] += 2.0 * 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 2.0 * 8.0 * xc[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[800 + i] += 8.0 * xc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SYYZ;
+            phi_tmp[832 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[832 + i] += 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[832 + i] += 2.0 * 5.0 * xc[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SYYZ;
+            phi_tmp[864 + i] += 6.0 * xc[i] * zc_pow[96 + i] * SYY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SYYZ;
+            phi_tmp[896 + i] += 2.0 * 7.0 * yc_pow[128 + i] * SYZ;
+            phi_tmp[896 + i] += 42.0 * yc_pow[96 + i] * SZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SYYZ;
+            phi_tmp[928 + i] += 2.0 * 6.0 * yc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * SYY;
+            phi_tmp[928 + i] += 30.0 * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += 2.0 * 6.0 * yc_pow[96 + i] * SY;
+            phi_tmp[928 + i] += 30.0 * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SYYZ;
+            phi_tmp[960 + i] += 2.0 * 5.0 * yc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SYY;
+            phi_tmp[960 + i] += 20.0 * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * 10.0 * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[960 + i] += 40.0 * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SYYZ;
+            phi_tmp[992 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * SYY;
+            phi_tmp[992 + i] += 12.0 * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 2.0 * 12.0 * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[992 + i] += 36.0 * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SYYZ;
+            phi_tmp[1024 + i] += 2.0 * 3.0 * yc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[1024 + i] += 6.0 * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 2.0 * 12.0 * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[1024 + i] += 24.0 * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SYYZ;
+            phi_tmp[1056 + i] += 2.0 * 2.0 * yc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1056 + i] += 2.0 * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 2.0 * 10.0 * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1056 + i] += 10.0 * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SYYZ;
+            phi_tmp[1088 + i] += 2.0 * zc_pow[128 + i] * SYZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1088 + i] += 2.0 * 6.0 * zc_pow[96 + i] * SY;
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SYYZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * SYY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
+        }
+
+        // Combine YZZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SYZ = S2[i] * yc[i] * zc[i];
+            const double SZZ = S2[i] * zc[i] * zc[i] + S1[i];
+            const double SYZZ = S3[i] * yc[i] * zc[i] * zc[i] + S2[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SYZZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SYZZ;
+            phi_tmp[32 + i] += xc_pow[128 + i] * SZZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SYZZ;
+            phi_tmp[64 + i] += 2.0 * xc_pow[128 + i] * SYZ;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SYZZ;
+            phi_tmp[96 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SZZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SYZZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SYZ;
+            phi_tmp[128 + i] += xc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[96 + i] * SZ;
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SYZZ;
+            phi_tmp[160 + i] += 2.0 * 2.0 * xc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[96 + i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SYZZ;
+            phi_tmp[192 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * SZZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SYZZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * SYZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZZ;
+            phi_tmp[224 + i] += 2.0 * 2.0 * xc_pow[64 + i] * yc[i] * SZ;
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SYZZ;
+            phi_tmp[256 + i] += 2.0 * 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SYZ;
+            phi_tmp[256 + i] += xc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * yc[i] * SY;
+            phi_tmp[256 + i] += 2.0 * 2.0 * xc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[64 + i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SYZZ;
+            phi_tmp[288 + i] += 2.0 * 3.0 * xc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[64 + i] * zc[i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SYZZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYZZ;
+            phi_tmp[352 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * SYZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZZ;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[32 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYZZ;
+            phi_tmp[384 + i] += 2.0 * 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SYZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[32 + i] * yc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYZZ;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SYZ;
+            phi_tmp[416 + i] += xc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SYZZ;
+            phi_tmp[448 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[448 + i] += 12.0 * xc_pow[32 + i] * zc_pow[i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SYZZ;
+            phi_tmp[480 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * SZZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SYZZ;
+            phi_tmp[512 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * SYZ;
+            phi_tmp[512 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZZ;
+            phi_tmp[512 + i] += 2.0 * 4.0 * xc_pow[i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYZZ;
+            phi_tmp[544 + i] += 2.0 * 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SYZ;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[i] * yc_pow[32 + i] * SY;
+            phi_tmp[544 + i] += 2.0 * 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYZZ;
+            phi_tmp[576 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SYZ;
+            phi_tmp[576 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[576 + i] += 2.0 * 6.0 * xc_pow[i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[576 + i] += 12.0 * xc_pow[i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SYZZ;
+            phi_tmp[608 + i] += 2.0 * 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[608 + i] += xc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[608 + i] += 2.0 * 4.0 * xc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SYZZ;
+            phi_tmp[640 + i] += 2.0 * 5.0 * xc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[640 + i] += 20.0 * xc_pow[i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SYZZ;
+            phi_tmp[672 + i] += 6.0 * xc[i] * yc_pow[96 + i] * SZZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SYZZ;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SYZ;
+            phi_tmp[704 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZZ;
+            phi_tmp[704 + i] += 2.0 * 5.0 * xc[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SYZZ;
+            phi_tmp[736 + i] += 2.0 * 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SYZ;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * SY;
+            phi_tmp[736 + i] += 2.0 * 8.0 * xc[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[736 + i] += 8.0 * xc[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYZZ;
+            phi_tmp[768 + i] += 2.0 * 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SYZ;
+            phi_tmp[768 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[768 + i] += 2.0 * 9.0 * xc[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[768 + i] += 18.0 * xc[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SYZZ;
+            phi_tmp[800 + i] += 2.0 * 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[800 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[800 + i] += 2.0 * 8.0 * xc[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[800 + i] += 24.0 * xc[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SYZZ;
+            phi_tmp[832 + i] += 2.0 * 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[832 + i] += xc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[832 + i] += 20.0 * xc[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[832 + i] += 2.0 * 5.0 * xc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[832 + i] += 20.0 * xc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SYZZ;
+            phi_tmp[864 + i] += 2.0 * 6.0 * xc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[864 + i] += 30.0 * xc[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SYZZ;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * SZZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SYZZ;
+            phi_tmp[928 + i] += 2.0 * yc_pow[128 + i] * SYZ;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[928 + i] += 2.0 * 6.0 * yc_pow[96 + i] * SZ;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SYZZ;
+            phi_tmp[960 + i] += 2.0 * 2.0 * yc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * SY;
+            phi_tmp[960 + i] += 2.0 * 10.0 * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[960 + i] += 10.0 * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SYZZ;
+            phi_tmp[992 + i] += 2.0 * 3.0 * yc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[992 + i] += 6.0 * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[992 + i] += 2.0 * 12.0 * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[992 + i] += 24.0 * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SYZZ;
+            phi_tmp[1024 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1024 + i] += 12.0 * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[1024 + i] += 2.0 * 12.0 * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1024 + i] += 36.0 * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SYZZ;
+            phi_tmp[1056 + i] += 2.0 * 5.0 * yc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1056 + i] += 20.0 * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * 10.0 * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1056 + i] += 40.0 * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SYZZ;
+            phi_tmp[1088 + i] += 2.0 * 6.0 * yc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * SZZ;
+            phi_tmp[1088 + i] += 30.0 * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1088 + i] += 2.0 * 6.0 * zc_pow[96 + i] * SZ;
+            phi_tmp[1088 + i] += 30.0 * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SYZZ;
+            phi_tmp[1120 + i] += 2.0 * 7.0 * zc_pow[128 + i] * SYZ;
+            phi_tmp[1120 + i] += 42.0 * zc_pow[96 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
+        }
+
+        // Combine ZZZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+            const double SZZ = S2[i] * zc[i] * zc[i] + S1[i];
+            const double SZZZ = S3[i] * zc[i] * zc[i] * zc[i] + 3 * zc[i] * S2[i];
+
+            phi_tmp[i] = xc_pow[160 + i] * SZZZ;
+
+            phi_tmp[32 + i] = xc_pow[128 + i] * yc[i] * SZZZ;
+
+            phi_tmp[64 + i] = xc_pow[128 + i] * zc[i] * SZZZ;
+            phi_tmp[64 + i] += 3.0 * xc_pow[128 + i] * SZZ;
+
+            phi_tmp[96 + i] = xc_pow[96 + i] * yc_pow[i] * SZZZ;
+
+            phi_tmp[128 + i] = xc_pow[96 + i] * yc[i] * zc[i] * SZZZ;
+            phi_tmp[128 + i] += 3.0 * xc_pow[96 + i] * yc[i] * SZZ;
+
+            phi_tmp[160 + i] = xc_pow[96 + i] * zc_pow[i] * SZZZ;
+            phi_tmp[160 + i] += 3.0 * 2.0 * xc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[160 + i] += 3.0 * 2.0 * xc_pow[96 + i] * SZ;
+
+            phi_tmp[192 + i] = xc_pow[64 + i] * yc_pow[32 + i] * SZZZ;
+
+            phi_tmp[224 + i] = xc_pow[64 + i] * yc_pow[i] * zc[i] * SZZZ;
+            phi_tmp[224 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * SZZ;
+
+            phi_tmp[256 + i] = xc_pow[64 + i] * yc[i] * zc_pow[i] * SZZZ;
+            phi_tmp[256 + i] += 3.0 * 2.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZZ;
+            phi_tmp[256 + i] += 3.0 * 2.0 * xc_pow[64 + i] * yc[i] * SZ;
+
+            phi_tmp[288 + i] = xc_pow[64 + i] * zc_pow[32 + i] * SZZZ;
+            phi_tmp[288 + i] += 3.0 * 3.0 * xc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[288 + i] += 3.0 * 6.0 * xc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[64 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[32 + i] * yc_pow[64 + i] * SZZZ;
+
+            phi_tmp[352 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZZZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZZ;
+
+            phi_tmp[384 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZZZ;
+            phi_tmp[384 + i] += 3.0 * 2.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZZ;
+            phi_tmp[384 + i] += 3.0 * 2.0 * xc_pow[32 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[416 + i] = xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZZZ;
+            phi_tmp[416 + i] += 3.0 * 3.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZZ;
+            phi_tmp[416 + i] += 3.0 * 6.0 * xc_pow[32 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[32 + i] * yc[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[32 + i] * zc_pow[64 + i] * SZZZ;
+            phi_tmp[448 + i] += 3.0 * 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[448 + i] += 3.0 * 12.0 * xc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[448 + i] += 24.0 * xc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[i] * yc_pow[96 + i] * SZZZ;
+
+            phi_tmp[512 + i] = xc_pow[i] * yc_pow[64 + i] * zc[i] * SZZZ;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * SZZ;
+
+            phi_tmp[544 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZZZ;
+            phi_tmp[544 + i] += 3.0 * 2.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZZ;
+            phi_tmp[544 + i] += 3.0 * 2.0 * xc_pow[i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[576 + i] = xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZZZ;
+            phi_tmp[576 + i] += 3.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZZ;
+            phi_tmp[576 + i] += 3.0 * 6.0 * xc_pow[i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[i] * yc[i] * zc_pow[64 + i] * SZZZ;
+            phi_tmp[608 + i] += 3.0 * 4.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[608 + i] += 3.0 * 12.0 * xc_pow[i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[608 + i] += 24.0 * xc_pow[i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[i] * zc_pow[96 + i] * SZZZ;
+            phi_tmp[640 + i] += 3.0 * 5.0 * xc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[640 + i] += 3.0 * 20.0 * xc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[640 + i] += 60.0 * xc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[672 + i] = xc[i] * yc_pow[128 + i] * SZZZ;
+
+            phi_tmp[704 + i] = xc[i] * yc_pow[96 + i] * zc[i] * SZZZ;
+            phi_tmp[704 + i] += 3.0 * xc[i] * yc_pow[96 + i] * SZZ;
+
+            phi_tmp[736 + i] = xc[i] * yc_pow[64 + i] * zc_pow[i] * SZZZ;
+            phi_tmp[736 + i] += 3.0 * 2.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZZ;
+            phi_tmp[736 + i] += 3.0 * 2.0 * xc[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[768 + i] = xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZZZ;
+            phi_tmp[768 + i] += 3.0 * 3.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZZ;
+            phi_tmp[768 + i] += 3.0 * 6.0 * xc[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc[i] * yc_pow[i] * zc_pow[64 + i] * SZZZ;
+            phi_tmp[800 + i] += 3.0 * 4.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[800 + i] += 3.0 * 12.0 * xc[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[800 + i] += 24.0 * xc[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[832 + i] = xc[i] * yc[i] * zc_pow[96 + i] * SZZZ;
+            phi_tmp[832 + i] += 3.0 * 5.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[832 + i] += 3.0 * 20.0 * xc[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[832 + i] += 60.0 * xc[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[864 + i] = xc[i] * zc_pow[128 + i] * SZZZ;
+            phi_tmp[864 + i] += 3.0 * 6.0 * xc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[864 + i] += 3.0 * 30.0 * xc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[864 + i] += 120.0 * xc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[896 + i] = yc_pow[160 + i] * SZZZ;
+
+            phi_tmp[928 + i] = yc_pow[128 + i] * zc[i] * SZZZ;
+            phi_tmp[928 + i] += 3.0 * yc_pow[128 + i] * SZZ;
+
+            phi_tmp[960 + i] = yc_pow[96 + i] * zc_pow[i] * SZZZ;
+            phi_tmp[960 + i] += 3.0 * 2.0 * yc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[960 + i] += 3.0 * 2.0 * yc_pow[96 + i] * SZ;
+
+            phi_tmp[992 + i] = yc_pow[64 + i] * zc_pow[32 + i] * SZZZ;
+            phi_tmp[992 + i] += 3.0 * 3.0 * yc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[992 + i] += 3.0 * 6.0 * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[992 + i] += 6.0 * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[1024 + i] = yc_pow[32 + i] * zc_pow[64 + i] * SZZZ;
+            phi_tmp[1024 + i] += 3.0 * 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[1024 + i] += 3.0 * 12.0 * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[1024 + i] += 24.0 * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[1056 + i] = yc_pow[i] * zc_pow[96 + i] * SZZZ;
+            phi_tmp[1056 + i] += 3.0 * 5.0 * yc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1056 + i] += 3.0 * 20.0 * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1056 + i] += 60.0 * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1088 + i] = yc[i] * zc_pow[128 + i] * SZZZ;
+            phi_tmp[1088 + i] += 3.0 * 6.0 * yc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1088 + i] += 3.0 * 30.0 * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1088 + i] += 120.0 * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1120 + i] = zc_pow[160 + i] * SZZZ;
+            phi_tmp[1120 + i] += 3.0 * 7.0 * zc_pow[128 + i] * SZZ;
+            phi_tmp[1120 + i] += 3.0 * 42.0 * zc_pow[96 + i] * SZ;
+            phi_tmp[1120 + i] += 210.0 * zc_pow[64 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
+        }
+    }
+
+    // Free S temporaries
+    ALIGNED_FREE(cache_data);
+    ALIGNED_FREE(expn1);
+    ALIGNED_FREE(expn2);
+
+    // Free Power temporaries
+    ALIGNED_FREE(xc_pow);
+    ALIGNED_FREE(yc_pow);
+    ALIGNED_FREE(zc_pow);
+
+    // Free inner temporaries
+    ALIGNED_FREE(phi_tmp);
+}
+
+void gg_collocation_L8_deriv3(
+    const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+    const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+    double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out,
+    double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+    double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out,
+    double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+    double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out,
+    double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
+    // Sizing
+    unsigned long nblocks = npoints / 32;
+    nblocks += (npoints % 32) ? 1 : 0;
+    const unsigned long ncart = 45;
+    const unsigned long nspherical = 17;
+    unsigned long nout;
+
+    if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
+        nout = nspherical;
+    } else {
+        nout = ncart;
+    }
+
+    // Allocate S temporaries, single block to stay on cache
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((288 * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT xc = cache_data + 0;
+    ASSUME_ALIGNED(xc, 64);
+    double* PRAGMA_RESTRICT yc = cache_data + 32;
+    ASSUME_ALIGNED(yc, 64);
+    double* PRAGMA_RESTRICT zc = cache_data + 64;
+    ASSUME_ALIGNED(zc, 64);
+    double* PRAGMA_RESTRICT R2 = cache_data + 96;
+    ASSUME_ALIGNED(R2, 64);
+    double* PRAGMA_RESTRICT S0 = cache_data + 128;
+    ASSUME_ALIGNED(S0, 64);
+    double* PRAGMA_RESTRICT tmp1 = cache_data + 160;
+    ASSUME_ALIGNED(tmp1, 64);
+    double* PRAGMA_RESTRICT S1 = cache_data + 192;
+    ASSUME_ALIGNED(S1, 64);
+    double* PRAGMA_RESTRICT S2 = cache_data + 224;
+    ASSUME_ALIGNED(S2, 64);
+    double* PRAGMA_RESTRICT S3 = cache_data + 256;
+    ASSUME_ALIGNED(S3, 64);
+
+    // Allocate exponential temporaries
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT expn2 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+
+    // Allocate power temporaries
+    double* PRAGMA_RESTRICT xc_pow = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(xc_pow, 64);
+    double* PRAGMA_RESTRICT yc_pow = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(yc_pow, 64);
+    double* PRAGMA_RESTRICT zc_pow = (double*)ALIGNED_MALLOC(64, ((((224 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(zc_pow, 64);
+
+    // Allocate output temporaries
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((1440 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(phi_tmp, 64);
+
+    // Declare doubles
+    const double center_x = center[0];
+    const double center_y = center[1];
+    const double center_z = center[2];
+    double A;
+    double AX, AY, AZ;
+    double AXX, AXY, AXZ, AYY, AYZ, AZZ;
+    double AXXX, XXY, XXZ, XYY, XYZ, XZZ, YYY, YYZ, YZZ, ZZZ;
+
+    // Build negative exponents
+    for (unsigned long i = 0; i < nprim; i++) {
+        expn1[i] = -1.0 * exponents[i];
+        expn2[i] = -2.0 * exponents[i];
+    }
+
+    // Start outer block loop
+    for (unsigned long block = 0; block < nblocks; block++) {
+        // Copy data into inner temps
+        const unsigned long start = block * 32;
+        const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
+
+        // Handle non-AM dependant temps
+        if (xyz_stride == 1) {
+            const double* PRAGMA_RESTRICT x = xyz + start;
+            const double* PRAGMA_RESTRICT y = xyz + npoints + start;
+            const double* PRAGMA_RESTRICT z = xyz + 2 * npoints + start;
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = x[i] - center_x;
+                yc[i] = y[i] - center_y;
+                zc[i] = z[i] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+                S2[i] = 0.0;
+                S3[i] = 0.0;
+            }
+        } else {
+            unsigned int start_shift = start * xyz_stride;
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = xyz[start_shift + i * xyz_stride] - center_x;
+                yc[i] = xyz[start_shift + i * xyz_stride + 1] - center_y;
+                zc[i] = xyz[start_shift + i * xyz_stride + 2] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+                S1[i] = 0.0;
+                S2[i] = 0.0;
+                S3[i] = 0.0;
+            }
+        }
+
+        // Start exponential block loop
+        for (unsigned long n = 0; n < nprim; n++) {
+            const double coef = coeffs[n];
+            const double alpha_n1 = expn1[n];
+            const double alpha_n2 = expn2[n];
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                const double width = alpha_n1 * R2[i];
+                const double T1 = coef * exp(width);
+                S0[i] += T1;
+                const double T2 = alpha_n2 * T1;
+                S1[i] += T2;
+                const double T3 = alpha_n2 * T2;
+                S2[i] += T3;
+                const double T4 = alpha_n2 * T3;
+                S3[i] += T4;
+            }
+        }
+
+        // Build powers
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            // Cartesian derivs
+            xc_pow[i] = xc[i] * xc[i];
+            yc_pow[i] = yc[i] * yc[i];
+            zc_pow[i] = zc[i] * zc[i];
+            xc_pow[32 + i] = xc_pow[i] * xc[i];
+            yc_pow[32 + i] = yc_pow[i] * yc[i];
+            zc_pow[32 + i] = zc_pow[i] * zc[i];
+            xc_pow[64 + i] = xc_pow[32 + i] * xc[i];
+            yc_pow[64 + i] = yc_pow[32 + i] * yc[i];
+            zc_pow[64 + i] = zc_pow[32 + i] * zc[i];
+            xc_pow[96 + i] = xc_pow[64 + i] * xc[i];
+            yc_pow[96 + i] = yc_pow[64 + i] * yc[i];
+            zc_pow[96 + i] = zc_pow[64 + i] * zc[i];
+            xc_pow[128 + i] = xc_pow[96 + i] * xc[i];
+            yc_pow[128 + i] = yc_pow[96 + i] * yc[i];
+            zc_pow[128 + i] = zc_pow[96 + i] * zc[i];
+            xc_pow[160 + i] = xc_pow[128 + i] * xc[i];
+            yc_pow[160 + i] = yc_pow[128 + i] * yc[i];
+            zc_pow[160 + i] = zc_pow[128 + i] * zc[i];
+            xc_pow[192 + i] = xc_pow[160 + i] * xc[i];
+            yc_pow[192 + i] = yc_pow[160 + i] * yc[i];
+            zc_pow[192 + i] = zc_pow[160 + i] * zc[i];
+        }
+        // Combine A blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            phi_tmp[i] = xc_pow[192 + i] * S0[i];
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * S0[i];
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * S0[i];
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * S0[i];
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * S0[i];
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * S0[i];
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * S0[i];
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * S0[i];
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * S0[i];
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * S0[i];
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * S0[i];
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * S0[i];
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * S0[i];
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * S0[i];
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * S0[i];
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * S0[i];
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * S0[i];
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * S0[i];
+            phi_tmp[1152 + i] = yc_pow[192 + i] * S0[i];
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * S0[i];
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * S0[i];
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * S0[i];
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * S0[i];
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * S0[i];
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * S0[i];
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * S0[i];
+            phi_tmp[1408 + i] = zc_pow[192 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        }
+
+        // Combine X blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SX;
+            phi_tmp[i] += 8.0 * xc_pow[160 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SX;
+            phi_tmp[480 + i] += 3.0 * xc_pow[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SX;
+            phi_tmp[640 + i] += 3.0 * xc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SX;
+            phi_tmp[672 + i] += 2.0 * xc[i] * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SX;
+            phi_tmp[864 + i] += 2.0 * xc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SX;
+            phi_tmp[896 + i] += yc_pow[160 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[928 + i] += yc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[960 + i] += yc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[992 + i] += yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[1024 + i] += yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[1056 + i] += yc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[1088 + i] += yc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SX;
+            phi_tmp[1120 + i] += zc_pow[160 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SX;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_x_out + start), npoints);
+        }
+
+        // Combine Y blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += xc_pow[160 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[96 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += xc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SY;
+            phi_tmp[672 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[832 + i] += xc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SY;
+            phi_tmp[896 + i] += 7.0 * xc[i] * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1088 + i] += xc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SY;
+            phi_tmp[1152 + i] += 8.0 * yc_pow[160 + i] * S0[i];
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SY;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SY;
+            phi_tmp[1216 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1248 + i] += 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SY;
+            phi_tmp[1312 + i] += 3.0 * yc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1344 + i] += 2.0 * yc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SY;
+            phi_tmp[1376 + i] += zc_pow[160 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_y_out + start), npoints);
+        }
+
+        // Combine Z blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += xc_pow[160 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += xc_pow[96 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += xc_pow[64 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += xc_pow[32 + i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += xc_pow[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[864 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += xc[i] * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SZ;
+            phi_tmp[1120 + i] += 7.0 * xc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SZ;
+            phi_tmp[1184 + i] += yc_pow[160 + i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * zc[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1248 + i] += 3.0 * yc_pow[96 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1312 + i] += 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1344 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SZ;
+            phi_tmp[1376 + i] += 7.0 * yc[i] * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SZ;
+            phi_tmp[1408 + i] += 8.0 * zc_pow[160 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_z_out + start), npoints);
+        }
+
+        // Combine XX blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SXX = S2[i] * xc[i] * xc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXX;
+            phi_tmp[i] += 16.0 * xc_pow[160 + i] * SX;
+            phi_tmp[i] += 56.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXX;
+            phi_tmp[32 + i] += 14.0 * xc_pow[128 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 42.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXX;
+            phi_tmp[64 + i] += 14.0 * xc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 42.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXX;
+            phi_tmp[96 + i] += 12.0 * xc_pow[96 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 30.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXX;
+            phi_tmp[128 + i] += 12.0 * xc_pow[96 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 30.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXX;
+            phi_tmp[160 + i] += 12.0 * xc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 30.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXX;
+            phi_tmp[192 + i] += 10.0 * xc_pow[64 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 20.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXX;
+            phi_tmp[224 + i] += 10.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 20.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXX;
+            phi_tmp[256 + i] += 10.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 20.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[288 + i] += 10.0 * xc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 20.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXX;
+            phi_tmp[320 + i] += 8.0 * xc_pow[32 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 12.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXX;
+            phi_tmp[352 + i] += 8.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXX;
+            phi_tmp[384 + i] += 8.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[416 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXX;
+            phi_tmp[448 + i] += 8.0 * xc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 12.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXX;
+            phi_tmp[480 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * SX;
+            phi_tmp[480 + i] += 6.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXX;
+            phi_tmp[512 + i] += 6.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 6.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXX;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[608 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 6.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXX;
+            phi_tmp[640 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[640 + i] += 6.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXX;
+            phi_tmp[672 + i] += 4.0 * xc[i] * yc_pow[128 + i] * SX;
+            phi_tmp[672 + i] += 2.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXX;
+            phi_tmp[704 + i] += 4.0 * xc[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += 2.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXX;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[768 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += 2.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += 2.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[832 + i] += 4.0 * xc[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXX;
+            phi_tmp[864 + i] += 4.0 * xc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[864 + i] += 2.0 * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXX;
+            phi_tmp[896 + i] += 2.0 * yc_pow[160 + i] * SX;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXX;
+            phi_tmp[928 + i] += 2.0 * yc_pow[128 + i] * zc[i] * SX;
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXX;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc_pow[i] * SX;
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[992 + i] += 2.0 * yc_pow[64 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXX;
+            phi_tmp[1024 + i] += 2.0 * yc_pow[32 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[1056 + i] += 2.0 * yc_pow[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXX;
+            phi_tmp[1088 + i] += 2.0 * yc[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXX;
+            phi_tmp[1120 + i] += 2.0 * zc_pow[160 + i] * SX;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXX;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xx_out + start), npoints);
+        }
+
+        // Combine XY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SY = S1[i] * yc[i];
+            const double SXY = S2[i] * xc[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXY;
+            phi_tmp[i] += 8.0 * xc_pow[160 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXY;
+            phi_tmp[32 + i] += xc_pow[160 + i] * SX;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXY;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * yc[i] * SX;
+            phi_tmp[96 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 12.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXY;
+            phi_tmp[128 + i] += xc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXY;
+            phi_tmp[160 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[96 + i] * yc_pow[i] * SX;
+            phi_tmp[192 + i] += 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 15.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXY;
+            phi_tmp[256 + i] += xc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[288 + i] += 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 16.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[416 + i] += xc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[480 + i] += 3.0 * xc_pow[i] * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 15.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[608 + i] += xc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXY;
+            phi_tmp[640 + i] += 3.0 * xc_pow[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXY;
+            phi_tmp[672 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * SX;
+            phi_tmp[672 + i] += 2.0 * xc[i] * yc_pow[128 + i] * SY;
+            phi_tmp[672 + i] += 12.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[832 + i] += xc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[832 + i] += 2.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[864 + i] += 2.0 * xc[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXY;
+            phi_tmp[896 + i] += 7.0 * xc[i] * yc_pow[128 + i] * SX;
+            phi_tmp[896 + i] += yc_pow[160 + i] * SY;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[928 + i] += yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[960 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[960 + i] += yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[992 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[992 + i] += yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1024 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[1024 + i] += yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[1056 + i] += yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[1088 + i] += xc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[1088 + i] += yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXY;
+            phi_tmp[1120 + i] += zc_pow[160 + i] * SY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXY;
+            phi_tmp[1152 + i] += 8.0 * yc_pow[160 + i] * SX;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXY;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * zc[i] * SX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXY;
+            phi_tmp[1216 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[1248 + i] += 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1312 + i] += 3.0 * yc_pow[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[1344 + i] += 2.0 * yc[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXY;
+            phi_tmp[1376 + i] += zc_pow[160 + i] * SX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xy_out + start), npoints);
+        }
+
+        // Combine XZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SXZ = S2[i] * xc[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXZ;
+            phi_tmp[i] += 8.0 * xc_pow[160 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXZ;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXZ;
+            phi_tmp[64 + i] += xc_pow[160 + i] * SX;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXZ;
+            phi_tmp[96 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * yc[i] * SX;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * zc[i] * SX;
+            phi_tmp[160 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 12.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXZ;
+            phi_tmp[192 + i] += 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXZ;
+            phi_tmp[224 + i] += xc_pow[96 + i] * yc_pow[i] * SX;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[96 + i] * zc_pow[i] * SX;
+            phi_tmp[288 + i] += 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 15.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXZ;
+            phi_tmp[352 + i] += xc_pow[64 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 8.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 12.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 16.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXZ;
+            phi_tmp[480 + i] += 3.0 * xc_pow[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXZ;
+            phi_tmp[512 + i] += xc_pow[32 + i] * yc_pow[64 + i] * SX;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * SX;
+            phi_tmp[640 + i] += 3.0 * xc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 15.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXZ;
+            phi_tmp[672 + i] += 2.0 * xc[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[704 + i] += xc_pow[i] * yc_pow[96 + i] * SX;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[768 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 8.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[864 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * SX;
+            phi_tmp[864 + i] += 2.0 * xc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[864 + i] += 12.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXZ;
+            phi_tmp[896 + i] += yc_pow[160 + i] * SZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[928 + i] += xc[i] * yc_pow[128 + i] * SX;
+            phi_tmp[928 + i] += yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[960 + i] += yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[992 + i] += 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[992 + i] += yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1024 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[1024 + i] += yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1056 + i] += 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[1056 + i] += yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[1088 + i] += yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXZ;
+            phi_tmp[1120 + i] += 7.0 * xc[i] * zc_pow[128 + i] * SX;
+            phi_tmp[1120 + i] += zc_pow[160 + i] * SZ;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXZ;
+            phi_tmp[1184 + i] += yc_pow[160 + i] * SX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * zc[i] * SX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[1248 + i] += 3.0 * yc_pow[96 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1312 + i] += 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[1344 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXZ;
+            phi_tmp[1376 + i] += 7.0 * yc[i] * zc_pow[128 + i] * SX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXZ;
+            phi_tmp[1408 + i] += 8.0 * zc_pow[160 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xz_out + start), npoints);
+        }
+
+        // Combine YY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SYY = S2[i] * yc[i] * yc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SYY;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SYY;
+            phi_tmp[32 + i] += 2.0 * xc_pow[160 + i] * SY;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SYY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SYY;
+            phi_tmp[96 + i] += 4.0 * xc_pow[128 + i] * yc[i] * SY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SYY;
+            phi_tmp[128 + i] += 2.0 * xc_pow[128 + i] * zc[i] * SY;
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SYY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SYY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * SY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SYY;
+            phi_tmp[224 + i] += 4.0 * xc_pow[96 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SYY;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * zc_pow[i] * SY;
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SYY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SYY;
+            phi_tmp[320 + i] += 8.0 * xc_pow[64 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[320 + i] += 12.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SYY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SYY;
+            phi_tmp[384 + i] += 4.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[416 + i] += 2.0 * xc_pow[64 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SYY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SYY;
+            phi_tmp[480 + i] += 10.0 * xc_pow[32 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[480 + i] += 20.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SYY;
+            phi_tmp[512 + i] += 8.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SYY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[576 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[608 + i] += 2.0 * xc_pow[32 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SYY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SYY;
+            phi_tmp[672 + i] += 12.0 * xc_pow[i] * yc_pow[96 + i] * SY;
+            phi_tmp[672 + i] += 30.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SYY;
+            phi_tmp[704 + i] += 10.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 20.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SYY;
+            phi_tmp[736 + i] += 8.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[832 + i] += 2.0 * xc_pow[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SYY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SYY;
+            phi_tmp[896 + i] += 14.0 * xc[i] * yc_pow[128 + i] * SY;
+            phi_tmp[896 + i] += 42.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SYY;
+            phi_tmp[928 + i] += 12.0 * xc[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 30.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SYY;
+            phi_tmp[960 + i] += 10.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 20.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[992 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1024 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 6.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1056 + i] += 4.0 * xc[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SYY;
+            phi_tmp[1088 + i] += 2.0 * xc[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SYY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SYY;
+            phi_tmp[1152 + i] += 16.0 * yc_pow[160 + i] * SY;
+            phi_tmp[1152 + i] += 56.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SYY;
+            phi_tmp[1184 + i] += 14.0 * yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[1184 + i] += 42.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SYY;
+            phi_tmp[1216 + i] += 12.0 * yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[1216 + i] += 30.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[1248 + i] += 10.0 * yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1248 + i] += 20.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1280 + i] += 8.0 * yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1280 + i] += 12.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1312 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1312 + i] += 6.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SYY;
+            phi_tmp[1344 + i] += 4.0 * yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1344 + i] += 2.0 * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SYY;
+            phi_tmp[1376 + i] += 2.0 * zc_pow[160 + i] * SY;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SYY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_yy_out + start), npoints);
+        }
+
+        // Combine YZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SYZ = S2[i] * yc[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SYZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SYZ;
+            phi_tmp[32 + i] += xc_pow[160 + i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SYZ;
+            phi_tmp[64 + i] += xc_pow[160 + i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SYZ;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * yc[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SYZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * yc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SYZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * zc[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SYZ;
+            phi_tmp[192 + i] += 3.0 * xc_pow[96 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SYZ;
+            phi_tmp[224 + i] += xc_pow[96 + i] * yc_pow[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SYZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[256 + i] += xc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[96 + i] * zc_pow[i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SYZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SYZ;
+            phi_tmp[352 + i] += xc_pow[64 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SYZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[416 + i] += xc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SYZ;
+            phi_tmp[480 + i] += 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SYZ;
+            phi_tmp[512 + i] += xc_pow[32 + i] * yc_pow[64 + i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SYZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[608 + i] += xc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SYZ;
+            phi_tmp[672 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[704 + i] += xc_pow[i] * yc_pow[96 + i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 8.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 8.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[832 + i] += xc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[864 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SYZ;
+            phi_tmp[896 + i] += 7.0 * xc[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[928 + i] += xc[i] * yc_pow[128 + i] * SY;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[960 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[992 + i] += 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[992 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 12.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1024 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1024 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1056 + i] += 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1088 + i] += xc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SYZ;
+            phi_tmp[1120 + i] += 7.0 * xc[i] * zc_pow[128 + i] * SY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SYZ;
+            phi_tmp[1152 + i] += 8.0 * yc_pow[160 + i] * SZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SYZ;
+            phi_tmp[1184 + i] += yc_pow[160 + i] * SY;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SYZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * zc[i] * SY;
+            phi_tmp[1216 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[1216 + i] += 12.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[1248 + i] += 3.0 * yc_pow[96 + i] * zc_pow[i] * SY;
+            phi_tmp[1248 + i] += 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1248 + i] += 15.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1280 + i] += 16.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1312 + i] += 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * SY;
+            phi_tmp[1312 + i] += 3.0 * yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1312 + i] += 15.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[1344 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1344 + i] += 2.0 * yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1344 + i] += 12.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SYZ;
+            phi_tmp[1376 + i] += 7.0 * yc[i] * zc_pow[128 + i] * SY;
+            phi_tmp[1376 + i] += zc_pow[160 + i] * SZ;
+            phi_tmp[1376 + i] += 7.0 * zc_pow[128 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SYZ;
+            phi_tmp[1408 + i] += 8.0 * zc_pow[160 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_yz_out + start), npoints);
+        }
+
+        // Combine ZZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+            const double SZZ = S2[i] * zc[i] * zc[i] + S1[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SZZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SZZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SZZ;
+            phi_tmp[64 + i] += 2.0 * xc_pow[160 + i] * SZ;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SZZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SZZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[128 + i] * yc[i] * SZ;
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SZZ;
+            phi_tmp[160 + i] += 4.0 * xc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SZZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SZZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SZZ;
+            phi_tmp[256 + i] += 4.0 * xc_pow[96 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SZZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SZZ;
+            phi_tmp[352 + i] += 2.0 * xc_pow[64 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SZZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[64 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[448 + i] += 8.0 * xc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[448 + i] += 12.0 * xc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SZZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SZZ;
+            phi_tmp[512 + i] += 2.0 * xc_pow[32 + i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SZZ;
+            phi_tmp[544 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[608 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[640 + i] += 10.0 * xc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[640 + i] += 20.0 * xc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SZZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[704 + i] += 2.0 * xc_pow[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[800 + i] += 8.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[800 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[832 + i] += 10.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[832 + i] += 20.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[864 + i] += 12.0 * xc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[864 + i] += 30.0 * xc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SZZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[928 + i] += 2.0 * xc[i] * yc_pow[128 + i] * SZ;
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[960 + i] += 4.0 * xc[i] * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[992 + i] += 6.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[992 + i] += 6.0 * xc[i] * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1024 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1024 + i] += 12.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1056 + i] += 10.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1056 + i] += 20.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[1088 + i] += 12.0 * xc[i] * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1088 + i] += 30.0 * xc[i] * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SZZ;
+            phi_tmp[1120 + i] += 14.0 * xc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1120 + i] += 42.0 * xc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SZZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SZZ;
+            phi_tmp[1184 + i] += 2.0 * yc_pow[160 + i] * SZ;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SZZ;
+            phi_tmp[1216 + i] += 4.0 * yc_pow[128 + i] * zc[i] * SZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[1248 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * SZ;
+            phi_tmp[1248 + i] += 6.0 * yc_pow[96 + i] * zc[i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1280 + i] += 8.0 * yc_pow[64 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1280 + i] += 12.0 * yc_pow[64 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1312 + i] += 10.0 * yc_pow[32 + i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1312 + i] += 20.0 * yc_pow[32 + i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[1344 + i] += 12.0 * yc_pow[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1344 + i] += 30.0 * yc_pow[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SZZ;
+            phi_tmp[1376 + i] += 14.0 * yc[i] * zc_pow[128 + i] * SZ;
+            phi_tmp[1376 + i] += 42.0 * yc[i] * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SZZ;
+            phi_tmp[1408 + i] += 16.0 * zc_pow[160 + i] * SZ;
+            phi_tmp[1408 + i] += 56.0 * zc_pow[128 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_zz_out + start), npoints);
+        }
+
+        // Combine XXX blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SXX = S2[i] * xc[i] * xc[i] + S1[i];
+            const double SXXX = S3[i] * xc[i] * xc[i] * xc[i] + 3 * xc[i] * S2[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXXX;
+            phi_tmp[i] += 3.0 * 8.0 * xc_pow[160 + i] * SXX;
+            phi_tmp[i] += 3.0 * 56.0 * xc_pow[128 + i] * SX;
+            phi_tmp[i] += 336.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXXX;
+            phi_tmp[32 + i] += 3.0 * 7.0 * xc_pow[128 + i] * yc[i] * SXX;
+            phi_tmp[32 + i] += 3.0 * 42.0 * xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[32 + i] += 210.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXXX;
+            phi_tmp[64 + i] += 3.0 * 7.0 * xc_pow[128 + i] * zc[i] * SXX;
+            phi_tmp[64 + i] += 3.0 * 42.0 * xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[64 + i] += 210.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXXX;
+            phi_tmp[96 + i] += 3.0 * 6.0 * xc_pow[96 + i] * yc_pow[i] * SXX;
+            phi_tmp[96 + i] += 3.0 * 30.0 * xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[96 + i] += 120.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXXX;
+            phi_tmp[128 + i] += 3.0 * 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * SXX;
+            phi_tmp[128 + i] += 3.0 * 30.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[128 + i] += 120.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXXX;
+            phi_tmp[160 + i] += 3.0 * 6.0 * xc_pow[96 + i] * zc_pow[i] * SXX;
+            phi_tmp[160 + i] += 3.0 * 30.0 * xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[160 + i] += 120.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXXX;
+            phi_tmp[192 + i] += 3.0 * 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * SXX;
+            phi_tmp[192 + i] += 3.0 * 20.0 * xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[192 + i] += 60.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXXX;
+            phi_tmp[224 + i] += 3.0 * 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SXX;
+            phi_tmp[224 + i] += 3.0 * 20.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 60.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXXX;
+            phi_tmp[256 + i] += 3.0 * 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SXX;
+            phi_tmp[256 + i] += 3.0 * 20.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 60.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXXX;
+            phi_tmp[288 + i] += 3.0 * 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[288 + i] += 3.0 * 20.0 * xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[288 + i] += 60.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXXX;
+            phi_tmp[320 + i] += 3.0 * 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * SXX;
+            phi_tmp[320 + i] += 3.0 * 12.0 * xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[320 + i] += 24.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXXX;
+            phi_tmp[352 + i] += 3.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXX;
+            phi_tmp[352 + i] += 3.0 * 12.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[352 + i] += 24.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXXX;
+            phi_tmp[384 + i] += 3.0 * 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXX;
+            phi_tmp[384 + i] += 3.0 * 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 24.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXXX;
+            phi_tmp[416 + i] += 3.0 * 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[416 + i] += 3.0 * 12.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 24.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXXX;
+            phi_tmp[448 + i] += 3.0 * 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * SXX;
+            phi_tmp[448 + i] += 3.0 * 12.0 * xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[448 + i] += 24.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXXX;
+            phi_tmp[480 + i] += 3.0 * 3.0 * xc_pow[i] * yc_pow[96 + i] * SXX;
+            phi_tmp[480 + i] += 3.0 * 6.0 * xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[480 + i] += 6.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXXX;
+            phi_tmp[512 + i] += 3.0 * 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SXX;
+            phi_tmp[512 + i] += 3.0 * 6.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 6.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXXX;
+            phi_tmp[544 + i] += 3.0 * 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXX;
+            phi_tmp[544 + i] += 3.0 * 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 6.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXXX;
+            phi_tmp[576 + i] += 3.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[576 + i] += 3.0 * 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 6.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXXX;
+            phi_tmp[608 + i] += 3.0 * 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[608 + i] += 3.0 * 6.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 6.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXXX;
+            phi_tmp[640 + i] += 3.0 * 3.0 * xc_pow[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[640 + i] += 3.0 * 6.0 * xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[640 + i] += 6.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXXX;
+            phi_tmp[672 + i] += 3.0 * 2.0 * xc[i] * yc_pow[128 + i] * SXX;
+            phi_tmp[672 + i] += 3.0 * 2.0 * yc_pow[128 + i] * SX;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXXX;
+            phi_tmp[704 + i] += 3.0 * 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SXX;
+            phi_tmp[704 + i] += 3.0 * 2.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXXX;
+            phi_tmp[736 + i] += 3.0 * 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SXX;
+            phi_tmp[736 + i] += 3.0 * 2.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXXX;
+            phi_tmp[768 + i] += 3.0 * 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[768 + i] += 3.0 * 2.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXXX;
+            phi_tmp[800 + i] += 3.0 * 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[800 + i] += 3.0 * 2.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXXX;
+            phi_tmp[832 + i] += 3.0 * 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[832 + i] += 3.0 * 2.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXXX;
+            phi_tmp[864 + i] += 3.0 * 2.0 * xc[i] * zc_pow[128 + i] * SXX;
+            phi_tmp[864 + i] += 3.0 * 2.0 * zc_pow[128 + i] * SX;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXXX;
+            phi_tmp[896 + i] += 3.0 * yc_pow[160 + i] * SXX;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXXX;
+            phi_tmp[928 + i] += 3.0 * yc_pow[128 + i] * zc[i] * SXX;
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXXX;
+            phi_tmp[960 + i] += 3.0 * yc_pow[96 + i] * zc_pow[i] * SXX;
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXXX;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[32 + i] * SXX;
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXXX;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[32 + i] * zc_pow[64 + i] * SXX;
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXXX;
+            phi_tmp[1056 + i] += 3.0 * yc_pow[i] * zc_pow[96 + i] * SXX;
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXXX;
+            phi_tmp[1088 + i] += 3.0 * yc[i] * zc_pow[128 + i] * SXX;
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXXX;
+            phi_tmp[1120 + i] += 3.0 * zc_pow[160 + i] * SXX;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXXX;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXXX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXXX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXXX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXXX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXXX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXXX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXXX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXXX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xxx_out + start), npoints);
+        }
+
+        // Combine XXY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SY = S1[i] * yc[i];
+            const double SXY = S2[i] * xc[i] * yc[i];
+            const double SXX = S2[i] * xc[i] * xc[i] + S1[i];
+            const double SXXY = S3[i] * xc[i] * xc[i] * yc[i] + S2[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXXY;
+            phi_tmp[i] += 2.0 * 8.0 * xc_pow[160 + i] * SXY;
+            phi_tmp[i] += 56.0 * xc_pow[128 + i] * SY;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXXY;
+            phi_tmp[32 + i] += 2.0 * 7.0 * xc_pow[128 + i] * yc[i] * SXY;
+            phi_tmp[32 + i] += xc_pow[160 + i] * SXX;
+            phi_tmp[32 + i] += 42.0 * xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[32 + i] += 2.0 * 7.0 * xc_pow[128 + i] * SX;
+            phi_tmp[32 + i] += 42.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXXY;
+            phi_tmp[64 + i] += 2.0 * 7.0 * xc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[64 + i] += 42.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXXY;
+            phi_tmp[96 + i] += 2.0 * 6.0 * xc_pow[96 + i] * yc_pow[i] * SXY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * yc[i] * SXX;
+            phi_tmp[96 + i] += 30.0 * xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[96 + i] += 2.0 * 12.0 * xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[96 + i] += 60.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXXY;
+            phi_tmp[128 + i] += 2.0 * 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * SXY;
+            phi_tmp[128 + i] += xc_pow[128 + i] * zc[i] * SXX;
+            phi_tmp[128 + i] += 30.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[128 + i] += 2.0 * 6.0 * xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[128 + i] += 30.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXXY;
+            phi_tmp[160 + i] += 2.0 * 6.0 * xc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[160 + i] += 30.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXXY;
+            phi_tmp[192 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * SXY;
+            phi_tmp[192 + i] += 3.0 * xc_pow[96 + i] * yc_pow[i] * SXX;
+            phi_tmp[192 + i] += 20.0 * xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[192 + i] += 2.0 * 15.0 * xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[192 + i] += 60.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXXY;
+            phi_tmp[224 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SXY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SXX;
+            phi_tmp[224 + i] += 20.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[224 + i] += 40.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXXY;
+            phi_tmp[256 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SXY;
+            phi_tmp[256 + i] += xc_pow[96 + i] * zc_pow[i] * SXX;
+            phi_tmp[256 + i] += 20.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[256 + i] += 2.0 * 5.0 * xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[256 + i] += 20.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXXY;
+            phi_tmp[288 + i] += 2.0 * 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[288 + i] += 20.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXXY;
+            phi_tmp[320 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * SXY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * SXX;
+            phi_tmp[320 + i] += 12.0 * xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[320 + i] += 2.0 * 16.0 * xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[320 + i] += 48.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXXY;
+            phi_tmp[352 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SXX;
+            phi_tmp[352 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[352 + i] += 2.0 * 12.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[352 + i] += 36.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXXY;
+            phi_tmp[384 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SXX;
+            phi_tmp[384 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * 8.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 24.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXXY;
+            phi_tmp[416 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[416 + i] += xc_pow[64 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[416 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[416 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[416 + i] += 12.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXXY;
+            phi_tmp[448 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[448 + i] += 12.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXXY;
+            phi_tmp[480 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[96 + i] * SXY;
+            phi_tmp[480 + i] += 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * SXX;
+            phi_tmp[480 + i] += 6.0 * xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[480 + i] += 2.0 * 15.0 * xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[480 + i] += 30.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXXY;
+            phi_tmp[512 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SXY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXX;
+            phi_tmp[512 + i] += 6.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 2.0 * 12.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[512 + i] += 24.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXXY;
+            phi_tmp[544 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXX;
+            phi_tmp[544 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 2.0 * 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 18.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXXY;
+            phi_tmp[576 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[576 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 2.0 * 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 12.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXXY;
+            phi_tmp[608 + i] += 2.0 * 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[608 + i] += xc_pow[32 + i] * zc_pow[64 + i] * SXX;
+            phi_tmp[608 + i] += 6.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[608 + i] += 2.0 * 3.0 * xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[608 + i] += 6.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXXY;
+            phi_tmp[640 + i] += 2.0 * 3.0 * xc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[640 + i] += 6.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXXY;
+            phi_tmp[672 + i] += 2.0 * 2.0 * xc[i] * yc_pow[128 + i] * SXY;
+            phi_tmp[672 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * SXX;
+            phi_tmp[672 + i] += 2.0 * yc_pow[128 + i] * SY;
+            phi_tmp[672 + i] += 2.0 * 12.0 * xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[672 + i] += 12.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXXY;
+            phi_tmp[704 + i] += 2.0 * 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SXX;
+            phi_tmp[704 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 2.0 * 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += 10.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXXY;
+            phi_tmp[736 + i] += 2.0 * 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXX;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 2.0 * 8.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += 8.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXXY;
+            phi_tmp[768 + i] += 2.0 * 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[768 + i] += 2.0 * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 2.0 * 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += 6.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXXY;
+            phi_tmp[800 + i] += 2.0 * 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[800 + i] += 2.0 * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 2.0 * 4.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += 4.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXXY;
+            phi_tmp[832 + i] += 2.0 * 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[832 + i] += xc_pow[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[832 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[832 + i] += 2.0 * 2.0 * xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXXY;
+            phi_tmp[864 + i] += 2.0 * 2.0 * xc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[864 + i] += 2.0 * zc_pow[128 + i] * SY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXXY;
+            phi_tmp[896 + i] += 2.0 * yc_pow[160 + i] * SXY;
+            phi_tmp[896 + i] += 7.0 * xc[i] * yc_pow[128 + i] * SXX;
+            phi_tmp[896 + i] += 2.0 * 7.0 * yc_pow[128 + i] * SX;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXXY;
+            phi_tmp[928 + i] += 2.0 * yc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * SXX;
+            phi_tmp[928 + i] += 2.0 * 6.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXXY;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[960 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SXX;
+            phi_tmp[960 + i] += 2.0 * 5.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXXY;
+            phi_tmp[992 + i] += 2.0 * yc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[992 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[992 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXXY;
+            phi_tmp[1024 + i] += 2.0 * yc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1024 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[1024 + i] += 2.0 * 3.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXXY;
+            phi_tmp[1056 + i] += 2.0 * yc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[1056 + i] += 2.0 * 2.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXXY;
+            phi_tmp[1088 + i] += 2.0 * yc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[1088 + i] += xc[i] * zc_pow[128 + i] * SXX;
+            phi_tmp[1088 + i] += 2.0 * zc_pow[128 + i] * SX;
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXXY;
+            phi_tmp[1120 + i] += 2.0 * zc_pow[160 + i] * SXY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXXY;
+            phi_tmp[1152 + i] += 8.0 * yc_pow[160 + i] * SXX;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXXY;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * zc[i] * SXX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXXY;
+            phi_tmp[1216 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * SXX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXXY;
+            phi_tmp[1248 + i] += 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * SXX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXXY;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * SXX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXXY;
+            phi_tmp[1312 + i] += 3.0 * yc_pow[i] * zc_pow[96 + i] * SXX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXXY;
+            phi_tmp[1344 + i] += 2.0 * yc[i] * zc_pow[128 + i] * SXX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXXY;
+            phi_tmp[1376 + i] += zc_pow[160 + i] * SXX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXXY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xxy_out + start), npoints);
+        }
+
+        // Combine XXZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SXZ = S2[i] * xc[i] * zc[i];
+            const double SXX = S2[i] * xc[i] * xc[i] + S1[i];
+            const double SXXZ = S3[i] * xc[i] * xc[i] * zc[i] + S2[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXXZ;
+            phi_tmp[i] += 2.0 * 8.0 * xc_pow[160 + i] * SXZ;
+            phi_tmp[i] += 56.0 * xc_pow[128 + i] * SZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXXZ;
+            phi_tmp[32 + i] += 2.0 * 7.0 * xc_pow[128 + i] * yc[i] * SXZ;
+            phi_tmp[32 + i] += 42.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXXZ;
+            phi_tmp[64 + i] += 2.0 * 7.0 * xc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[64 + i] += xc_pow[160 + i] * SXX;
+            phi_tmp[64 + i] += 42.0 * xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[64 + i] += 2.0 * 7.0 * xc_pow[128 + i] * SX;
+            phi_tmp[64 + i] += 42.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXXZ;
+            phi_tmp[96 + i] += 2.0 * 6.0 * xc_pow[96 + i] * yc_pow[i] * SXZ;
+            phi_tmp[96 + i] += 30.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXXZ;
+            phi_tmp[128 + i] += 2.0 * 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * SXZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * yc[i] * SXX;
+            phi_tmp[128 + i] += 30.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[128 + i] += 2.0 * 6.0 * xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[128 + i] += 30.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXXZ;
+            phi_tmp[160 + i] += 2.0 * 6.0 * xc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * zc[i] * SXX;
+            phi_tmp[160 + i] += 30.0 * xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[160 + i] += 2.0 * 12.0 * xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[160 + i] += 60.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXXZ;
+            phi_tmp[192 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * SXZ;
+            phi_tmp[192 + i] += 20.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXXZ;
+            phi_tmp[224 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SXZ;
+            phi_tmp[224 + i] += xc_pow[96 + i] * yc_pow[i] * SXX;
+            phi_tmp[224 + i] += 20.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[224 + i] += 20.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXXZ;
+            phi_tmp[256 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SXZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SXX;
+            phi_tmp[256 + i] += 20.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[256 + i] += 40.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXXZ;
+            phi_tmp[288 + i] += 2.0 * 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[96 + i] * zc_pow[i] * SXX;
+            phi_tmp[288 + i] += 20.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[288 + i] += 2.0 * 15.0 * xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[288 + i] += 60.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXXZ;
+            phi_tmp[320 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * SXZ;
+            phi_tmp[320 + i] += 12.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXXZ;
+            phi_tmp[352 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXZ;
+            phi_tmp[352 + i] += xc_pow[64 + i] * yc_pow[32 + i] * SXX;
+            phi_tmp[352 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[352 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXXZ;
+            phi_tmp[384 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SXX;
+            phi_tmp[384 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * 8.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[384 + i] += 24.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXXZ;
+            phi_tmp[416 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SXX;
+            phi_tmp[416 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 2.0 * 12.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[416 + i] += 36.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXXZ;
+            phi_tmp[448 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[448 + i] += 12.0 * xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[448 + i] += 2.0 * 16.0 * xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[448 + i] += 48.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXXZ;
+            phi_tmp[480 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[96 + i] * SXZ;
+            phi_tmp[480 + i] += 6.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXXZ;
+            phi_tmp[512 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SXZ;
+            phi_tmp[512 + i] += xc_pow[32 + i] * yc_pow[64 + i] * SXX;
+            phi_tmp[512 + i] += 6.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[512 + i] += 6.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXXZ;
+            phi_tmp[544 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXX;
+            phi_tmp[544 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[544 + i] += 12.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXXZ;
+            phi_tmp[576 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXX;
+            phi_tmp[576 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 2.0 * 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[576 + i] += 18.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXXZ;
+            phi_tmp[608 + i] += 2.0 * 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[608 + i] += 6.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 2.0 * 12.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[608 + i] += 24.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXXZ;
+            phi_tmp[640 + i] += 2.0 * 3.0 * xc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * SXX;
+            phi_tmp[640 + i] += 6.0 * xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[640 + i] += 2.0 * 15.0 * xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[640 + i] += 30.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXXZ;
+            phi_tmp[672 + i] += 2.0 * 2.0 * xc[i] * yc_pow[128 + i] * SXZ;
+            phi_tmp[672 + i] += 2.0 * yc_pow[128 + i] * SZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXXZ;
+            phi_tmp[704 + i] += 2.0 * 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[704 + i] += xc_pow[i] * yc_pow[96 + i] * SXX;
+            phi_tmp[704 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += 2.0 * 2.0 * xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[704 + i] += 2.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXXZ;
+            phi_tmp[736 + i] += 2.0 * 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SXX;
+            phi_tmp[736 + i] += 2.0 * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * 4.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[736 + i] += 4.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXXZ;
+            phi_tmp[768 + i] += 2.0 * 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXX;
+            phi_tmp[768 + i] += 2.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 2.0 * 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[768 + i] += 6.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXXZ;
+            phi_tmp[800 + i] += 2.0 * 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXX;
+            phi_tmp[800 + i] += 2.0 * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 2.0 * 8.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[800 + i] += 8.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXXZ;
+            phi_tmp[832 + i] += 2.0 * 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[832 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 2.0 * 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[832 + i] += 10.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXXZ;
+            phi_tmp[864 + i] += 2.0 * 2.0 * xc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[864 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[864 + i] += 2.0 * zc_pow[128 + i] * SZ;
+            phi_tmp[864 + i] += 2.0 * 12.0 * xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[864 + i] += 12.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXXZ;
+            phi_tmp[896 + i] += 2.0 * yc_pow[160 + i] * SXZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXXZ;
+            phi_tmp[928 + i] += 2.0 * yc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[928 + i] += xc[i] * yc_pow[128 + i] * SXX;
+            phi_tmp[928 + i] += 2.0 * yc_pow[128 + i] * SX;
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXXZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SXX;
+            phi_tmp[960 + i] += 2.0 * 2.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXXZ;
+            phi_tmp[992 + i] += 2.0 * yc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[992 + i] += 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SXX;
+            phi_tmp[992 + i] += 2.0 * 3.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXXZ;
+            phi_tmp[1024 + i] += 2.0 * yc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1024 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXX;
+            phi_tmp[1024 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXXZ;
+            phi_tmp[1056 + i] += 2.0 * yc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1056 + i] += 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SXX;
+            phi_tmp[1056 + i] += 2.0 * 5.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXXZ;
+            phi_tmp[1088 + i] += 2.0 * yc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * SXX;
+            phi_tmp[1088 + i] += 2.0 * 6.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXXZ;
+            phi_tmp[1120 + i] += 2.0 * zc_pow[160 + i] * SXZ;
+            phi_tmp[1120 + i] += 7.0 * xc[i] * zc_pow[128 + i] * SXX;
+            phi_tmp[1120 + i] += 2.0 * 7.0 * zc_pow[128 + i] * SX;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXXZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXXZ;
+            phi_tmp[1184 + i] += yc_pow[160 + i] * SXX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXXZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * zc[i] * SXX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXXZ;
+            phi_tmp[1248 + i] += 3.0 * yc_pow[96 + i] * zc_pow[i] * SXX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXXZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * SXX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXXZ;
+            phi_tmp[1312 + i] += 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * SXX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXXZ;
+            phi_tmp[1344 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * SXX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXXZ;
+            phi_tmp[1376 + i] += 7.0 * yc[i] * zc_pow[128 + i] * SXX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXXZ;
+            phi_tmp[1408 + i] += 8.0 * zc_pow[160 + i] * SXX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xxz_out + start), npoints);
+        }
+
+        // Combine XYY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SY = S1[i] * yc[i];
+            const double SXY = S2[i] * xc[i] * yc[i];
+            const double SYY = S2[i] * yc[i] * yc[i] + S1[i];
+            const double SXYY = S3[i] * xc[i] * yc[i] * yc[i] + S2[i] * xc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXYY;
+            phi_tmp[i] += 8.0 * xc_pow[160 + i] * SYY;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXYY;
+            phi_tmp[32 + i] += 2.0 * xc_pow[160 + i] * SXY;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * yc[i] * SYY;
+            phi_tmp[32 + i] += 2.0 * 7.0 * xc_pow[128 + i] * SY;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXYY;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * zc[i] * SYY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXYY;
+            phi_tmp[96 + i] += 2.0 * 2.0 * xc_pow[128 + i] * yc[i] * SXY;
+            phi_tmp[96 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * SYY;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * SX;
+            phi_tmp[96 + i] += 2.0 * 12.0 * xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[96 + i] += 12.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXYY;
+            phi_tmp[128 + i] += 2.0 * xc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * SYY;
+            phi_tmp[128 + i] += 2.0 * 6.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXYY;
+            phi_tmp[160 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * SYY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXYY;
+            phi_tmp[192 + i] += 2.0 * 3.0 * xc_pow[96 + i] * yc_pow[i] * SXY;
+            phi_tmp[192 + i] += 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * SYY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[192 + i] += 2.0 * 15.0 * xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[192 + i] += 30.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXYY;
+            phi_tmp[224 + i] += 2.0 * 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SXY;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SYY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[224 + i] += 2.0 * 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[224 + i] += 10.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXYY;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SYY;
+            phi_tmp[256 + i] += 2.0 * 5.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXYY;
+            phi_tmp[288 + i] += 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * SYY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXYY;
+            phi_tmp[320 + i] += 2.0 * 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * SXY;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * SYY;
+            phi_tmp[320 + i] += 12.0 * xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[320 + i] += 2.0 * 16.0 * xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[320 + i] += 48.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXYY;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SXY;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[352 + i] += 2.0 * 12.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[352 + i] += 24.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXYY;
+            phi_tmp[384 + i] += 2.0 * 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SXY;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[384 + i] += 2.0 * 8.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[384 + i] += 8.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXYY;
+            phi_tmp[416 + i] += 2.0 * xc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[416 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXYY;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * SYY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXYY;
+            phi_tmp[480 + i] += 2.0 * 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * SXY;
+            phi_tmp[480 + i] += 3.0 * xc_pow[i] * yc_pow[96 + i] * SYY;
+            phi_tmp[480 + i] += 20.0 * xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[480 + i] += 2.0 * 15.0 * xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[480 + i] += 60.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXYY;
+            phi_tmp[512 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXY;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SYY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[512 + i] += 2.0 * 12.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[512 + i] += 36.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXYY;
+            phi_tmp[544 + i] += 2.0 * 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXY;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[544 + i] += 2.0 * 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 18.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXYY;
+            phi_tmp[576 + i] += 2.0 * 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[576 + i] += 2.0 * 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXYY;
+            phi_tmp[608 + i] += 2.0 * xc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[608 + i] += 2.0 * 3.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXYY;
+            phi_tmp[640 + i] += 3.0 * xc_pow[i] * zc_pow[96 + i] * SYY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXYY;
+            phi_tmp[672 + i] += 2.0 * 6.0 * xc_pow[i] * yc_pow[96 + i] * SXY;
+            phi_tmp[672 + i] += 2.0 * xc[i] * yc_pow[128 + i] * SYY;
+            phi_tmp[672 + i] += 30.0 * xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[672 + i] += 2.0 * 12.0 * xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[672 + i] += 60.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXYY;
+            phi_tmp[704 + i] += 2.0 * 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SXY;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SYY;
+            phi_tmp[704 + i] += 20.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[704 + i] += 2.0 * 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 40.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXYY;
+            phi_tmp[736 + i] += 2.0 * 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXY;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SYY;
+            phi_tmp[736 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[736 + i] += 2.0 * 8.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 24.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXYY;
+            phi_tmp[768 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[768 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[768 + i] += 2.0 * 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 12.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXYY;
+            phi_tmp[800 + i] += 2.0 * 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[800 + i] += 2.0 * 4.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[800 + i] += 4.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXYY;
+            phi_tmp[832 + i] += 2.0 * xc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[832 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[832 + i] += 2.0 * 2.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXYY;
+            phi_tmp[864 + i] += 2.0 * xc[i] * zc_pow[128 + i] * SYY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXYY;
+            phi_tmp[896 + i] += 2.0 * 7.0 * xc[i] * yc_pow[128 + i] * SXY;
+            phi_tmp[896 + i] += yc_pow[160 + i] * SYY;
+            phi_tmp[896 + i] += 42.0 * xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[896 + i] += 2.0 * 7.0 * yc_pow[128 + i] * SY;
+            phi_tmp[896 + i] += 42.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXYY;
+            phi_tmp[928 + i] += 2.0 * 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[928 + i] += yc_pow[128 + i] * zc[i] * SYY;
+            phi_tmp[928 + i] += 30.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[928 + i] += 2.0 * 6.0 * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 30.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXYY;
+            phi_tmp[960 + i] += 2.0 * 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[960 + i] += yc_pow[96 + i] * zc_pow[i] * SYY;
+            phi_tmp[960 + i] += 20.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[960 + i] += 2.0 * 5.0 * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 20.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXYY;
+            phi_tmp[992 + i] += 2.0 * 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[992 + i] += yc_pow[64 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[992 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[992 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 12.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXYY;
+            phi_tmp[1024 + i] += 2.0 * 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1024 + i] += yc_pow[32 + i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1024 + i] += 6.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[1024 + i] += 2.0 * 3.0 * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 6.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXYY;
+            phi_tmp[1056 + i] += 2.0 * 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1056 + i] += yc_pow[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[1056 + i] += 2.0 * 2.0 * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXYY;
+            phi_tmp[1088 + i] += 2.0 * xc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[1088 + i] += yc[i] * zc_pow[128 + i] * SYY;
+            phi_tmp[1088 + i] += 2.0 * zc_pow[128 + i] * SY;
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXYY;
+            phi_tmp[1120 + i] += zc_pow[160 + i] * SYY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXYY;
+            phi_tmp[1152 + i] += 2.0 * 8.0 * yc_pow[160 + i] * SXY;
+            phi_tmp[1152 + i] += 56.0 * yc_pow[128 + i] * SX;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXYY;
+            phi_tmp[1184 + i] += 2.0 * 7.0 * yc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[1184 + i] += 42.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXYY;
+            phi_tmp[1216 + i] += 2.0 * 6.0 * yc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[1216 + i] += 30.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXYY;
+            phi_tmp[1248 + i] += 2.0 * 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[1248 + i] += 20.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXYY;
+            phi_tmp[1280 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1280 + i] += 12.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXYY;
+            phi_tmp[1312 + i] += 2.0 * 3.0 * yc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1312 + i] += 6.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXYY;
+            phi_tmp[1344 + i] += 2.0 * 2.0 * yc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[1344 + i] += 2.0 * zc_pow[128 + i] * SX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXYY;
+            phi_tmp[1376 + i] += 2.0 * zc_pow[160 + i] * SXY;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXYY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xyy_out + start), npoints);
+        }
+
+        // Combine XYZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SY = S1[i] * yc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SXY = S2[i] * xc[i] * yc[i];
+            const double SXZ = S2[i] * xc[i] * zc[i];
+            const double SYZ = S2[i] * yc[i] * zc[i];
+            const double SXYZ = S3[i] * xc[i] * yc[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXYZ;
+            phi_tmp[i] += 8.0 * xc_pow[160 + i] * SYZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXYZ;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * yc[i] * SYZ;
+            phi_tmp[32 + i] += xc_pow[160 + i] * SXZ;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * SZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXYZ;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[64 + i] += xc_pow[160 + i] * SXY;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * SY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXYZ;
+            phi_tmp[96 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * SYZ;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * yc[i] * SXZ;
+            phi_tmp[96 + i] += 12.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXYZ;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * SYZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * yc[i] * SXY;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[128 + i] += xc_pow[128 + i] * SX;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXYZ;
+            phi_tmp[160 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[160 + i] += 12.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXYZ;
+            phi_tmp[192 + i] += 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * SYZ;
+            phi_tmp[192 + i] += 3.0 * xc_pow[96 + i] * yc_pow[i] * SXZ;
+            phi_tmp[192 + i] += 15.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXYZ;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SYZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SXZ;
+            phi_tmp[224 + i] += xc_pow[96 + i] * yc_pow[i] * SXY;
+            phi_tmp[224 + i] += 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[224 + i] += 20.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXYZ;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SYZ;
+            phi_tmp[256 + i] += xc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SXY;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[256 + i] += 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXYZ;
+            phi_tmp[288 + i] += 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[288 + i] += 15.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXYZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * SYZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * SXZ;
+            phi_tmp[320 + i] += 16.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXYZ;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SXZ;
+            phi_tmp[352 + i] += xc_pow[64 + i] * yc_pow[32 + i] * SXY;
+            phi_tmp[352 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[352 + i] += 36.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXYZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SXZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SXY;
+            phi_tmp[384 + i] += 8.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 8.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[384 + i] += 4.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[384 + i] += 16.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXYZ;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[416 + i] += xc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SXY;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[416 + i] += 12.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXYZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[448 + i] += 16.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXYZ;
+            phi_tmp[480 + i] += 3.0 * xc_pow[i] * yc_pow[96 + i] * SYZ;
+            phi_tmp[480 + i] += 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * SXZ;
+            phi_tmp[480 + i] += 15.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXYZ;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SYZ;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXZ;
+            phi_tmp[512 + i] += xc_pow[32 + i] * yc_pow[64 + i] * SXY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[512 + i] += 48.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXYZ;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYZ;
+            phi_tmp[544 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXY;
+            phi_tmp[544 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[544 + i] += 27.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXYZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXY;
+            phi_tmp[576 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[576 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[576 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXYZ;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[608 + i] += xc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXYZ;
+            phi_tmp[640 + i] += 3.0 * xc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[640 + i] += 15.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXYZ;
+            phi_tmp[672 + i] += 2.0 * xc[i] * yc_pow[128 + i] * SYZ;
+            phi_tmp[672 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * SXZ;
+            phi_tmp[672 + i] += 12.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXYZ;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SXZ;
+            phi_tmp[704 + i] += xc_pow[i] * yc_pow[96 + i] * SXY;
+            phi_tmp[704 + i] += 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[704 + i] += 50.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXYZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SXY;
+            phi_tmp[736 + i] += 8.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[736 + i] += 8.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[736 + i] += 32.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXYZ;
+            phi_tmp[768 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXY;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[768 + i] += 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[768 + i] += 18.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXYZ;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXY;
+            phi_tmp[800 + i] += 4.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 8.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[800 + i] += 8.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[800 + i] += 8.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXYZ;
+            phi_tmp[832 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[832 + i] += xc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[832 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[832 + i] += 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXYZ;
+            phi_tmp[864 + i] += 2.0 * xc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[864 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[864 + i] += 12.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXYZ;
+            phi_tmp[896 + i] += yc_pow[160 + i] * SYZ;
+            phi_tmp[896 + i] += 7.0 * xc[i] * yc_pow[128 + i] * SXZ;
+            phi_tmp[896 + i] += 7.0 * yc_pow[128 + i] * SZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXYZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[928 + i] += xc[i] * yc_pow[128 + i] * SXY;
+            phi_tmp[928 + i] += 6.0 * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * SY;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[928 + i] += 36.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXYZ;
+            phi_tmp[960 + i] += yc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[960 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SXY;
+            phi_tmp[960 + i] += 5.0 * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[960 + i] += 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[960 + i] += 25.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXYZ;
+            phi_tmp[992 + i] += yc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[992 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[992 + i] += 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SXY;
+            phi_tmp[992 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 3.0 * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[992 + i] += 12.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[992 + i] += 16.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXYZ;
+            phi_tmp[1024 + i] += yc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1024 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1024 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[1024 + i] += 3.0 * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1024 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[1024 + i] += 9.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXYZ;
+            phi_tmp[1056 + i] += yc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1056 + i] += 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1056 + i] += 2.0 * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 5.0 * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1056 + i] += 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[1056 + i] += 4.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXYZ;
+            phi_tmp[1088 + i] += yc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[1088 + i] += xc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1088 + i] += zc_pow[128 + i] * SZ;
+            phi_tmp[1088 + i] += 6.0 * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[1088 + i] += zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXYZ;
+            phi_tmp[1120 + i] += zc_pow[160 + i] * SYZ;
+            phi_tmp[1120 + i] += 7.0 * xc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[1120 + i] += 7.0 * zc_pow[128 + i] * SY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXYZ;
+            phi_tmp[1152 + i] += 8.0 * yc_pow[160 + i] * SXZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXYZ;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[1184 + i] += yc_pow[160 + i] * SXY;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * SX;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXYZ;
+            phi_tmp[1216 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * zc[i] * SXY;
+            phi_tmp[1216 + i] += 12.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXYZ;
+            phi_tmp[1248 + i] += 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[1248 + i] += 3.0 * yc_pow[96 + i] * zc_pow[i] * SXY;
+            phi_tmp[1248 + i] += 15.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXYZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * SXY;
+            phi_tmp[1280 + i] += 16.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXYZ;
+            phi_tmp[1312 + i] += 3.0 * yc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1312 + i] += 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * SXY;
+            phi_tmp[1312 + i] += 15.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXYZ;
+            phi_tmp[1344 + i] += 2.0 * yc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[1344 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * SXY;
+            phi_tmp[1344 + i] += 12.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXYZ;
+            phi_tmp[1376 + i] += zc_pow[160 + i] * SXZ;
+            phi_tmp[1376 + i] += 7.0 * yc[i] * zc_pow[128 + i] * SXY;
+            phi_tmp[1376 + i] += 7.0 * zc_pow[128 + i] * SX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXYZ;
+            phi_tmp[1408 + i] += 8.0 * zc_pow[160 + i] * SXY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xyz_out + start), npoints);
+        }
+
+        // Combine XZZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SX = S1[i] * xc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SXZ = S2[i] * xc[i] * zc[i];
+            const double SZZ = S2[i] * zc[i] * zc[i] + S1[i];
+            const double SXZZ = S3[i] * xc[i] * zc[i] * zc[i] + S2[i] * xc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SXZZ;
+            phi_tmp[i] += 8.0 * xc_pow[160 + i] * SZZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SXZZ;
+            phi_tmp[32 + i] += 7.0 * xc_pow[128 + i] * yc[i] * SZZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SXZZ;
+            phi_tmp[64 + i] += 2.0 * xc_pow[160 + i] * SXZ;
+            phi_tmp[64 + i] += 7.0 * xc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[64 + i] += 2.0 * 7.0 * xc_pow[128 + i] * SZ;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SXZZ;
+            phi_tmp[96 + i] += 6.0 * xc_pow[96 + i] * yc_pow[i] * SZZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SXZZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[128 + i] * yc[i] * SXZ;
+            phi_tmp[128 + i] += 6.0 * xc_pow[96 + i] * yc[i] * zc[i] * SZZ;
+            phi_tmp[128 + i] += 2.0 * 6.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SXZZ;
+            phi_tmp[160 + i] += 2.0 * 2.0 * xc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[160 + i] += 6.0 * xc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * SX;
+            phi_tmp[160 + i] += 2.0 * 12.0 * xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[160 + i] += 12.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SXZZ;
+            phi_tmp[192 + i] += 5.0 * xc_pow[64 + i] * yc_pow[32 + i] * SZZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SXZZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc_pow[i] * SXZ;
+            phi_tmp[224 + i] += 5.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SZZ;
+            phi_tmp[224 + i] += 2.0 * 5.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SXZZ;
+            phi_tmp[256 + i] += 2.0 * 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SXZ;
+            phi_tmp[256 + i] += 5.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SZZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SX;
+            phi_tmp[256 + i] += 2.0 * 10.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[256 + i] += 10.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SXZZ;
+            phi_tmp[288 + i] += 2.0 * 3.0 * xc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[288 + i] += 5.0 * xc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[96 + i] * zc[i] * SX;
+            phi_tmp[288 + i] += 2.0 * 15.0 * xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[288 + i] += 30.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SXZZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[32 + i] * yc_pow[64 + i] * SZZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SXZZ;
+            phi_tmp[352 + i] += 2.0 * xc_pow[64 + i] * yc_pow[32 + i] * SXZ;
+            phi_tmp[352 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZZ;
+            phi_tmp[352 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SXZZ;
+            phi_tmp[384 + i] += 2.0 * 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SXZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * SX;
+            phi_tmp[384 + i] += 2.0 * 8.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[384 + i] += 8.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SXZZ;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SXZ;
+            phi_tmp[416 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[64 + i] * yc[i] * zc[i] * SX;
+            phi_tmp[416 + i] += 2.0 * 12.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[416 + i] += 24.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SXZZ;
+            phi_tmp[448 + i] += 2.0 * 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[448 + i] += 12.0 * xc_pow[64 + i] * zc_pow[i] * SX;
+            phi_tmp[448 + i] += 2.0 * 16.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[448 + i] += 48.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SXZZ;
+            phi_tmp[480 + i] += 3.0 * xc_pow[i] * yc_pow[96 + i] * SZZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SXZZ;
+            phi_tmp[512 + i] += 2.0 * xc_pow[32 + i] * yc_pow[64 + i] * SXZ;
+            phi_tmp[512 + i] += 3.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SZZ;
+            phi_tmp[512 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SXZZ;
+            phi_tmp[544 + i] += 2.0 * 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SXZ;
+            phi_tmp[544 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * SX;
+            phi_tmp[544 + i] += 2.0 * 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[544 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SXZZ;
+            phi_tmp[576 + i] += 2.0 * 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SXZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SX;
+            phi_tmp[576 + i] += 2.0 * 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[576 + i] += 18.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SXZZ;
+            phi_tmp[608 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[608 + i] += 3.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SX;
+            phi_tmp[608 + i] += 2.0 * 12.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[608 + i] += 36.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SXZZ;
+            phi_tmp[640 + i] += 2.0 * 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[640 + i] += 3.0 * xc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[640 + i] += 20.0 * xc_pow[32 + i] * zc_pow[32 + i] * SX;
+            phi_tmp[640 + i] += 2.0 * 15.0 * xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[640 + i] += 60.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SXZZ;
+            phi_tmp[672 + i] += 2.0 * xc[i] * yc_pow[128 + i] * SZZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SXZZ;
+            phi_tmp[704 + i] += 2.0 * xc_pow[i] * yc_pow[96 + i] * SXZ;
+            phi_tmp[704 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[704 + i] += 2.0 * 2.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SXZZ;
+            phi_tmp[736 + i] += 2.0 * 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SXZ;
+            phi_tmp[736 + i] += 2.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * SX;
+            phi_tmp[736 + i] += 2.0 * 4.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[736 + i] += 4.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXZZ;
+            phi_tmp[768 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SXZ;
+            phi_tmp[768 + i] += 2.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SX;
+            phi_tmp[768 + i] += 2.0 * 6.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[768 + i] += 12.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SXZZ;
+            phi_tmp[800 + i] += 2.0 * 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[800 + i] += 2.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[800 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SX;
+            phi_tmp[800 + i] += 2.0 * 8.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[800 + i] += 24.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SXZZ;
+            phi_tmp[832 + i] += 2.0 * 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[832 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[832 + i] += 20.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SX;
+            phi_tmp[832 + i] += 2.0 * 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[832 + i] += 40.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SXZZ;
+            phi_tmp[864 + i] += 2.0 * 6.0 * xc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[864 + i] += 2.0 * xc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[864 + i] += 30.0 * xc_pow[i] * zc_pow[64 + i] * SX;
+            phi_tmp[864 + i] += 2.0 * 12.0 * xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[864 + i] += 60.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SXZZ;
+            phi_tmp[896 + i] += yc_pow[160 + i] * SZZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SXZZ;
+            phi_tmp[928 + i] += 2.0 * xc[i] * yc_pow[128 + i] * SXZ;
+            phi_tmp[928 + i] += yc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[928 + i] += 2.0 * yc_pow[128 + i] * SZ;
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SXZZ;
+            phi_tmp[960 + i] += 2.0 * 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SXZ;
+            phi_tmp[960 + i] += yc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SX;
+            phi_tmp[960 + i] += 2.0 * 2.0 * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SXZZ;
+            phi_tmp[992 + i] += 2.0 * 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SXZ;
+            phi_tmp[992 + i] += yc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[992 + i] += 6.0 * xc[i] * yc_pow[64 + i] * zc[i] * SX;
+            phi_tmp[992 + i] += 2.0 * 3.0 * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[992 + i] += 6.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SXZZ;
+            phi_tmp[1024 + i] += 2.0 * 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[1024 + i] += yc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1024 + i] += 12.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SX;
+            phi_tmp[1024 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1024 + i] += 12.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SXZZ;
+            phi_tmp[1056 + i] += 2.0 * 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1056 + i] += yc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1056 + i] += 20.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SX;
+            phi_tmp[1056 + i] += 2.0 * 5.0 * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1056 + i] += 20.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SXZZ;
+            phi_tmp[1088 + i] += 2.0 * 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1088 + i] += yc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[1088 + i] += 30.0 * xc[i] * yc[i] * zc_pow[64 + i] * SX;
+            phi_tmp[1088 + i] += 2.0 * 6.0 * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1088 + i] += 30.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SXZZ;
+            phi_tmp[1120 + i] += 2.0 * 7.0 * xc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[1120 + i] += zc_pow[160 + i] * SZZ;
+            phi_tmp[1120 + i] += 42.0 * xc[i] * zc_pow[96 + i] * SX;
+            phi_tmp[1120 + i] += 2.0 * 7.0 * zc_pow[128 + i] * SZ;
+            phi_tmp[1120 + i] += 42.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SXZZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SXZZ;
+            phi_tmp[1184 + i] += 2.0 * yc_pow[160 + i] * SXZ;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SXZZ;
+            phi_tmp[1216 + i] += 2.0 * 2.0 * yc_pow[128 + i] * zc[i] * SXZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * SX;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SXZZ;
+            phi_tmp[1248 + i] += 2.0 * 3.0 * yc_pow[96 + i] * zc_pow[i] * SXZ;
+            phi_tmp[1248 + i] += 6.0 * yc_pow[96 + i] * zc[i] * SX;
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SXZZ;
+            phi_tmp[1280 + i] += 2.0 * 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * SXZ;
+            phi_tmp[1280 + i] += 12.0 * yc_pow[64 + i] * zc_pow[i] * SX;
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SXZZ;
+            phi_tmp[1312 + i] += 2.0 * 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * SXZ;
+            phi_tmp[1312 + i] += 20.0 * yc_pow[32 + i] * zc_pow[32 + i] * SX;
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SXZZ;
+            phi_tmp[1344 + i] += 2.0 * 6.0 * yc_pow[i] * zc_pow[96 + i] * SXZ;
+            phi_tmp[1344 + i] += 30.0 * yc_pow[i] * zc_pow[64 + i] * SX;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SXZZ;
+            phi_tmp[1376 + i] += 2.0 * 7.0 * yc[i] * zc_pow[128 + i] * SXZ;
+            phi_tmp[1376 + i] += 42.0 * yc[i] * zc_pow[96 + i] * SX;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SXZZ;
+            phi_tmp[1408 + i] += 2.0 * 8.0 * zc_pow[160 + i] * SXZ;
+            phi_tmp[1408 + i] += 56.0 * zc_pow[128 + i] * SX;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_xzz_out + start), npoints);
+        }
+
+        // Combine YYY blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SYY = S2[i] * yc[i] * yc[i] + S1[i];
+            const double SYYY = S3[i] * yc[i] * yc[i] * yc[i] + 3 * yc[i] * S2[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SYYY;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SYYY;
+            phi_tmp[32 + i] += 3.0 * xc_pow[160 + i] * SYY;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SYYY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SYYY;
+            phi_tmp[96 + i] += 3.0 * 2.0 * xc_pow[128 + i] * yc[i] * SYY;
+            phi_tmp[96 + i] += 3.0 * 2.0 * xc_pow[128 + i] * SY;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SYYY;
+            phi_tmp[128 + i] += 3.0 * xc_pow[128 + i] * zc[i] * SYY;
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SYYY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SYYY;
+            phi_tmp[192 + i] += 3.0 * 3.0 * xc_pow[96 + i] * yc_pow[i] * SYY;
+            phi_tmp[192 + i] += 3.0 * 6.0 * xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[192 + i] += 6.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SYYY;
+            phi_tmp[224 + i] += 3.0 * 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SYY;
+            phi_tmp[224 + i] += 3.0 * 2.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SYYY;
+            phi_tmp[256 + i] += 3.0 * xc_pow[96 + i] * zc_pow[i] * SYY;
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SYYY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SYYY;
+            phi_tmp[320 + i] += 3.0 * 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * SYY;
+            phi_tmp[320 + i] += 3.0 * 12.0 * xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[320 + i] += 24.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SYYY;
+            phi_tmp[352 + i] += 3.0 * 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SYY;
+            phi_tmp[352 + i] += 3.0 * 6.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SYYY;
+            phi_tmp[384 + i] += 3.0 * 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SYY;
+            phi_tmp[384 + i] += 3.0 * 2.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SYYY;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * zc_pow[32 + i] * SYY;
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SYYY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SYYY;
+            phi_tmp[480 + i] += 3.0 * 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * SYY;
+            phi_tmp[480 + i] += 3.0 * 20.0 * xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[480 + i] += 60.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SYYY;
+            phi_tmp[512 + i] += 3.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYY;
+            phi_tmp[512 + i] += 3.0 * 12.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[512 + i] += 24.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SYYY;
+            phi_tmp[544 + i] += 3.0 * 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYY;
+            phi_tmp[544 + i] += 3.0 * 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SYYY;
+            phi_tmp[576 + i] += 3.0 * 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[576 + i] += 3.0 * 2.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SYYY;
+            phi_tmp[608 + i] += 3.0 * xc_pow[32 + i] * zc_pow[64 + i] * SYY;
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SYYY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SYYY;
+            phi_tmp[672 + i] += 3.0 * 6.0 * xc_pow[i] * yc_pow[96 + i] * SYY;
+            phi_tmp[672 + i] += 3.0 * 30.0 * xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[672 + i] += 120.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SYYY;
+            phi_tmp[704 + i] += 3.0 * 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SYY;
+            phi_tmp[704 + i] += 3.0 * 20.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[704 + i] += 60.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SYYY;
+            phi_tmp[736 + i] += 3.0 * 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYY;
+            phi_tmp[736 + i] += 3.0 * 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[736 + i] += 24.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYYY;
+            phi_tmp[768 + i] += 3.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[768 + i] += 3.0 * 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SYYY;
+            phi_tmp[800 + i] += 3.0 * 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[800 + i] += 3.0 * 2.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SYYY;
+            phi_tmp[832 + i] += 3.0 * xc_pow[i] * zc_pow[96 + i] * SYY;
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SYYY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SYYY;
+            phi_tmp[896 + i] += 3.0 * 7.0 * xc[i] * yc_pow[128 + i] * SYY;
+            phi_tmp[896 + i] += 3.0 * 42.0 * xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[896 + i] += 210.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SYYY;
+            phi_tmp[928 + i] += 3.0 * 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * SYY;
+            phi_tmp[928 + i] += 3.0 * 30.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[928 + i] += 120.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SYYY;
+            phi_tmp[960 + i] += 3.0 * 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SYY;
+            phi_tmp[960 + i] += 3.0 * 20.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[960 + i] += 60.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SYYY;
+            phi_tmp[992 + i] += 3.0 * 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[992 + i] += 3.0 * 12.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[992 + i] += 24.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SYYY;
+            phi_tmp[1024 + i] += 3.0 * 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1024 + i] += 3.0 * 6.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1024 + i] += 6.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SYYY;
+            phi_tmp[1056 + i] += 3.0 * 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1056 + i] += 3.0 * 2.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SYYY;
+            phi_tmp[1088 + i] += 3.0 * xc[i] * zc_pow[128 + i] * SYY;
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SYYY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SYYY;
+            phi_tmp[1152 + i] += 3.0 * 8.0 * yc_pow[160 + i] * SYY;
+            phi_tmp[1152 + i] += 3.0 * 56.0 * yc_pow[128 + i] * SY;
+            phi_tmp[1152 + i] += 336.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SYYY;
+            phi_tmp[1184 + i] += 3.0 * 7.0 * yc_pow[128 + i] * zc[i] * SYY;
+            phi_tmp[1184 + i] += 3.0 * 42.0 * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[1184 + i] += 210.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SYYY;
+            phi_tmp[1216 + i] += 3.0 * 6.0 * yc_pow[96 + i] * zc_pow[i] * SYY;
+            phi_tmp[1216 + i] += 3.0 * 30.0 * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[1216 + i] += 120.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SYYY;
+            phi_tmp[1248 + i] += 3.0 * 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[1248 + i] += 3.0 * 20.0 * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1248 + i] += 60.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SYYY;
+            phi_tmp[1280 + i] += 3.0 * 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1280 + i] += 3.0 * 12.0 * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1280 + i] += 24.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SYYY;
+            phi_tmp[1312 + i] += 3.0 * 3.0 * yc_pow[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1312 + i] += 3.0 * 6.0 * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1312 + i] += 6.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SYYY;
+            phi_tmp[1344 + i] += 3.0 * 2.0 * yc[i] * zc_pow[128 + i] * SYY;
+            phi_tmp[1344 + i] += 3.0 * 2.0 * zc_pow[128 + i] * SY;
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SYYY;
+            phi_tmp[1376 + i] += 3.0 * zc_pow[160 + i] * SYY;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SYYY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_yyy_out + start), npoints);
+        }
+
+        // Combine YYZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SYZ = S2[i] * yc[i] * zc[i];
+            const double SYY = S2[i] * yc[i] * yc[i] + S1[i];
+            const double SYYZ = S3[i] * yc[i] * yc[i] * zc[i] + S2[i] * zc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SYYZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SYYZ;
+            phi_tmp[32 + i] += 2.0 * xc_pow[160 + i] * SYZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SYYZ;
+            phi_tmp[64 + i] += xc_pow[160 + i] * SYY;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SYYZ;
+            phi_tmp[96 + i] += 2.0 * 2.0 * xc_pow[128 + i] * yc[i] * SYZ;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * SZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SYYZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * yc[i] * SYY;
+            phi_tmp[128 + i] += 2.0 * xc_pow[128 + i] * SY;
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SYYZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * zc[i] * SYY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SYYZ;
+            phi_tmp[192 + i] += 2.0 * 3.0 * xc_pow[96 + i] * yc_pow[i] * SYZ;
+            phi_tmp[192 + i] += 6.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SYYZ;
+            phi_tmp[224 + i] += 2.0 * 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SYZ;
+            phi_tmp[224 + i] += xc_pow[96 + i] * yc_pow[i] * SYY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[224 + i] += 2.0 * 2.0 * xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SYYZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SYY;
+            phi_tmp[256 + i] += 2.0 * 2.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SYYZ;
+            phi_tmp[288 + i] += 3.0 * xc_pow[96 + i] * zc_pow[i] * SYY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SYYZ;
+            phi_tmp[320 + i] += 2.0 * 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * SYZ;
+            phi_tmp[320 + i] += 12.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SYYZ;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SYZ;
+            phi_tmp[352 + i] += xc_pow[64 + i] * yc_pow[32 + i] * SYY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[352 + i] += 6.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SYYZ;
+            phi_tmp[384 + i] += 2.0 * 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SYZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SYY;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[384 + i] += 2.0 * 4.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[384 + i] += 4.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SYYZ;
+            phi_tmp[416 + i] += 2.0 * xc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[416 + i] += 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SYY;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SYYZ;
+            phi_tmp[448 + i] += 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * SYY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SYYZ;
+            phi_tmp[480 + i] += 2.0 * 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * SYZ;
+            phi_tmp[480 + i] += 20.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SYYZ;
+            phi_tmp[512 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYZ;
+            phi_tmp[512 + i] += xc_pow[32 + i] * yc_pow[64 + i] * SYY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[512 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[512 + i] += 12.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SYYZ;
+            phi_tmp[544 + i] += 2.0 * 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYY;
+            phi_tmp[544 + i] += 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[544 + i] += 2.0 * 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[544 + i] += 12.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SYYZ;
+            phi_tmp[576 + i] += 2.0 * 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[576 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYY;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[576 + i] += 2.0 * 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[576 + i] += 6.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SYYZ;
+            phi_tmp[608 + i] += 2.0 * xc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[608 + i] += 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[608 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SYYZ;
+            phi_tmp[640 + i] += 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * SYY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SYYZ;
+            phi_tmp[672 + i] += 2.0 * 6.0 * xc_pow[i] * yc_pow[96 + i] * SYZ;
+            phi_tmp[672 + i] += 30.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SYYZ;
+            phi_tmp[704 + i] += 2.0 * 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SYZ;
+            phi_tmp[704 + i] += xc_pow[i] * yc_pow[96 + i] * SYY;
+            phi_tmp[704 + i] += 20.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[704 + i] += 2.0 * 5.0 * xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[704 + i] += 20.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SYYZ;
+            phi_tmp[736 + i] += 2.0 * 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SYY;
+            phi_tmp[736 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[736 + i] += 2.0 * 8.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[736 + i] += 24.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYYZ;
+            phi_tmp[768 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYY;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[768 + i] += 2.0 * 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[768 + i] += 18.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SYYZ;
+            phi_tmp[800 + i] += 2.0 * 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[800 + i] += 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYY;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[800 + i] += 2.0 * 8.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[800 + i] += 8.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SYYZ;
+            phi_tmp[832 + i] += 2.0 * xc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[832 + i] += 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[832 + i] += 2.0 * 5.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SYYZ;
+            phi_tmp[864 + i] += 6.0 * xc_pow[i] * zc_pow[96 + i] * SYY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SYYZ;
+            phi_tmp[896 + i] += 2.0 * 7.0 * xc[i] * yc_pow[128 + i] * SYZ;
+            phi_tmp[896 + i] += 42.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SYYZ;
+            phi_tmp[928 + i] += 2.0 * 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[928 + i] += xc[i] * yc_pow[128 + i] * SYY;
+            phi_tmp[928 + i] += 30.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[928 + i] += 2.0 * 6.0 * xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[928 + i] += 30.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SYYZ;
+            phi_tmp[960 + i] += 2.0 * 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SYY;
+            phi_tmp[960 + i] += 20.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[960 + i] += 2.0 * 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[960 + i] += 40.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SYYZ;
+            phi_tmp[992 + i] += 2.0 * 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[992 + i] += 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SYY;
+            phi_tmp[992 + i] += 12.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[992 + i] += 2.0 * 12.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[992 + i] += 36.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SYYZ;
+            phi_tmp[1024 + i] += 2.0 * 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1024 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[1024 + i] += 6.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1024 + i] += 2.0 * 12.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[1024 + i] += 24.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SYYZ;
+            phi_tmp[1056 + i] += 2.0 * 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1056 + i] += 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1056 + i] += 2.0 * 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1056 + i] += 10.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SYYZ;
+            phi_tmp[1088 + i] += 2.0 * xc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[1088 + i] += 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1088 + i] += 2.0 * 6.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SYYZ;
+            phi_tmp[1120 + i] += 7.0 * xc[i] * zc_pow[128 + i] * SYY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SYYZ;
+            phi_tmp[1152 + i] += 2.0 * 8.0 * yc_pow[160 + i] * SYZ;
+            phi_tmp[1152 + i] += 56.0 * yc_pow[128 + i] * SZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SYYZ;
+            phi_tmp[1184 + i] += 2.0 * 7.0 * yc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[1184 + i] += yc_pow[160 + i] * SYY;
+            phi_tmp[1184 + i] += 42.0 * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[1184 + i] += 2.0 * 7.0 * yc_pow[128 + i] * SY;
+            phi_tmp[1184 + i] += 42.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SYYZ;
+            phi_tmp[1216 + i] += 2.0 * 6.0 * yc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * zc[i] * SYY;
+            phi_tmp[1216 + i] += 30.0 * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[1216 + i] += 2.0 * 12.0 * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[1216 + i] += 60.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SYYZ;
+            phi_tmp[1248 + i] += 2.0 * 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[1248 + i] += 3.0 * yc_pow[96 + i] * zc_pow[i] * SYY;
+            phi_tmp[1248 + i] += 20.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1248 + i] += 2.0 * 15.0 * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[1248 + i] += 60.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SYYZ;
+            phi_tmp[1280 + i] += 2.0 * 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * SYY;
+            phi_tmp[1280 + i] += 12.0 * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1280 + i] += 2.0 * 16.0 * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1280 + i] += 48.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SYYZ;
+            phi_tmp[1312 + i] += 2.0 * 3.0 * yc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1312 + i] += 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * SYY;
+            phi_tmp[1312 + i] += 6.0 * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1312 + i] += 2.0 * 15.0 * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1312 + i] += 30.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SYYZ;
+            phi_tmp[1344 + i] += 2.0 * 2.0 * yc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[1344 + i] += 6.0 * yc_pow[i] * zc_pow[96 + i] * SYY;
+            phi_tmp[1344 + i] += 2.0 * zc_pow[128 + i] * SZ;
+            phi_tmp[1344 + i] += 2.0 * 12.0 * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1344 + i] += 12.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SYYZ;
+            phi_tmp[1376 + i] += 2.0 * zc_pow[160 + i] * SYZ;
+            phi_tmp[1376 + i] += 7.0 * yc[i] * zc_pow[128 + i] * SYY;
+            phi_tmp[1376 + i] += 2.0 * 7.0 * zc_pow[128 + i] * SY;
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SYYZ;
+            phi_tmp[1408 + i] += 8.0 * zc_pow[160 + i] * SYY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_yyz_out + start), npoints);
+        }
+
+        // Combine YZZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SY = S1[i] * yc[i];
+            const double SZ = S1[i] * zc[i];
+            const double SYZ = S2[i] * yc[i] * zc[i];
+            const double SZZ = S2[i] * zc[i] * zc[i] + S1[i];
+            const double SYZZ = S3[i] * yc[i] * zc[i] * zc[i] + S2[i] * yc[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SYZZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SYZZ;
+            phi_tmp[32 + i] += xc_pow[160 + i] * SZZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SYZZ;
+            phi_tmp[64 + i] += 2.0 * xc_pow[160 + i] * SYZ;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SYZZ;
+            phi_tmp[96 + i] += 2.0 * xc_pow[128 + i] * yc[i] * SZZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SYZZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[128 + i] * yc[i] * SYZ;
+            phi_tmp[128 + i] += xc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[128 + i] += 2.0 * xc_pow[128 + i] * SZ;
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SYZZ;
+            phi_tmp[160 + i] += 2.0 * 2.0 * xc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[160 + i] += 2.0 * xc_pow[128 + i] * SY;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SYZZ;
+            phi_tmp[192 + i] += 3.0 * xc_pow[96 + i] * yc_pow[i] * SZZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SYZZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc_pow[i] * SYZ;
+            phi_tmp[224 + i] += 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SZZ;
+            phi_tmp[224 + i] += 2.0 * 2.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SYZZ;
+            phi_tmp[256 + i] += 2.0 * 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SYZ;
+            phi_tmp[256 + i] += xc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * yc[i] * SY;
+            phi_tmp[256 + i] += 2.0 * 2.0 * xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[256 + i] += 2.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SYZZ;
+            phi_tmp[288 + i] += 2.0 * 3.0 * xc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[96 + i] * zc[i] * SY;
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SYZZ;
+            phi_tmp[320 + i] += 4.0 * xc_pow[64 + i] * yc_pow[32 + i] * SZZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SYZZ;
+            phi_tmp[352 + i] += 2.0 * xc_pow[64 + i] * yc_pow[32 + i] * SYZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SZZ;
+            phi_tmp[352 + i] += 2.0 * 3.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SYZZ;
+            phi_tmp[384 + i] += 2.0 * 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SYZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SZZ;
+            phi_tmp[384 + i] += 2.0 * xc_pow[64 + i] * yc_pow[i] * SY;
+            phi_tmp[384 + i] += 2.0 * 4.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[384 + i] += 4.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SYZZ;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SYZ;
+            phi_tmp[416 + i] += xc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[64 + i] * yc[i] * zc[i] * SY;
+            phi_tmp[416 + i] += 2.0 * 3.0 * xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SYZZ;
+            phi_tmp[448 + i] += 2.0 * 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[448 + i] += 12.0 * xc_pow[64 + i] * zc_pow[i] * SY;
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SYZZ;
+            phi_tmp[480 + i] += 5.0 * xc_pow[32 + i] * yc_pow[64 + i] * SZZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SYZZ;
+            phi_tmp[512 + i] += 2.0 * xc_pow[32 + i] * yc_pow[64 + i] * SYZ;
+            phi_tmp[512 + i] += 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZZ;
+            phi_tmp[512 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SYZZ;
+            phi_tmp[544 + i] += 2.0 * 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SYZ;
+            phi_tmp[544 + i] += 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZZ;
+            phi_tmp[544 + i] += 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * SY;
+            phi_tmp[544 + i] += 2.0 * 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[544 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SYZZ;
+            phi_tmp[576 + i] += 2.0 * 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SYZ;
+            phi_tmp[576 + i] += 2.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SY;
+            phi_tmp[576 + i] += 2.0 * 6.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[576 + i] += 12.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SYZZ;
+            phi_tmp[608 + i] += 2.0 * 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[608 + i] += xc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SY;
+            phi_tmp[608 + i] += 2.0 * 4.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[608 + i] += 12.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SYZZ;
+            phi_tmp[640 + i] += 2.0 * 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[640 + i] += 20.0 * xc_pow[32 + i] * zc_pow[32 + i] * SY;
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SYZZ;
+            phi_tmp[672 + i] += 6.0 * xc_pow[i] * yc_pow[96 + i] * SZZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SYZZ;
+            phi_tmp[704 + i] += 2.0 * xc_pow[i] * yc_pow[96 + i] * SYZ;
+            phi_tmp[704 + i] += 5.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SZZ;
+            phi_tmp[704 + i] += 2.0 * 5.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SYZZ;
+            phi_tmp[736 + i] += 2.0 * 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SYZ;
+            phi_tmp[736 + i] += 4.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZZ;
+            phi_tmp[736 + i] += 2.0 * xc_pow[i] * yc_pow[64 + i] * SY;
+            phi_tmp[736 + i] += 2.0 * 8.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[736 + i] += 8.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYZZ;
+            phi_tmp[768 + i] += 2.0 * 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SYZ;
+            phi_tmp[768 + i] += 3.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SY;
+            phi_tmp[768 + i] += 2.0 * 9.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[768 + i] += 18.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SYZZ;
+            phi_tmp[800 + i] += 2.0 * 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[800 + i] += 2.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[800 + i] += 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SY;
+            phi_tmp[800 + i] += 2.0 * 8.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[800 + i] += 24.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SYZZ;
+            phi_tmp[832 + i] += 2.0 * 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[832 + i] += xc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[832 + i] += 20.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SY;
+            phi_tmp[832 + i] += 2.0 * 5.0 * xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[832 + i] += 20.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SYZZ;
+            phi_tmp[864 + i] += 2.0 * 6.0 * xc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[864 + i] += 30.0 * xc_pow[i] * zc_pow[64 + i] * SY;
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SYZZ;
+            phi_tmp[896 + i] += 7.0 * xc[i] * yc_pow[128 + i] * SZZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SYZZ;
+            phi_tmp[928 + i] += 2.0 * xc[i] * yc_pow[128 + i] * SYZ;
+            phi_tmp[928 + i] += 6.0 * xc[i] * yc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[928 + i] += 2.0 * 6.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SYZZ;
+            phi_tmp[960 + i] += 2.0 * 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SYZ;
+            phi_tmp[960 + i] += 5.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[960 + i] += 2.0 * xc[i] * yc_pow[96 + i] * SY;
+            phi_tmp[960 + i] += 2.0 * 10.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[960 + i] += 10.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SYZZ;
+            phi_tmp[992 + i] += 2.0 * 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SYZ;
+            phi_tmp[992 + i] += 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[992 + i] += 6.0 * xc[i] * yc_pow[64 + i] * zc[i] * SY;
+            phi_tmp[992 + i] += 2.0 * 12.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[992 + i] += 24.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SYZZ;
+            phi_tmp[1024 + i] += 2.0 * 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[1024 + i] += 3.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1024 + i] += 12.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SY;
+            phi_tmp[1024 + i] += 2.0 * 12.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1024 + i] += 36.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SYZZ;
+            phi_tmp[1056 + i] += 2.0 * 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1056 + i] += 2.0 * xc[i] * yc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1056 + i] += 20.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SY;
+            phi_tmp[1056 + i] += 2.0 * 10.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1056 + i] += 40.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SYZZ;
+            phi_tmp[1088 + i] += 2.0 * 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1088 + i] += xc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[1088 + i] += 30.0 * xc[i] * yc[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1088 + i] += 2.0 * 6.0 * xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1088 + i] += 30.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SYZZ;
+            phi_tmp[1120 + i] += 2.0 * 7.0 * xc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[1120 + i] += 42.0 * xc[i] * zc_pow[96 + i] * SY;
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SYZZ;
+            phi_tmp[1152 + i] += 8.0 * yc_pow[160 + i] * SZZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SYZZ;
+            phi_tmp[1184 + i] += 2.0 * yc_pow[160 + i] * SYZ;
+            phi_tmp[1184 + i] += 7.0 * yc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[1184 + i] += 2.0 * 7.0 * yc_pow[128 + i] * SZ;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SYZZ;
+            phi_tmp[1216 + i] += 2.0 * 2.0 * yc_pow[128 + i] * zc[i] * SYZ;
+            phi_tmp[1216 + i] += 6.0 * yc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[1216 + i] += 2.0 * yc_pow[128 + i] * SY;
+            phi_tmp[1216 + i] += 2.0 * 12.0 * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[1216 + i] += 12.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SYZZ;
+            phi_tmp[1248 + i] += 2.0 * 3.0 * yc_pow[96 + i] * zc_pow[i] * SYZ;
+            phi_tmp[1248 + i] += 5.0 * yc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[1248 + i] += 6.0 * yc_pow[96 + i] * zc[i] * SY;
+            phi_tmp[1248 + i] += 2.0 * 15.0 * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[1248 + i] += 30.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SYZZ;
+            phi_tmp[1280 + i] += 2.0 * 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * SYZ;
+            phi_tmp[1280 + i] += 4.0 * yc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1280 + i] += 12.0 * yc_pow[64 + i] * zc_pow[i] * SY;
+            phi_tmp[1280 + i] += 2.0 * 16.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1280 + i] += 48.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SYZZ;
+            phi_tmp[1312 + i] += 2.0 * 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * SYZ;
+            phi_tmp[1312 + i] += 3.0 * yc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1312 + i] += 20.0 * yc_pow[32 + i] * zc_pow[32 + i] * SY;
+            phi_tmp[1312 + i] += 2.0 * 15.0 * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1312 + i] += 60.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SYZZ;
+            phi_tmp[1344 + i] += 2.0 * 6.0 * yc_pow[i] * zc_pow[96 + i] * SYZ;
+            phi_tmp[1344 + i] += 2.0 * yc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[1344 + i] += 30.0 * yc_pow[i] * zc_pow[64 + i] * SY;
+            phi_tmp[1344 + i] += 2.0 * 12.0 * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1344 + i] += 60.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SYZZ;
+            phi_tmp[1376 + i] += 2.0 * 7.0 * yc[i] * zc_pow[128 + i] * SYZ;
+            phi_tmp[1376 + i] += zc_pow[160 + i] * SZZ;
+            phi_tmp[1376 + i] += 42.0 * yc[i] * zc_pow[96 + i] * SY;
+            phi_tmp[1376 + i] += 2.0 * 7.0 * zc_pow[128 + i] * SZ;
+            phi_tmp[1376 + i] += 42.0 * zc_pow[96 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SYZZ;
+            phi_tmp[1408 + i] += 2.0 * 8.0 * zc_pow[160 + i] * SYZ;
+            phi_tmp[1408 + i] += 56.0 * zc_pow[128 + i] * SY;
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_yzz_out + start), npoints);
+        }
+
+        // Combine ZZZ blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            const double SZ = S1[i] * zc[i];
+            const double SZZ = S2[i] * zc[i] * zc[i] + S1[i];
+            const double SZZZ = S3[i] * zc[i] * zc[i] * zc[i] + 3 * zc[i] * S2[i];
+
+            phi_tmp[i] = xc_pow[192 + i] * SZZZ;
+
+            phi_tmp[32 + i] = xc_pow[160 + i] * yc[i] * SZZZ;
+
+            phi_tmp[64 + i] = xc_pow[160 + i] * zc[i] * SZZZ;
+            phi_tmp[64 + i] += 3.0 * xc_pow[160 + i] * SZZ;
+
+            phi_tmp[96 + i] = xc_pow[128 + i] * yc_pow[i] * SZZZ;
+
+            phi_tmp[128 + i] = xc_pow[128 + i] * yc[i] * zc[i] * SZZZ;
+            phi_tmp[128 + i] += 3.0 * xc_pow[128 + i] * yc[i] * SZZ;
+
+            phi_tmp[160 + i] = xc_pow[128 + i] * zc_pow[i] * SZZZ;
+            phi_tmp[160 + i] += 3.0 * 2.0 * xc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[160 + i] += 3.0 * 2.0 * xc_pow[128 + i] * SZ;
+
+            phi_tmp[192 + i] = xc_pow[96 + i] * yc_pow[32 + i] * SZZZ;
+
+            phi_tmp[224 + i] = xc_pow[96 + i] * yc_pow[i] * zc[i] * SZZZ;
+            phi_tmp[224 + i] += 3.0 * xc_pow[96 + i] * yc_pow[i] * SZZ;
+
+            phi_tmp[256 + i] = xc_pow[96 + i] * yc[i] * zc_pow[i] * SZZZ;
+            phi_tmp[256 + i] += 3.0 * 2.0 * xc_pow[96 + i] * yc[i] * zc[i] * SZZ;
+            phi_tmp[256 + i] += 3.0 * 2.0 * xc_pow[96 + i] * yc[i] * SZ;
+
+            phi_tmp[288 + i] = xc_pow[96 + i] * zc_pow[32 + i] * SZZZ;
+            phi_tmp[288 + i] += 3.0 * 3.0 * xc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[288 + i] += 3.0 * 6.0 * xc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[288 + i] += 6.0 * xc_pow[96 + i] * S0[i];
+
+            phi_tmp[320 + i] = xc_pow[64 + i] * yc_pow[64 + i] * SZZZ;
+
+            phi_tmp[352 + i] = xc_pow[64 + i] * yc_pow[32 + i] * zc[i] * SZZZ;
+            phi_tmp[352 + i] += 3.0 * xc_pow[64 + i] * yc_pow[32 + i] * SZZ;
+
+            phi_tmp[384 + i] = xc_pow[64 + i] * yc_pow[i] * zc_pow[i] * SZZZ;
+            phi_tmp[384 + i] += 3.0 * 2.0 * xc_pow[64 + i] * yc_pow[i] * zc[i] * SZZ;
+            phi_tmp[384 + i] += 3.0 * 2.0 * xc_pow[64 + i] * yc_pow[i] * SZ;
+
+            phi_tmp[416 + i] = xc_pow[64 + i] * yc[i] * zc_pow[32 + i] * SZZZ;
+            phi_tmp[416 + i] += 3.0 * 3.0 * xc_pow[64 + i] * yc[i] * zc_pow[i] * SZZ;
+            phi_tmp[416 + i] += 3.0 * 6.0 * xc_pow[64 + i] * yc[i] * zc[i] * SZ;
+            phi_tmp[416 + i] += 6.0 * xc_pow[64 + i] * yc[i] * S0[i];
+
+            phi_tmp[448 + i] = xc_pow[64 + i] * zc_pow[64 + i] * SZZZ;
+            phi_tmp[448 + i] += 3.0 * 4.0 * xc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[448 + i] += 3.0 * 12.0 * xc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[448 + i] += 24.0 * xc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[480 + i] = xc_pow[32 + i] * yc_pow[96 + i] * SZZZ;
+
+            phi_tmp[512 + i] = xc_pow[32 + i] * yc_pow[64 + i] * zc[i] * SZZZ;
+            phi_tmp[512 + i] += 3.0 * xc_pow[32 + i] * yc_pow[64 + i] * SZZ;
+
+            phi_tmp[544 + i] = xc_pow[32 + i] * yc_pow[32 + i] * zc_pow[i] * SZZZ;
+            phi_tmp[544 + i] += 3.0 * 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * zc[i] * SZZ;
+            phi_tmp[544 + i] += 3.0 * 2.0 * xc_pow[32 + i] * yc_pow[32 + i] * SZ;
+
+            phi_tmp[576 + i] = xc_pow[32 + i] * yc_pow[i] * zc_pow[32 + i] * SZZZ;
+            phi_tmp[576 + i] += 3.0 * 3.0 * xc_pow[32 + i] * yc_pow[i] * zc_pow[i] * SZZ;
+            phi_tmp[576 + i] += 3.0 * 6.0 * xc_pow[32 + i] * yc_pow[i] * zc[i] * SZ;
+            phi_tmp[576 + i] += 6.0 * xc_pow[32 + i] * yc_pow[i] * S0[i];
+
+            phi_tmp[608 + i] = xc_pow[32 + i] * yc[i] * zc_pow[64 + i] * SZZZ;
+            phi_tmp[608 + i] += 3.0 * 4.0 * xc_pow[32 + i] * yc[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[608 + i] += 3.0 * 12.0 * xc_pow[32 + i] * yc[i] * zc_pow[i] * SZ;
+            phi_tmp[608 + i] += 24.0 * xc_pow[32 + i] * yc[i] * zc[i] * S0[i];
+
+            phi_tmp[640 + i] = xc_pow[32 + i] * zc_pow[96 + i] * SZZZ;
+            phi_tmp[640 + i] += 3.0 * 5.0 * xc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[640 + i] += 3.0 * 20.0 * xc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[640 + i] += 60.0 * xc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[672 + i] = xc_pow[i] * yc_pow[128 + i] * SZZZ;
+
+            phi_tmp[704 + i] = xc_pow[i] * yc_pow[96 + i] * zc[i] * SZZZ;
+            phi_tmp[704 + i] += 3.0 * xc_pow[i] * yc_pow[96 + i] * SZZ;
+
+            phi_tmp[736 + i] = xc_pow[i] * yc_pow[64 + i] * zc_pow[i] * SZZZ;
+            phi_tmp[736 + i] += 3.0 * 2.0 * xc_pow[i] * yc_pow[64 + i] * zc[i] * SZZ;
+            phi_tmp[736 + i] += 3.0 * 2.0 * xc_pow[i] * yc_pow[64 + i] * SZ;
+
+            phi_tmp[768 + i] = xc_pow[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZZZ;
+            phi_tmp[768 + i] += 3.0 * 3.0 * xc_pow[i] * yc_pow[32 + i] * zc_pow[i] * SZZ;
+            phi_tmp[768 + i] += 3.0 * 6.0 * xc_pow[i] * yc_pow[32 + i] * zc[i] * SZ;
+            phi_tmp[768 + i] += 6.0 * xc_pow[i] * yc_pow[32 + i] * S0[i];
+
+            phi_tmp[800 + i] = xc_pow[i] * yc_pow[i] * zc_pow[64 + i] * SZZZ;
+            phi_tmp[800 + i] += 3.0 * 4.0 * xc_pow[i] * yc_pow[i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[800 + i] += 3.0 * 12.0 * xc_pow[i] * yc_pow[i] * zc_pow[i] * SZ;
+            phi_tmp[800 + i] += 24.0 * xc_pow[i] * yc_pow[i] * zc[i] * S0[i];
+
+            phi_tmp[832 + i] = xc_pow[i] * yc[i] * zc_pow[96 + i] * SZZZ;
+            phi_tmp[832 + i] += 3.0 * 5.0 * xc_pow[i] * yc[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[832 + i] += 3.0 * 20.0 * xc_pow[i] * yc[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[832 + i] += 60.0 * xc_pow[i] * yc[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[864 + i] = xc_pow[i] * zc_pow[128 + i] * SZZZ;
+            phi_tmp[864 + i] += 3.0 * 6.0 * xc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[864 + i] += 3.0 * 30.0 * xc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[864 + i] += 120.0 * xc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[896 + i] = xc[i] * yc_pow[160 + i] * SZZZ;
+
+            phi_tmp[928 + i] = xc[i] * yc_pow[128 + i] * zc[i] * SZZZ;
+            phi_tmp[928 + i] += 3.0 * xc[i] * yc_pow[128 + i] * SZZ;
+
+            phi_tmp[960 + i] = xc[i] * yc_pow[96 + i] * zc_pow[i] * SZZZ;
+            phi_tmp[960 + i] += 3.0 * 2.0 * xc[i] * yc_pow[96 + i] * zc[i] * SZZ;
+            phi_tmp[960 + i] += 3.0 * 2.0 * xc[i] * yc_pow[96 + i] * SZ;
+
+            phi_tmp[992 + i] = xc[i] * yc_pow[64 + i] * zc_pow[32 + i] * SZZZ;
+            phi_tmp[992 + i] += 3.0 * 3.0 * xc[i] * yc_pow[64 + i] * zc_pow[i] * SZZ;
+            phi_tmp[992 + i] += 3.0 * 6.0 * xc[i] * yc_pow[64 + i] * zc[i] * SZ;
+            phi_tmp[992 + i] += 6.0 * xc[i] * yc_pow[64 + i] * S0[i];
+
+            phi_tmp[1024 + i] = xc[i] * yc_pow[32 + i] * zc_pow[64 + i] * SZZZ;
+            phi_tmp[1024 + i] += 3.0 * 4.0 * xc[i] * yc_pow[32 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[1024 + i] += 3.0 * 12.0 * xc[i] * yc_pow[32 + i] * zc_pow[i] * SZ;
+            phi_tmp[1024 + i] += 24.0 * xc[i] * yc_pow[32 + i] * zc[i] * S0[i];
+
+            phi_tmp[1056 + i] = xc[i] * yc_pow[i] * zc_pow[96 + i] * SZZZ;
+            phi_tmp[1056 + i] += 3.0 * 5.0 * xc[i] * yc_pow[i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1056 + i] += 3.0 * 20.0 * xc[i] * yc_pow[i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1056 + i] += 60.0 * xc[i] * yc_pow[i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1088 + i] = xc[i] * yc[i] * zc_pow[128 + i] * SZZZ;
+            phi_tmp[1088 + i] += 3.0 * 6.0 * xc[i] * yc[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1088 + i] += 3.0 * 30.0 * xc[i] * yc[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1088 + i] += 120.0 * xc[i] * yc[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1120 + i] = xc[i] * zc_pow[160 + i] * SZZZ;
+            phi_tmp[1120 + i] += 3.0 * 7.0 * xc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[1120 + i] += 3.0 * 42.0 * xc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1120 + i] += 210.0 * xc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1152 + i] = yc_pow[192 + i] * SZZZ;
+
+            phi_tmp[1184 + i] = yc_pow[160 + i] * zc[i] * SZZZ;
+            phi_tmp[1184 + i] += 3.0 * yc_pow[160 + i] * SZZ;
+
+            phi_tmp[1216 + i] = yc_pow[128 + i] * zc_pow[i] * SZZZ;
+            phi_tmp[1216 + i] += 3.0 * 2.0 * yc_pow[128 + i] * zc[i] * SZZ;
+            phi_tmp[1216 + i] += 3.0 * 2.0 * yc_pow[128 + i] * SZ;
+
+            phi_tmp[1248 + i] = yc_pow[96 + i] * zc_pow[32 + i] * SZZZ;
+            phi_tmp[1248 + i] += 3.0 * 3.0 * yc_pow[96 + i] * zc_pow[i] * SZZ;
+            phi_tmp[1248 + i] += 3.0 * 6.0 * yc_pow[96 + i] * zc[i] * SZ;
+            phi_tmp[1248 + i] += 6.0 * yc_pow[96 + i] * S0[i];
+
+            phi_tmp[1280 + i] = yc_pow[64 + i] * zc_pow[64 + i] * SZZZ;
+            phi_tmp[1280 + i] += 3.0 * 4.0 * yc_pow[64 + i] * zc_pow[32 + i] * SZZ;
+            phi_tmp[1280 + i] += 3.0 * 12.0 * yc_pow[64 + i] * zc_pow[i] * SZ;
+            phi_tmp[1280 + i] += 24.0 * yc_pow[64 + i] * zc[i] * S0[i];
+
+            phi_tmp[1312 + i] = yc_pow[32 + i] * zc_pow[96 + i] * SZZZ;
+            phi_tmp[1312 + i] += 3.0 * 5.0 * yc_pow[32 + i] * zc_pow[64 + i] * SZZ;
+            phi_tmp[1312 + i] += 3.0 * 20.0 * yc_pow[32 + i] * zc_pow[32 + i] * SZ;
+            phi_tmp[1312 + i] += 60.0 * yc_pow[32 + i] * zc_pow[i] * S0[i];
+
+            phi_tmp[1344 + i] = yc_pow[i] * zc_pow[128 + i] * SZZZ;
+            phi_tmp[1344 + i] += 3.0 * 6.0 * yc_pow[i] * zc_pow[96 + i] * SZZ;
+            phi_tmp[1344 + i] += 3.0 * 30.0 * yc_pow[i] * zc_pow[64 + i] * SZ;
+            phi_tmp[1344 + i] += 120.0 * yc_pow[i] * zc_pow[32 + i] * S0[i];
+
+            phi_tmp[1376 + i] = yc[i] * zc_pow[160 + i] * SZZZ;
+            phi_tmp[1376 + i] += 3.0 * 7.0 * yc[i] * zc_pow[128 + i] * SZZ;
+            phi_tmp[1376 + i] += 3.0 * 42.0 * yc[i] * zc_pow[96 + i] * SZ;
+            phi_tmp[1376 + i] += 210.0 * yc[i] * zc_pow[64 + i] * S0[i];
+
+            phi_tmp[1408 + i] = zc_pow[192 + i] * SZZZ;
+            phi_tmp[1408 + i] += 3.0 * 8.0 * zc_pow[160 + i] * SZZ;
+            phi_tmp[1408 + i] += 3.0 * 56.0 * zc_pow[128 + i] * SZ;
+            phi_tmp[1408 + i] += 336.0 * zc_pow[96 + i] * S0[i];
+        }
+
+        if (order == GG_SPHERICAL_CCA) {
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_zzz_out + start), npoints);
+        }
+    }
+
+    // Free S temporaries
+    ALIGNED_FREE(cache_data);
+    ALIGNED_FREE(expn1);
+    ALIGNED_FREE(expn2);
+
+    // Free Power temporaries
+    ALIGNED_FREE(xc_pow);
+    ALIGNED_FREE(yc_pow);
+    ALIGNED_FREE(zc_pow);
+
+    // Free inner temporaries
+    ALIGNED_FREE(phi_tmp);
 }

--- a/external/gau2grid/generated_source/gau2grid_helper.c
+++ b/external/gau2grid/generated_source/gau2grid_helper.c
@@ -8,12 +8,10 @@
 #include <math.h>
 #if defined(__clang__) && defined(_MSC_VER)
 #include <malloc.h>
-#include <stdlib.h>
 #elif defined __clang__
 #include <mm_malloc.h>
 #elif defined _MSC_VER
 #include <malloc.h>
-#include <stdlib.h>
 #else
 #include <stdlib.h>
 #endif

--- a/external/gau2grid/generated_source/gau2grid_helper.c
+++ b/external/gau2grid/generated_source/gau2grid_helper.c
@@ -23,18 +23,21 @@
 #include "gau2grid/gau2grid_pragma.h"
 
 // Information helpers
-int gg_max_L() { return 6; }
+int gg_max_L(void) { return 8; }
 
 int gg_ncomponents(const int L, const int spherical) {
     if (spherical) {
-    return 2 * L + 1;
+        return 2 * L + 1;
     } else {
-    return (L + 2) * (L + 1) / 2;
+        return (L + 2) * (L + 1) / 2;
     }
 }
 
 // Collocation selector functions
-void gg_orbitals(int L, const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
+void gg_orbitals(int L, const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                 const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                 const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                 const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
     // Chooses the correct function for a given L
     if (L == 0) {
         gg_orbitals_L0(C, norbitals, npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, orbital_out);
@@ -50,11 +53,18 @@ void gg_orbitals(int L, const double* PRAGMA_RESTRICT C, const unsigned long nor
         gg_orbitals_L5(C, norbitals, npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, orbital_out);
     } else if (L == 6) {
         gg_orbitals_L6(C, norbitals, npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, orbital_out);
+    } else if (L == 7) {
+        gg_orbitals_L7(C, norbitals, npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, orbital_out);
+    } else if (L == 8) {
+        gg_orbitals_L8(C, norbitals, npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, orbital_out);
     } else {
         exit(0);
     }
 }
-void gg_collocation(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
+void gg_collocation(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                    const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                    const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order,
+                    double* PRAGMA_RESTRICT phi_out) {
     // Chooses the correct function for a given L
     if (L == 0) {
         gg_collocation_L0(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out);
@@ -70,66 +80,159 @@ void gg_collocation(int L, const unsigned long npoints, const double* PRAGMA_RES
         gg_collocation_L5(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out);
     } else if (L == 6) {
         gg_collocation_L6(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out);
+    } else if (L == 7) {
+        gg_collocation_L7(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out);
+    } else if (L == 8) {
+        gg_collocation_L8(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out);
     } else {
         exit(0);
     }
 }
-void gg_collocation_deriv1(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
+void gg_collocation_deriv1(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                           const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                           const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                           const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                           double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out) {
     // Chooses the correct function for a given L
     if (L == 0) {
-        gg_collocation_L0_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out);
+        gg_collocation_L0_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out);
     } else if (L == 1) {
-        gg_collocation_L1_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out);
+        gg_collocation_L1_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out);
     } else if (L == 2) {
-        gg_collocation_L2_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out);
+        gg_collocation_L2_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out);
     } else if (L == 3) {
-        gg_collocation_L3_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out);
+        gg_collocation_L3_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out);
     } else if (L == 4) {
-        gg_collocation_L4_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out);
+        gg_collocation_L4_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out);
     } else if (L == 5) {
-        gg_collocation_L5_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out);
+        gg_collocation_L5_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out);
     } else if (L == 6) {
-        gg_collocation_L6_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out);
+        gg_collocation_L6_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out);
+    } else if (L == 7) {
+        gg_collocation_L7_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out);
+    } else if (L == 8) {
+        gg_collocation_L8_deriv1(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out);
     } else {
         exit(0);
     }
 }
-void gg_collocation_deriv2(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
+void gg_collocation_deriv2(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                           const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                           const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                           const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                           double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                           double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                           double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                           double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out) {
     // Chooses the correct function for a given L
     if (L == 0) {
-        gg_collocation_L0_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out);
+        gg_collocation_L0_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out);
     } else if (L == 1) {
-        gg_collocation_L1_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out);
+        gg_collocation_L1_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out);
     } else if (L == 2) {
-        gg_collocation_L2_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out);
+        gg_collocation_L2_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out);
     } else if (L == 3) {
-        gg_collocation_L3_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out);
+        gg_collocation_L3_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out);
     } else if (L == 4) {
-        gg_collocation_L4_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out);
+        gg_collocation_L4_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out);
     } else if (L == 5) {
-        gg_collocation_L5_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out);
+        gg_collocation_L5_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out);
     } else if (L == 6) {
-        gg_collocation_L6_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out);
+        gg_collocation_L6_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out);
+    } else if (L == 7) {
+        gg_collocation_L7_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out);
+    } else if (L == 8) {
+        gg_collocation_L8_deriv2(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out);
     } else {
         exit(0);
     }
 }
-void gg_collocation_deriv3(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out, double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out, double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out, double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out, double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out, double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out, double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out, double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out, double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out, double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
+void gg_collocation_deriv3(int L, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz,
+                           const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs,
+                           const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center,
+                           const int order, double* PRAGMA_RESTRICT phi_out, double* PRAGMA_RESTRICT phi_x_out,
+                           double* PRAGMA_RESTRICT phi_y_out, double* PRAGMA_RESTRICT phi_z_out,
+                           double* PRAGMA_RESTRICT phi_xx_out, double* PRAGMA_RESTRICT phi_xy_out,
+                           double* PRAGMA_RESTRICT phi_xz_out, double* PRAGMA_RESTRICT phi_yy_out,
+                           double* PRAGMA_RESTRICT phi_yz_out, double* PRAGMA_RESTRICT phi_zz_out,
+                           double* PRAGMA_RESTRICT phi_xxx_out, double* PRAGMA_RESTRICT phi_xxy_out,
+                           double* PRAGMA_RESTRICT phi_xxz_out, double* PRAGMA_RESTRICT phi_xyy_out,
+                           double* PRAGMA_RESTRICT phi_xyz_out, double* PRAGMA_RESTRICT phi_xzz_out,
+                           double* PRAGMA_RESTRICT phi_yyy_out, double* PRAGMA_RESTRICT phi_yyz_out,
+                           double* PRAGMA_RESTRICT phi_yzz_out, double* PRAGMA_RESTRICT phi_zzz_out) {
     // Chooses the correct function for a given L
     if (L == 0) {
-        gg_collocation_L0_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out, phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
+        gg_collocation_L0_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out,
+                                 phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
     } else if (L == 1) {
-        gg_collocation_L1_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out, phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
+        gg_collocation_L1_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out,
+                                 phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
     } else if (L == 2) {
-        gg_collocation_L2_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out, phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
+        gg_collocation_L2_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out,
+                                 phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
     } else if (L == 3) {
-        gg_collocation_L3_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out, phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
+        gg_collocation_L3_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out,
+                                 phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
     } else if (L == 4) {
-        gg_collocation_L4_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out, phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
+        gg_collocation_L4_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out,
+                                 phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
     } else if (L == 5) {
-        gg_collocation_L5_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out, phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
+        gg_collocation_L5_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out,
+                                 phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
     } else if (L == 6) {
-        gg_collocation_L6_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out, phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out, phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out, phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
+        gg_collocation_L6_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out,
+                                 phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
+    } else if (L == 7) {
+        gg_collocation_L7_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out,
+                                 phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
+    } else if (L == 8) {
+        gg_collocation_L8_deriv3(npoints, xyz, xyz_stride, nprim, coeffs, exponents, center, order, phi_out, phi_x_out,
+                                 phi_y_out, phi_z_out, phi_xx_out, phi_xy_out, phi_xz_out, phi_yy_out, phi_yz_out,
+                                 phi_zz_out, phi_xxx_out, phi_xxy_out, phi_xxz_out, phi_xyy_out, phi_xyz_out,
+                                 phi_xzz_out, phi_yyy_out, phi_yyz_out, phi_yzz_out, phi_zzz_out);
     } else {
         exit(0);
     }

--- a/external/gau2grid/generated_source/gau2grid_orbital.c
+++ b/external/gau2grid/generated_source/gau2grid_orbital.c
@@ -63,9 +63,10 @@ void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -114,7 +115,7 @@ void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbita
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -211,9 +212,10 @@ void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -262,7 +264,7 @@ void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbita
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -368,7 +370,7 @@ void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -417,7 +419,7 @@ void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbita
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -540,7 +542,7 @@ void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -589,7 +591,7 @@ void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbita
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -732,7 +734,7 @@ void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -781,7 +783,7 @@ void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbita
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -948,7 +950,7 @@ void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -997,7 +999,7 @@ void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbita
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -1192,7 +1194,7 @@ void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -1241,7 +1243,7 @@ void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbita
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 

--- a/external/gau2grid/generated_source/gau2grid_orbital.c
+++ b/external/gau2grid/generated_source/gau2grid_orbital.c
@@ -20,10 +20,10 @@
 #include "gau2grid/gau2grid_utility.h"
 #include "gau2grid/gau2grid_pragma.h"
 
-
-
-void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
-
+void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -33,12 +33,12 @@ void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -53,10 +53,10 @@ void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -71,8 +71,6 @@ void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -96,8 +94,8 @@ void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -126,38 +124,38 @@ void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Density AM=0 Component=0
             phi_tmp[i] = S0[i];
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_cca_cart_to_spherical_sum_L0(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_cca_cart_to_spherical_sum_L0(remain, (C + i * nout), phi_tmp, 32,
+                                                (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_gaussian_cart_to_spherical_sum_L0(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_gaussian_cart_to_spherical_sum_L0(remain, (C + i * nout), phi_tmp, 32,
+                                                     (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
                 gg_cca_cart_sum_L0(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_molden_cart_sum_L0(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_molden_cart_sum_L0(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start),
+                                      npoints);
             }
         }
     }
@@ -168,11 +166,12 @@ void gg_orbitals_L0(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
-
+void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -182,12 +181,12 @@ void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -202,10 +201,10 @@ void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -220,8 +219,6 @@ void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -245,8 +242,8 @@ void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -275,13 +272,11 @@ void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Density AM=1 Component=X
             phi_tmp[i] = S0[i] * xc[i];
 
@@ -290,29 +285,31 @@ void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
             // Density AM=1 Component=Z
             phi_tmp[64 + i] = S0[i] * zc[i];
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_cca_cart_to_spherical_sum_L1(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_cca_cart_to_spherical_sum_L1(remain, (C + i * nout), phi_tmp, 32,
+                                                (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_gaussian_cart_to_spherical_sum_L1(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_gaussian_cart_to_spherical_sum_L1(remain, (C + i * nout), phi_tmp, 32,
+                                                     (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
                 gg_cca_cart_sum_L1(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_molden_cart_sum_L1(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_molden_cart_sum_L1(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start),
+                                      npoints);
             }
         }
     }
@@ -323,11 +320,12 @@ void gg_orbitals_L1(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
-
+void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -337,12 +335,12 @@ void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -357,10 +355,10 @@ void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -376,8 +374,6 @@ void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -401,8 +397,8 @@ void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -431,18 +427,15 @@ void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
             const double zc_pow2 = zc[i] * zc[i];
-
 
             // Density AM=2 Component=XX
             phi_tmp[i] = S0[i] * xc_pow2;
@@ -464,29 +457,31 @@ void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
             // Density AM=2 Component=ZZ
             phi_tmp[160 + i] = S0[i] * zc_pow2;
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_cca_cart_to_spherical_sum_L2(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_cca_cart_to_spherical_sum_L2(remain, (C + i * nout), phi_tmp, 32,
+                                                (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_gaussian_cart_to_spherical_sum_L2(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_gaussian_cart_to_spherical_sum_L2(remain, (C + i * nout), phi_tmp, 32,
+                                                     (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
                 gg_cca_cart_sum_L2(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_molden_cart_sum_L2(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_molden_cart_sum_L2(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start),
+                                      npoints);
             }
         }
     }
@@ -497,11 +492,12 @@ void gg_orbitals_L2(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
-
+void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -511,12 +507,12 @@ void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -531,10 +527,10 @@ void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 320 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((320 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -550,8 +546,6 @@ void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -575,8 +569,8 @@ void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -605,13 +599,11 @@ void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
@@ -620,7 +612,6 @@ void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbita
             const double xc_pow3 = xc_pow2 * xc[i];
             const double yc_pow3 = yc_pow2 * yc[i];
             const double zc_pow3 = zc_pow2 * zc[i];
-
 
             // Density AM=3 Component=XXX
             phi_tmp[i] = S0[i] * xc_pow3;
@@ -658,29 +649,31 @@ void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
             // Density AM=3 Component=ZZZ
             phi_tmp[288 + i] = S0[i] * zc_pow3;
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_cca_cart_to_spherical_sum_L3(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_cca_cart_to_spherical_sum_L3(remain, (C + i * nout), phi_tmp, 32,
+                                                (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_gaussian_cart_to_spherical_sum_L3(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_gaussian_cart_to_spherical_sum_L3(remain, (C + i * nout), phi_tmp, 32,
+                                                     (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
                 gg_cca_cart_sum_L3(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_molden_cart_sum_L3(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_molden_cart_sum_L3(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start),
+                                      npoints);
             }
         }
     }
@@ -691,11 +684,12 @@ void gg_orbitals_L3(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
-
+void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -705,12 +699,12 @@ void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -725,10 +719,10 @@ void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 480 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((480 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -744,8 +738,6 @@ void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -769,8 +761,8 @@ void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -799,13 +791,11 @@ void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
@@ -818,7 +808,6 @@ void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbita
             const double xc_pow4 = xc_pow3 * xc[i];
             const double yc_pow4 = yc_pow3 * yc[i];
             const double zc_pow4 = zc_pow3 * zc[i];
-
 
             // Density AM=4 Component=XXXX
             phi_tmp[i] = S0[i] * xc_pow4;
@@ -876,29 +865,31 @@ void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
             // Density AM=4 Component=ZZZZ
             phi_tmp[448 + i] = S0[i] * zc_pow4;
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_cca_cart_to_spherical_sum_L4(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_cca_cart_to_spherical_sum_L4(remain, (C + i * nout), phi_tmp, 32,
+                                                (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_gaussian_cart_to_spherical_sum_L4(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_gaussian_cart_to_spherical_sum_L4(remain, (C + i * nout), phi_tmp, 32,
+                                                     (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
                 gg_cca_cart_sum_L4(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_molden_cart_sum_L4(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_molden_cart_sum_L4(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start),
+                                      npoints);
             }
         }
     }
@@ -909,11 +900,12 @@ void gg_orbitals_L4(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
-
+void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -923,12 +915,12 @@ void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -943,10 +935,10 @@ void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 672 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((672 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -962,8 +954,6 @@ void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -987,8 +977,8 @@ void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -1017,13 +1007,11 @@ void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
@@ -1040,7 +1028,6 @@ void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbita
             const double xc_pow5 = xc_pow4 * xc[i];
             const double yc_pow5 = yc_pow4 * yc[i];
             const double zc_pow5 = zc_pow4 * zc[i];
-
 
             // Density AM=5 Component=XXXXX
             phi_tmp[i] = S0[i] * xc_pow5;
@@ -1122,29 +1109,31 @@ void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
             // Density AM=5 Component=ZZZZZ
             phi_tmp[640 + i] = S0[i] * zc_pow5;
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_cca_cart_to_spherical_sum_L5(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_cca_cart_to_spherical_sum_L5(remain, (C + i * nout), phi_tmp, 32,
+                                                (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_gaussian_cart_to_spherical_sum_L5(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_gaussian_cart_to_spherical_sum_L5(remain, (C + i * nout), phi_tmp, 32,
+                                                     (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
                 gg_cca_cart_sum_L5(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_molden_cart_sum_L5(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_molden_cart_sum_L5(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start),
+                                      npoints);
             }
         }
     }
@@ -1155,11 +1144,12 @@ void gg_orbitals_L5(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
-
+void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -1169,12 +1159,12 @@ void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -1189,10 +1179,10 @@ void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbita
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 896 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((896 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -1208,8 +1198,6 @@ void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -1233,8 +1221,8 @@ void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -1263,13 +1251,11 @@ void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbita
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
@@ -1290,7 +1276,6 @@ void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbita
             const double xc_pow6 = xc_pow5 * xc[i];
             const double yc_pow6 = yc_pow5 * yc[i];
             const double zc_pow6 = zc_pow5 * zc[i];
-
 
             // Density AM=6 Component=XXXXXX
             phi_tmp[i] = S0[i] * xc_pow6;
@@ -1400,29 +1385,31 @@ void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
             // Density AM=6 Component=ZZZZZZ
             phi_tmp[864 + i] = S0[i] * zc_pow6;
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_cca_cart_to_spherical_sum_L6(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_cca_cart_to_spherical_sum_L6(remain, (C + i * nout), phi_tmp, 32,
+                                                (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_gaussian_cart_to_spherical_sum_L6(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_gaussian_cart_to_spherical_sum_L6(remain, (C + i * nout), phi_tmp, 32,
+                                                     (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
                 gg_cca_cart_sum_L6(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
             }
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             for (unsigned long i = 0; i < norbitals; i++) {
-                gg_molden_cart_sum_L6(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+                gg_molden_cart_sum_L6(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start),
+                                      npoints);
             }
         }
     }
@@ -1433,5 +1420,668 @@ void gg_orbitals_L6(const double* PRAGMA_RESTRICT C, const unsigned long norbita
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
+}
 
+void gg_orbitals_L7(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
+    // Sizing
+    unsigned long nblocks = npoints / 32;
+    nblocks += (npoints % 32) ? 1 : 0;
+    const unsigned long ncart = 36;
+    const unsigned long nspherical = 15;
+    unsigned long nout;
+
+    if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
+        nout = nspherical;
+    } else {
+        nout = ncart;
+    }
+
+    // Allocate S temporaries, single block to stay on cache
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT xc = cache_data + 0;
+    ASSUME_ALIGNED(xc, 64);
+    double* PRAGMA_RESTRICT yc = cache_data + 32;
+    ASSUME_ALIGNED(yc, 64);
+    double* PRAGMA_RESTRICT zc = cache_data + 64;
+    ASSUME_ALIGNED(zc, 64);
+    double* PRAGMA_RESTRICT R2 = cache_data + 96;
+    ASSUME_ALIGNED(R2, 64);
+    double* PRAGMA_RESTRICT S0 = cache_data + 128;
+    ASSUME_ALIGNED(S0, 64);
+    double* PRAGMA_RESTRICT tmp1 = cache_data + 160;
+    ASSUME_ALIGNED(tmp1, 64);
+
+    // Allocate exponential temporaries
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+
+    // Allocate output temporaries
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((1152 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(phi_tmp, 64);
+
+    // Declare doubles
+    const double center_x = center[0];
+    const double center_y = center[1];
+    const double center_z = center[2];
+    double A;
+
+    // Build negative exponents
+    for (unsigned long i = 0; i < nprim; i++) {
+        expn1[i] = -1.0 * exponents[i];
+    }
+
+    // Start outer block loop
+    for (unsigned long block = 0; block < nblocks; block++) {
+        // Copy data into inner temps
+        const unsigned long start = block * 32;
+        const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
+
+        // Handle non-AM dependant temps
+        if (xyz_stride == 1) {
+            const double* PRAGMA_RESTRICT x = xyz + start;
+            const double* PRAGMA_RESTRICT y = xyz + npoints + start;
+            const double* PRAGMA_RESTRICT z = xyz + 2 * npoints + start;
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = x[i] - center_x;
+                yc[i] = y[i] - center_y;
+                zc[i] = z[i] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+            }
+        } else {
+            unsigned int start_shift = start * xyz_stride;
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = xyz[start_shift + i * xyz_stride] - center_x;
+                yc[i] = xyz[start_shift + i * xyz_stride + 1] - center_y;
+                zc[i] = xyz[start_shift + i * xyz_stride + 2] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+            }
+        }
+
+        // Start exponential block loop
+        for (unsigned long n = 0; n < nprim; n++) {
+            const double coef = coeffs[n];
+            const double alpha_n1 = expn1[n];
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                const double width = alpha_n1 * R2[i];
+                const double T1 = coef * exp(width);
+                S0[i] += T1;
+            }
+        }
+
+        // Combine blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            // Cartesian derivs
+            const double xc_pow2 = xc[i] * xc[i];
+            const double yc_pow2 = yc[i] * yc[i];
+            const double zc_pow2 = zc[i] * zc[i];
+
+            const double xc_pow3 = xc_pow2 * xc[i];
+            const double yc_pow3 = yc_pow2 * yc[i];
+            const double zc_pow3 = zc_pow2 * zc[i];
+
+            const double xc_pow4 = xc_pow3 * xc[i];
+            const double yc_pow4 = yc_pow3 * yc[i];
+            const double zc_pow4 = zc_pow3 * zc[i];
+
+            const double xc_pow5 = xc_pow4 * xc[i];
+            const double yc_pow5 = yc_pow4 * yc[i];
+            const double zc_pow5 = zc_pow4 * zc[i];
+
+            const double xc_pow6 = xc_pow5 * xc[i];
+            const double yc_pow6 = yc_pow5 * yc[i];
+            const double zc_pow6 = zc_pow5 * zc[i];
+
+            const double xc_pow7 = xc_pow6 * xc[i];
+            const double yc_pow7 = yc_pow6 * yc[i];
+            const double zc_pow7 = zc_pow6 * zc[i];
+
+            // Density AM=7 Component=XXXXXXX
+            phi_tmp[i] = S0[i] * xc_pow7;
+
+            // Density AM=7 Component=XXXXXXY
+            A = xc_pow6 * yc[i];
+            phi_tmp[32 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXXXZ
+            A = xc_pow6 * zc[i];
+            phi_tmp[64 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXXYY
+            A = xc_pow5 * yc_pow2;
+            phi_tmp[96 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXXYZ
+            A = xc_pow5 * yc[i] * zc[i];
+            phi_tmp[128 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXXZZ
+            A = xc_pow5 * zc_pow2;
+            phi_tmp[160 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXYYY
+            A = xc_pow4 * yc_pow3;
+            phi_tmp[192 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXYYZ
+            A = xc_pow4 * yc_pow2 * zc[i];
+            phi_tmp[224 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXYZZ
+            A = xc_pow4 * yc[i] * zc_pow2;
+            phi_tmp[256 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXZZZ
+            A = xc_pow4 * zc_pow3;
+            phi_tmp[288 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXYYYY
+            A = xc_pow3 * yc_pow4;
+            phi_tmp[320 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXYYYZ
+            A = xc_pow3 * yc_pow3 * zc[i];
+            phi_tmp[352 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXYYZZ
+            A = xc_pow3 * yc_pow2 * zc_pow2;
+            phi_tmp[384 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXYZZZ
+            A = xc_pow3 * yc[i] * zc_pow3;
+            phi_tmp[416 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXZZZZ
+            A = xc_pow3 * zc_pow4;
+            phi_tmp[448 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXYYYYY
+            A = xc_pow2 * yc_pow5;
+            phi_tmp[480 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXYYYYZ
+            A = xc_pow2 * yc_pow4 * zc[i];
+            phi_tmp[512 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXYYYZZ
+            A = xc_pow2 * yc_pow3 * zc_pow2;
+            phi_tmp[544 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXYYZZZ
+            A = xc_pow2 * yc_pow2 * zc_pow3;
+            phi_tmp[576 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXYZZZZ
+            A = xc_pow2 * yc[i] * zc_pow4;
+            phi_tmp[608 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXZZZZZ
+            A = xc_pow2 * zc_pow5;
+            phi_tmp[640 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYYYYYY
+            A = xc[i] * yc_pow6;
+            phi_tmp[672 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYYYYYZ
+            A = xc[i] * yc_pow5 * zc[i];
+            phi_tmp[704 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYYYYZZ
+            A = xc[i] * yc_pow4 * zc_pow2;
+            phi_tmp[736 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYYYZZZ
+            A = xc[i] * yc_pow3 * zc_pow3;
+            phi_tmp[768 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYYZZZZ
+            A = xc[i] * yc_pow2 * zc_pow4;
+            phi_tmp[800 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYZZZZZ
+            A = xc[i] * yc[i] * zc_pow5;
+            phi_tmp[832 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XZZZZZZ
+            A = xc[i] * zc_pow6;
+            phi_tmp[864 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YYYYYYY
+            phi_tmp[896 + i] = S0[i] * yc_pow7;
+
+            // Density AM=7 Component=YYYYYYZ
+            A = yc_pow6 * zc[i];
+            phi_tmp[928 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YYYYYZZ
+            A = yc_pow5 * zc_pow2;
+            phi_tmp[960 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YYYYZZZ
+            A = yc_pow4 * zc_pow3;
+            phi_tmp[992 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YYYZZZZ
+            A = yc_pow3 * zc_pow4;
+            phi_tmp[1024 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YYZZZZZ
+            A = yc_pow2 * zc_pow5;
+            phi_tmp[1056 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YZZZZZZ
+            A = yc[i] * zc_pow6;
+            phi_tmp[1088 + i] = S0[i] * A;
+
+            // Density AM=7 Component=ZZZZZZZ
+            phi_tmp[1120 + i] = S0[i] * zc_pow7;
+        }
+
+        // Copy data back into outer temps
+        if (order == GG_SPHERICAL_CCA) {
+            // Phi, transform data to outer temps
+            for (unsigned long i = 0; i < norbitals; i++) {
+                gg_cca_cart_to_spherical_sum_L7(remain, (C + i * nout), phi_tmp, 32,
+                                                (orbital_out + npoints * i + start), npoints);
+            }
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            // Phi, transform data to outer temps
+            for (unsigned long i = 0; i < norbitals; i++) {
+                gg_gaussian_cart_to_spherical_sum_L7(remain, (C + i * nout), phi_tmp, 32,
+                                                     (orbital_out + npoints * i + start), npoints);
+            }
+        } else if (order == GG_CARTESIAN_CCA) {
+            // Phi, transform data to outer temps
+            for (unsigned long i = 0; i < norbitals; i++) {
+                gg_cca_cart_sum_L7(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+            }
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            // Phi, transform data to outer temps
+            for (unsigned long i = 0; i < norbitals; i++) {
+                gg_molden_cart_sum_L7(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start),
+                                      npoints);
+            }
+        }
+    }
+
+    // Free S temporaries
+    ALIGNED_FREE(cache_data);
+    ALIGNED_FREE(expn1);
+
+    // Free inner temporaries
+    ALIGNED_FREE(phi_tmp);
+}
+
+void gg_orbitals_L8(const double* PRAGMA_RESTRICT C, const unsigned long norbitals, const unsigned long npoints,
+                    const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim,
+                    const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                    const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT orbital_out) {
+    // Sizing
+    unsigned long nblocks = npoints / 32;
+    nblocks += (npoints % 32) ? 1 : 0;
+    const unsigned long ncart = 45;
+    const unsigned long nspherical = 17;
+    unsigned long nout;
+
+    if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
+        nout = nspherical;
+    } else {
+        nout = ncart;
+    }
+
+    // Allocate S temporaries, single block to stay on cache
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT xc = cache_data + 0;
+    ASSUME_ALIGNED(xc, 64);
+    double* PRAGMA_RESTRICT yc = cache_data + 32;
+    ASSUME_ALIGNED(yc, 64);
+    double* PRAGMA_RESTRICT zc = cache_data + 64;
+    ASSUME_ALIGNED(zc, 64);
+    double* PRAGMA_RESTRICT R2 = cache_data + 96;
+    ASSUME_ALIGNED(R2, 64);
+    double* PRAGMA_RESTRICT S0 = cache_data + 128;
+    ASSUME_ALIGNED(S0, 64);
+    double* PRAGMA_RESTRICT tmp1 = cache_data + 160;
+    ASSUME_ALIGNED(tmp1, 64);
+
+    // Allocate exponential temporaries
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+
+    // Allocate output temporaries
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((1440 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(phi_tmp, 64);
+
+    // Declare doubles
+    const double center_x = center[0];
+    const double center_y = center[1];
+    const double center_z = center[2];
+    double A;
+
+    // Build negative exponents
+    for (unsigned long i = 0; i < nprim; i++) {
+        expn1[i] = -1.0 * exponents[i];
+    }
+
+    // Start outer block loop
+    for (unsigned long block = 0; block < nblocks; block++) {
+        // Copy data into inner temps
+        const unsigned long start = block * 32;
+        const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
+
+        // Handle non-AM dependant temps
+        if (xyz_stride == 1) {
+            const double* PRAGMA_RESTRICT x = xyz + start;
+            const double* PRAGMA_RESTRICT y = xyz + npoints + start;
+            const double* PRAGMA_RESTRICT z = xyz + 2 * npoints + start;
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = x[i] - center_x;
+                yc[i] = y[i] - center_y;
+                zc[i] = z[i] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+            }
+        } else {
+            unsigned int start_shift = start * xyz_stride;
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = xyz[start_shift + i * xyz_stride] - center_x;
+                yc[i] = xyz[start_shift + i * xyz_stride + 1] - center_y;
+                zc[i] = xyz[start_shift + i * xyz_stride + 2] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+            }
+        }
+
+        // Start exponential block loop
+        for (unsigned long n = 0; n < nprim; n++) {
+            const double coef = coeffs[n];
+            const double alpha_n1 = expn1[n];
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                const double width = alpha_n1 * R2[i];
+                const double T1 = coef * exp(width);
+                S0[i] += T1;
+            }
+        }
+
+        // Combine blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            // Cartesian derivs
+            const double xc_pow2 = xc[i] * xc[i];
+            const double yc_pow2 = yc[i] * yc[i];
+            const double zc_pow2 = zc[i] * zc[i];
+
+            const double xc_pow3 = xc_pow2 * xc[i];
+            const double yc_pow3 = yc_pow2 * yc[i];
+            const double zc_pow3 = zc_pow2 * zc[i];
+
+            const double xc_pow4 = xc_pow3 * xc[i];
+            const double yc_pow4 = yc_pow3 * yc[i];
+            const double zc_pow4 = zc_pow3 * zc[i];
+
+            const double xc_pow5 = xc_pow4 * xc[i];
+            const double yc_pow5 = yc_pow4 * yc[i];
+            const double zc_pow5 = zc_pow4 * zc[i];
+
+            const double xc_pow6 = xc_pow5 * xc[i];
+            const double yc_pow6 = yc_pow5 * yc[i];
+            const double zc_pow6 = zc_pow5 * zc[i];
+
+            const double xc_pow7 = xc_pow6 * xc[i];
+            const double yc_pow7 = yc_pow6 * yc[i];
+            const double zc_pow7 = zc_pow6 * zc[i];
+
+            const double xc_pow8 = xc_pow7 * xc[i];
+            const double yc_pow8 = yc_pow7 * yc[i];
+            const double zc_pow8 = zc_pow7 * zc[i];
+
+            // Density AM=8 Component=XXXXXXXX
+            phi_tmp[i] = S0[i] * xc_pow8;
+
+            // Density AM=8 Component=XXXXXXXY
+            A = xc_pow7 * yc[i];
+            phi_tmp[32 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXXXZ
+            A = xc_pow7 * zc[i];
+            phi_tmp[64 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXXYY
+            A = xc_pow6 * yc_pow2;
+            phi_tmp[96 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXXYZ
+            A = xc_pow6 * yc[i] * zc[i];
+            phi_tmp[128 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXXZZ
+            A = xc_pow6 * zc_pow2;
+            phi_tmp[160 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXYYY
+            A = xc_pow5 * yc_pow3;
+            phi_tmp[192 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXYYZ
+            A = xc_pow5 * yc_pow2 * zc[i];
+            phi_tmp[224 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXYZZ
+            A = xc_pow5 * yc[i] * zc_pow2;
+            phi_tmp[256 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXZZZ
+            A = xc_pow5 * zc_pow3;
+            phi_tmp[288 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXYYYY
+            A = xc_pow4 * yc_pow4;
+            phi_tmp[320 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXYYYZ
+            A = xc_pow4 * yc_pow3 * zc[i];
+            phi_tmp[352 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXYYZZ
+            A = xc_pow4 * yc_pow2 * zc_pow2;
+            phi_tmp[384 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXYZZZ
+            A = xc_pow4 * yc[i] * zc_pow3;
+            phi_tmp[416 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXZZZZ
+            A = xc_pow4 * zc_pow4;
+            phi_tmp[448 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXYYYYY
+            A = xc_pow3 * yc_pow5;
+            phi_tmp[480 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXYYYYZ
+            A = xc_pow3 * yc_pow4 * zc[i];
+            phi_tmp[512 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXYYYZZ
+            A = xc_pow3 * yc_pow3 * zc_pow2;
+            phi_tmp[544 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXYYZZZ
+            A = xc_pow3 * yc_pow2 * zc_pow3;
+            phi_tmp[576 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXYZZZZ
+            A = xc_pow3 * yc[i] * zc_pow4;
+            phi_tmp[608 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXZZZZZ
+            A = xc_pow3 * zc_pow5;
+            phi_tmp[640 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYYYYYY
+            A = xc_pow2 * yc_pow6;
+            phi_tmp[672 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYYYYYZ
+            A = xc_pow2 * yc_pow5 * zc[i];
+            phi_tmp[704 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYYYYZZ
+            A = xc_pow2 * yc_pow4 * zc_pow2;
+            phi_tmp[736 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYYYZZZ
+            A = xc_pow2 * yc_pow3 * zc_pow3;
+            phi_tmp[768 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYYZZZZ
+            A = xc_pow2 * yc_pow2 * zc_pow4;
+            phi_tmp[800 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYZZZZZ
+            A = xc_pow2 * yc[i] * zc_pow5;
+            phi_tmp[832 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXZZZZZZ
+            A = xc_pow2 * zc_pow6;
+            phi_tmp[864 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYYYYYY
+            A = xc[i] * yc_pow7;
+            phi_tmp[896 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYYYYYZ
+            A = xc[i] * yc_pow6 * zc[i];
+            phi_tmp[928 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYYYYZZ
+            A = xc[i] * yc_pow5 * zc_pow2;
+            phi_tmp[960 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYYYZZZ
+            A = xc[i] * yc_pow4 * zc_pow3;
+            phi_tmp[992 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYYZZZZ
+            A = xc[i] * yc_pow3 * zc_pow4;
+            phi_tmp[1024 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYZZZZZ
+            A = xc[i] * yc_pow2 * zc_pow5;
+            phi_tmp[1056 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYZZZZZZ
+            A = xc[i] * yc[i] * zc_pow6;
+            phi_tmp[1088 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XZZZZZZZ
+            A = xc[i] * zc_pow7;
+            phi_tmp[1120 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYYYYYYY
+            phi_tmp[1152 + i] = S0[i] * yc_pow8;
+
+            // Density AM=8 Component=YYYYYYYZ
+            A = yc_pow7 * zc[i];
+            phi_tmp[1184 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYYYYYZZ
+            A = yc_pow6 * zc_pow2;
+            phi_tmp[1216 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYYYYZZZ
+            A = yc_pow5 * zc_pow3;
+            phi_tmp[1248 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYYYZZZZ
+            A = yc_pow4 * zc_pow4;
+            phi_tmp[1280 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYYZZZZZ
+            A = yc_pow3 * zc_pow5;
+            phi_tmp[1312 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYZZZZZZ
+            A = yc_pow2 * zc_pow6;
+            phi_tmp[1344 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YZZZZZZZ
+            A = yc[i] * zc_pow7;
+            phi_tmp[1376 + i] = S0[i] * A;
+
+            // Density AM=8 Component=ZZZZZZZZ
+            phi_tmp[1408 + i] = S0[i] * zc_pow8;
+        }
+
+        // Copy data back into outer temps
+        if (order == GG_SPHERICAL_CCA) {
+            // Phi, transform data to outer temps
+            for (unsigned long i = 0; i < norbitals; i++) {
+                gg_cca_cart_to_spherical_sum_L8(remain, (C + i * nout), phi_tmp, 32,
+                                                (orbital_out + npoints * i + start), npoints);
+            }
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            // Phi, transform data to outer temps
+            for (unsigned long i = 0; i < norbitals; i++) {
+                gg_gaussian_cart_to_spherical_sum_L8(remain, (C + i * nout), phi_tmp, 32,
+                                                     (orbital_out + npoints * i + start), npoints);
+            }
+        } else if (order == GG_CARTESIAN_CCA) {
+            // Phi, transform data to outer temps
+            for (unsigned long i = 0; i < norbitals; i++) {
+                gg_cca_cart_sum_L8(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start), npoints);
+            }
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            // Phi, transform data to outer temps
+            for (unsigned long i = 0; i < norbitals; i++) {
+                gg_molden_cart_sum_L8(remain, (C + i * nout), phi_tmp, 32, (orbital_out + npoints * i + start),
+                                      npoints);
+            }
+        }
+    }
+
+    // Free S temporaries
+    ALIGNED_FREE(cache_data);
+    ALIGNED_FREE(expn1);
+
+    // Free inner temporaries
+    ALIGNED_FREE(phi_tmp);
 }

--- a/external/gau2grid/generated_source/gau2grid_phi.c
+++ b/external/gau2grid/generated_source/gau2grid_phi.c
@@ -20,10 +20,9 @@
 #include "gau2grid/gau2grid_utility.h"
 #include "gau2grid/gau2grid_pragma.h"
 
-
-
-void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
-
+void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -33,12 +32,12 @@ void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -53,10 +52,10 @@ void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRIC
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 32 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((32 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -71,8 +70,6 @@ void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -96,8 +93,8 @@ void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -126,7 +123,6 @@ void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
@@ -142,11 +138,11 @@ void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
-
+void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -156,12 +152,12 @@ void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -176,10 +172,10 @@ void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRIC
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 96 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((96 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -194,8 +190,6 @@ void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -219,8 +213,8 @@ void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -249,13 +243,11 @@ void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Density AM=1 Component=X
             phi_tmp[i] = S0[i] * xc[i];
 
@@ -264,24 +256,22 @@ void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
             // Density AM=1 Component=Z
             phi_tmp[64 + i] = S0[i] * zc[i];
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_to_spherical_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L1(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -290,11 +280,11 @@ void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
-
+void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -304,12 +294,12 @@ void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -324,10 +314,10 @@ void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRIC
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -343,8 +333,6 @@ void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -368,8 +356,8 @@ void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -398,18 +386,15 @@ void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
             const double zc_pow2 = zc[i] * zc[i];
-
 
             // Density AM=2 Component=XX
             phi_tmp[i] = S0[i] * xc_pow2;
@@ -431,24 +416,22 @@ void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
             // Density AM=2 Component=ZZ
             phi_tmp[160 + i] = S0[i] * zc_pow2;
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L2(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -457,11 +440,11 @@ void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
-
+void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -471,12 +454,12 @@ void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -491,10 +474,10 @@ void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRIC
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 320 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((320 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -510,8 +493,6 @@ void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -535,8 +516,8 @@ void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -565,13 +546,11 @@ void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
@@ -580,7 +559,6 @@ void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRIC
             const double xc_pow3 = xc_pow2 * xc[i];
             const double yc_pow3 = yc_pow2 * yc[i];
             const double zc_pow3 = zc_pow2 * zc[i];
-
 
             // Density AM=3 Component=XXX
             phi_tmp[i] = S0[i] * xc_pow3;
@@ -618,24 +596,22 @@ void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
             // Density AM=3 Component=ZZZ
             phi_tmp[288 + i] = S0[i] * zc_pow3;
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L3(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -644,11 +620,11 @@ void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
-
+void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -658,12 +634,12 @@ void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -678,10 +654,10 @@ void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRIC
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 480 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((480 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -697,8 +673,6 @@ void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -722,8 +696,8 @@ void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -752,13 +726,11 @@ void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
@@ -771,7 +743,6 @@ void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRIC
             const double xc_pow4 = xc_pow3 * xc[i];
             const double yc_pow4 = yc_pow3 * yc[i];
             const double zc_pow4 = zc_pow3 * zc[i];
-
 
             // Density AM=4 Component=XXXX
             phi_tmp[i] = S0[i] * xc_pow4;
@@ -829,24 +800,22 @@ void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
             // Density AM=4 Component=ZZZZ
             phi_tmp[448 + i] = S0[i] * zc_pow4;
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L4(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -855,11 +824,11 @@ void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
-
+void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -869,12 +838,12 @@ void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -889,10 +858,10 @@ void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRIC
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 672 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((672 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -908,8 +877,6 @@ void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -933,8 +900,8 @@ void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -963,13 +930,11 @@ void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
@@ -986,7 +951,6 @@ void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRIC
             const double xc_pow5 = xc_pow4 * xc[i];
             const double yc_pow5 = yc_pow4 * yc[i];
             const double zc_pow5 = zc_pow4 * zc[i];
-
 
             // Density AM=5 Component=XXXXX
             phi_tmp[i] = S0[i] * xc_pow5;
@@ -1068,24 +1032,22 @@ void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
             // Density AM=5 Component=ZZZZZ
             phi_tmp[640 + i] = S0[i] * zc_pow5;
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L5(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -1094,11 +1056,11 @@ void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
-
 }
 
-void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride, const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents, const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
-
+void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
     // Sizing
     unsigned long nblocks = npoints / 32;
     nblocks += (npoints % 32) ? 1 : 0;
@@ -1108,12 +1070,12 @@ void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
         nout = nspherical;
-        } else {
+    } else {
         nout = ncart;
     }
 
     // Allocate S temporaries, single block to stay on cache
-    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, 192 * sizeof(double));
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
     double* PRAGMA_RESTRICT xc = cache_data + 0;
     ASSUME_ALIGNED(xc, 64);
     double* PRAGMA_RESTRICT yc = cache_data + 32;
@@ -1128,10 +1090,10 @@ void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRIC
     ASSUME_ALIGNED(tmp1, 64);
 
     // Allocate exponential temporaries
-    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, nprim * sizeof(double));
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
 
     // Allocate output temporaries
-    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, 896 * sizeof(double));
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((896 * sizeof(double)) + 64 - 1) / 64) * 64));
     ASSUME_ALIGNED(phi_tmp, 64);
 
     // Declare doubles
@@ -1147,8 +1109,6 @@ void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Start outer block loop
     for (unsigned long block = 0; block < nblocks; block++) {
-
-
         // Copy data into inner temps
         const unsigned long start = block * 32;
         const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
@@ -1172,8 +1132,8 @@ void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 // Zero out S tmps
                 S0[i] = 0.0;
             }
-            } else {
-            unsigned long start_shift = start * xyz_stride;
+        } else {
+            unsigned int start_shift = start * xyz_stride;
 
             PRAGMA_VECTORIZE
             for (unsigned long i = 0; i < remain; i++) {
@@ -1202,13 +1162,11 @@ void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRIC
                 const double T1 = coef * exp(width);
                 S0[i] += T1;
             }
-
         }
 
         // Combine blocks
         PRAGMA_VECTORIZE
         for (unsigned long i = 0; i < remain; i++) {
-
             // Cartesian derivs
             const double xc_pow2 = xc[i] * xc[i];
             const double yc_pow2 = yc[i] * yc[i];
@@ -1229,7 +1187,6 @@ void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRIC
             const double xc_pow6 = xc_pow5 * xc[i];
             const double yc_pow6 = yc_pow5 * yc[i];
             const double zc_pow6 = zc_pow5 * zc[i];
-
 
             // Density AM=6 Component=XXXXXX
             phi_tmp[i] = S0[i] * xc_pow6;
@@ -1339,24 +1296,22 @@ void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
             // Density AM=6 Component=ZZZZZZ
             phi_tmp[864 + i] = S0[i] * zc_pow6;
-
         }
 
         // Copy data back into outer temps
         if (order == GG_SPHERICAL_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_SPHERICAL_GAUSSIAN) {
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
             // Phi, transform data to outer temps
             gg_gaussian_cart_to_spherical_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_CCA) {
+        } else if (order == GG_CARTESIAN_CCA) {
             // Phi, transform data to outer temps
             gg_cca_cart_copy_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
-            } else if (order == GG_CARTESIAN_MOLDEN) {
+        } else if (order == GG_CARTESIAN_MOLDEN) {
             // Phi, transform data to outer temps
             gg_molden_cart_copy_L6(remain, phi_tmp, 32, (phi_out + start), npoints);
         }
-
     }
 
     // Free S temporaries
@@ -1365,5 +1320,644 @@ void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRIC
 
     // Free inner temporaries
     ALIGNED_FREE(phi_tmp);
+}
 
+void gg_collocation_L7(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
+    // Sizing
+    unsigned long nblocks = npoints / 32;
+    nblocks += (npoints % 32) ? 1 : 0;
+    const unsigned long ncart = 36;
+    const unsigned long nspherical = 15;
+    unsigned long nout;
+
+    if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
+        nout = nspherical;
+    } else {
+        nout = ncart;
+    }
+
+    // Allocate S temporaries, single block to stay on cache
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT xc = cache_data + 0;
+    ASSUME_ALIGNED(xc, 64);
+    double* PRAGMA_RESTRICT yc = cache_data + 32;
+    ASSUME_ALIGNED(yc, 64);
+    double* PRAGMA_RESTRICT zc = cache_data + 64;
+    ASSUME_ALIGNED(zc, 64);
+    double* PRAGMA_RESTRICT R2 = cache_data + 96;
+    ASSUME_ALIGNED(R2, 64);
+    double* PRAGMA_RESTRICT S0 = cache_data + 128;
+    ASSUME_ALIGNED(S0, 64);
+    double* PRAGMA_RESTRICT tmp1 = cache_data + 160;
+    ASSUME_ALIGNED(tmp1, 64);
+
+    // Allocate exponential temporaries
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+
+    // Allocate output temporaries
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((1152 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(phi_tmp, 64);
+
+    // Declare doubles
+    const double center_x = center[0];
+    const double center_y = center[1];
+    const double center_z = center[2];
+    double A;
+
+    // Build negative exponents
+    for (unsigned long i = 0; i < nprim; i++) {
+        expn1[i] = -1.0 * exponents[i];
+    }
+
+    // Start outer block loop
+    for (unsigned long block = 0; block < nblocks; block++) {
+        // Copy data into inner temps
+        const unsigned long start = block * 32;
+        const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
+
+        // Handle non-AM dependant temps
+        if (xyz_stride == 1) {
+            const double* PRAGMA_RESTRICT x = xyz + start;
+            const double* PRAGMA_RESTRICT y = xyz + npoints + start;
+            const double* PRAGMA_RESTRICT z = xyz + 2 * npoints + start;
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = x[i] - center_x;
+                yc[i] = y[i] - center_y;
+                zc[i] = z[i] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+            }
+        } else {
+            unsigned int start_shift = start * xyz_stride;
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = xyz[start_shift + i * xyz_stride] - center_x;
+                yc[i] = xyz[start_shift + i * xyz_stride + 1] - center_y;
+                zc[i] = xyz[start_shift + i * xyz_stride + 2] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+            }
+        }
+
+        // Start exponential block loop
+        for (unsigned long n = 0; n < nprim; n++) {
+            const double coef = coeffs[n];
+            const double alpha_n1 = expn1[n];
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                const double width = alpha_n1 * R2[i];
+                const double T1 = coef * exp(width);
+                S0[i] += T1;
+            }
+        }
+
+        // Combine blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            // Cartesian derivs
+            const double xc_pow2 = xc[i] * xc[i];
+            const double yc_pow2 = yc[i] * yc[i];
+            const double zc_pow2 = zc[i] * zc[i];
+
+            const double xc_pow3 = xc_pow2 * xc[i];
+            const double yc_pow3 = yc_pow2 * yc[i];
+            const double zc_pow3 = zc_pow2 * zc[i];
+
+            const double xc_pow4 = xc_pow3 * xc[i];
+            const double yc_pow4 = yc_pow3 * yc[i];
+            const double zc_pow4 = zc_pow3 * zc[i];
+
+            const double xc_pow5 = xc_pow4 * xc[i];
+            const double yc_pow5 = yc_pow4 * yc[i];
+            const double zc_pow5 = zc_pow4 * zc[i];
+
+            const double xc_pow6 = xc_pow5 * xc[i];
+            const double yc_pow6 = yc_pow5 * yc[i];
+            const double zc_pow6 = zc_pow5 * zc[i];
+
+            const double xc_pow7 = xc_pow6 * xc[i];
+            const double yc_pow7 = yc_pow6 * yc[i];
+            const double zc_pow7 = zc_pow6 * zc[i];
+
+            // Density AM=7 Component=XXXXXXX
+            phi_tmp[i] = S0[i] * xc_pow7;
+
+            // Density AM=7 Component=XXXXXXY
+            A = xc_pow6 * yc[i];
+            phi_tmp[32 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXXXZ
+            A = xc_pow6 * zc[i];
+            phi_tmp[64 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXXYY
+            A = xc_pow5 * yc_pow2;
+            phi_tmp[96 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXXYZ
+            A = xc_pow5 * yc[i] * zc[i];
+            phi_tmp[128 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXXZZ
+            A = xc_pow5 * zc_pow2;
+            phi_tmp[160 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXYYY
+            A = xc_pow4 * yc_pow3;
+            phi_tmp[192 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXYYZ
+            A = xc_pow4 * yc_pow2 * zc[i];
+            phi_tmp[224 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXYZZ
+            A = xc_pow4 * yc[i] * zc_pow2;
+            phi_tmp[256 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXXZZZ
+            A = xc_pow4 * zc_pow3;
+            phi_tmp[288 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXYYYY
+            A = xc_pow3 * yc_pow4;
+            phi_tmp[320 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXYYYZ
+            A = xc_pow3 * yc_pow3 * zc[i];
+            phi_tmp[352 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXYYZZ
+            A = xc_pow3 * yc_pow2 * zc_pow2;
+            phi_tmp[384 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXYZZZ
+            A = xc_pow3 * yc[i] * zc_pow3;
+            phi_tmp[416 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXXZZZZ
+            A = xc_pow3 * zc_pow4;
+            phi_tmp[448 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXYYYYY
+            A = xc_pow2 * yc_pow5;
+            phi_tmp[480 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXYYYYZ
+            A = xc_pow2 * yc_pow4 * zc[i];
+            phi_tmp[512 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXYYYZZ
+            A = xc_pow2 * yc_pow3 * zc_pow2;
+            phi_tmp[544 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXYYZZZ
+            A = xc_pow2 * yc_pow2 * zc_pow3;
+            phi_tmp[576 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXYZZZZ
+            A = xc_pow2 * yc[i] * zc_pow4;
+            phi_tmp[608 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XXZZZZZ
+            A = xc_pow2 * zc_pow5;
+            phi_tmp[640 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYYYYYY
+            A = xc[i] * yc_pow6;
+            phi_tmp[672 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYYYYYZ
+            A = xc[i] * yc_pow5 * zc[i];
+            phi_tmp[704 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYYYYZZ
+            A = xc[i] * yc_pow4 * zc_pow2;
+            phi_tmp[736 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYYYZZZ
+            A = xc[i] * yc_pow3 * zc_pow3;
+            phi_tmp[768 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYYZZZZ
+            A = xc[i] * yc_pow2 * zc_pow4;
+            phi_tmp[800 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XYZZZZZ
+            A = xc[i] * yc[i] * zc_pow5;
+            phi_tmp[832 + i] = S0[i] * A;
+
+            // Density AM=7 Component=XZZZZZZ
+            A = xc[i] * zc_pow6;
+            phi_tmp[864 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YYYYYYY
+            phi_tmp[896 + i] = S0[i] * yc_pow7;
+
+            // Density AM=7 Component=YYYYYYZ
+            A = yc_pow6 * zc[i];
+            phi_tmp[928 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YYYYYZZ
+            A = yc_pow5 * zc_pow2;
+            phi_tmp[960 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YYYYZZZ
+            A = yc_pow4 * zc_pow3;
+            phi_tmp[992 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YYYZZZZ
+            A = yc_pow3 * zc_pow4;
+            phi_tmp[1024 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YYZZZZZ
+            A = yc_pow2 * zc_pow5;
+            phi_tmp[1056 + i] = S0[i] * A;
+
+            // Density AM=7 Component=YZZZZZZ
+            A = yc[i] * zc_pow6;
+            phi_tmp[1088 + i] = S0[i] * A;
+
+            // Density AM=7 Component=ZZZZZZZ
+            phi_tmp[1120 + i] = S0[i] * zc_pow7;
+        }
+
+        // Copy data back into outer temps
+        if (order == GG_SPHERICAL_CCA) {
+            // Phi, transform data to outer temps
+            gg_cca_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            // Phi, transform data to outer temps
+            gg_gaussian_cart_to_spherical_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            // Phi, transform data to outer temps
+            gg_cca_cart_copy_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            // Phi, transform data to outer temps
+            gg_molden_cart_copy_L7(remain, phi_tmp, 32, (phi_out + start), npoints);
+        }
+    }
+
+    // Free S temporaries
+    ALIGNED_FREE(cache_data);
+    ALIGNED_FREE(expn1);
+
+    // Free inner temporaries
+    ALIGNED_FREE(phi_tmp);
+}
+
+void gg_collocation_L8(const unsigned long npoints, const double* PRAGMA_RESTRICT xyz, const unsigned long xyz_stride,
+                       const int nprim, const double* PRAGMA_RESTRICT coeffs, const double* PRAGMA_RESTRICT exponents,
+                       const double* PRAGMA_RESTRICT center, const int order, double* PRAGMA_RESTRICT phi_out) {
+    // Sizing
+    unsigned long nblocks = npoints / 32;
+    nblocks += (npoints % 32) ? 1 : 0;
+    const unsigned long ncart = 45;
+    const unsigned long nspherical = 17;
+    unsigned long nout;
+
+    if ((order == GG_SPHERICAL_CCA) || (order == GG_SPHERICAL_GAUSSIAN)) {
+        nout = nspherical;
+    } else {
+        nout = ncart;
+    }
+
+    // Allocate S temporaries, single block to stay on cache
+    double* PRAGMA_RESTRICT cache_data = (double*)ALIGNED_MALLOC(64, ((((192 * sizeof(double)) + 64 - 1) / 64) * 64));
+    double* PRAGMA_RESTRICT xc = cache_data + 0;
+    ASSUME_ALIGNED(xc, 64);
+    double* PRAGMA_RESTRICT yc = cache_data + 32;
+    ASSUME_ALIGNED(yc, 64);
+    double* PRAGMA_RESTRICT zc = cache_data + 64;
+    ASSUME_ALIGNED(zc, 64);
+    double* PRAGMA_RESTRICT R2 = cache_data + 96;
+    ASSUME_ALIGNED(R2, 64);
+    double* PRAGMA_RESTRICT S0 = cache_data + 128;
+    ASSUME_ALIGNED(S0, 64);
+    double* PRAGMA_RESTRICT tmp1 = cache_data + 160;
+    ASSUME_ALIGNED(tmp1, 64);
+
+    // Allocate exponential temporaries
+    double* PRAGMA_RESTRICT expn1 = (double*)ALIGNED_MALLOC(64, ((((nprim * sizeof(double)) + 64 - 1) / 64) * 64));
+
+    // Allocate output temporaries
+    double* PRAGMA_RESTRICT phi_tmp = (double*)ALIGNED_MALLOC(64, ((((1440 * sizeof(double)) + 64 - 1) / 64) * 64));
+    ASSUME_ALIGNED(phi_tmp, 64);
+
+    // Declare doubles
+    const double center_x = center[0];
+    const double center_y = center[1];
+    const double center_z = center[2];
+    double A;
+
+    // Build negative exponents
+    for (unsigned long i = 0; i < nprim; i++) {
+        expn1[i] = -1.0 * exponents[i];
+    }
+
+    // Start outer block loop
+    for (unsigned long block = 0; block < nblocks; block++) {
+        // Copy data into inner temps
+        const unsigned long start = block * 32;
+        const unsigned long remain = ((start + 32) > npoints) ? (npoints - start) : 32;
+
+        // Handle non-AM dependant temps
+        if (xyz_stride == 1) {
+            const double* PRAGMA_RESTRICT x = xyz + start;
+            const double* PRAGMA_RESTRICT y = xyz + npoints + start;
+            const double* PRAGMA_RESTRICT z = xyz + 2 * npoints + start;
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = x[i] - center_x;
+                yc[i] = y[i] - center_y;
+                zc[i] = z[i] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+            }
+        } else {
+            unsigned int start_shift = start * xyz_stride;
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                xc[i] = xyz[start_shift + i * xyz_stride] - center_x;
+                yc[i] = xyz[start_shift + i * xyz_stride + 1] - center_y;
+                zc[i] = xyz[start_shift + i * xyz_stride + 2] - center_z;
+
+                // Distance
+                R2[i] = xc[i] * xc[i];
+                R2[i] += yc[i] * yc[i];
+                R2[i] += zc[i] * zc[i];
+
+                // Zero out S tmps
+                S0[i] = 0.0;
+            }
+        }
+
+        // Start exponential block loop
+        for (unsigned long n = 0; n < nprim; n++) {
+            const double coef = coeffs[n];
+            const double alpha_n1 = expn1[n];
+
+            PRAGMA_VECTORIZE
+            for (unsigned long i = 0; i < remain; i++) {
+                const double width = alpha_n1 * R2[i];
+                const double T1 = coef * exp(width);
+                S0[i] += T1;
+            }
+        }
+
+        // Combine blocks
+        PRAGMA_VECTORIZE
+        for (unsigned long i = 0; i < remain; i++) {
+            // Cartesian derivs
+            const double xc_pow2 = xc[i] * xc[i];
+            const double yc_pow2 = yc[i] * yc[i];
+            const double zc_pow2 = zc[i] * zc[i];
+
+            const double xc_pow3 = xc_pow2 * xc[i];
+            const double yc_pow3 = yc_pow2 * yc[i];
+            const double zc_pow3 = zc_pow2 * zc[i];
+
+            const double xc_pow4 = xc_pow3 * xc[i];
+            const double yc_pow4 = yc_pow3 * yc[i];
+            const double zc_pow4 = zc_pow3 * zc[i];
+
+            const double xc_pow5 = xc_pow4 * xc[i];
+            const double yc_pow5 = yc_pow4 * yc[i];
+            const double zc_pow5 = zc_pow4 * zc[i];
+
+            const double xc_pow6 = xc_pow5 * xc[i];
+            const double yc_pow6 = yc_pow5 * yc[i];
+            const double zc_pow6 = zc_pow5 * zc[i];
+
+            const double xc_pow7 = xc_pow6 * xc[i];
+            const double yc_pow7 = yc_pow6 * yc[i];
+            const double zc_pow7 = zc_pow6 * zc[i];
+
+            const double xc_pow8 = xc_pow7 * xc[i];
+            const double yc_pow8 = yc_pow7 * yc[i];
+            const double zc_pow8 = zc_pow7 * zc[i];
+
+            // Density AM=8 Component=XXXXXXXX
+            phi_tmp[i] = S0[i] * xc_pow8;
+
+            // Density AM=8 Component=XXXXXXXY
+            A = xc_pow7 * yc[i];
+            phi_tmp[32 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXXXZ
+            A = xc_pow7 * zc[i];
+            phi_tmp[64 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXXYY
+            A = xc_pow6 * yc_pow2;
+            phi_tmp[96 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXXYZ
+            A = xc_pow6 * yc[i] * zc[i];
+            phi_tmp[128 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXXZZ
+            A = xc_pow6 * zc_pow2;
+            phi_tmp[160 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXYYY
+            A = xc_pow5 * yc_pow3;
+            phi_tmp[192 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXYYZ
+            A = xc_pow5 * yc_pow2 * zc[i];
+            phi_tmp[224 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXYZZ
+            A = xc_pow5 * yc[i] * zc_pow2;
+            phi_tmp[256 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXXZZZ
+            A = xc_pow5 * zc_pow3;
+            phi_tmp[288 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXYYYY
+            A = xc_pow4 * yc_pow4;
+            phi_tmp[320 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXYYYZ
+            A = xc_pow4 * yc_pow3 * zc[i];
+            phi_tmp[352 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXYYZZ
+            A = xc_pow4 * yc_pow2 * zc_pow2;
+            phi_tmp[384 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXYZZZ
+            A = xc_pow4 * yc[i] * zc_pow3;
+            phi_tmp[416 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXXZZZZ
+            A = xc_pow4 * zc_pow4;
+            phi_tmp[448 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXYYYYY
+            A = xc_pow3 * yc_pow5;
+            phi_tmp[480 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXYYYYZ
+            A = xc_pow3 * yc_pow4 * zc[i];
+            phi_tmp[512 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXYYYZZ
+            A = xc_pow3 * yc_pow3 * zc_pow2;
+            phi_tmp[544 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXYYZZZ
+            A = xc_pow3 * yc_pow2 * zc_pow3;
+            phi_tmp[576 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXYZZZZ
+            A = xc_pow3 * yc[i] * zc_pow4;
+            phi_tmp[608 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXXZZZZZ
+            A = xc_pow3 * zc_pow5;
+            phi_tmp[640 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYYYYYY
+            A = xc_pow2 * yc_pow6;
+            phi_tmp[672 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYYYYYZ
+            A = xc_pow2 * yc_pow5 * zc[i];
+            phi_tmp[704 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYYYYZZ
+            A = xc_pow2 * yc_pow4 * zc_pow2;
+            phi_tmp[736 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYYYZZZ
+            A = xc_pow2 * yc_pow3 * zc_pow3;
+            phi_tmp[768 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYYZZZZ
+            A = xc_pow2 * yc_pow2 * zc_pow4;
+            phi_tmp[800 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXYZZZZZ
+            A = xc_pow2 * yc[i] * zc_pow5;
+            phi_tmp[832 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XXZZZZZZ
+            A = xc_pow2 * zc_pow6;
+            phi_tmp[864 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYYYYYY
+            A = xc[i] * yc_pow7;
+            phi_tmp[896 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYYYYYZ
+            A = xc[i] * yc_pow6 * zc[i];
+            phi_tmp[928 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYYYYZZ
+            A = xc[i] * yc_pow5 * zc_pow2;
+            phi_tmp[960 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYYYZZZ
+            A = xc[i] * yc_pow4 * zc_pow3;
+            phi_tmp[992 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYYZZZZ
+            A = xc[i] * yc_pow3 * zc_pow4;
+            phi_tmp[1024 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYYZZZZZ
+            A = xc[i] * yc_pow2 * zc_pow5;
+            phi_tmp[1056 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XYZZZZZZ
+            A = xc[i] * yc[i] * zc_pow6;
+            phi_tmp[1088 + i] = S0[i] * A;
+
+            // Density AM=8 Component=XZZZZZZZ
+            A = xc[i] * zc_pow7;
+            phi_tmp[1120 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYYYYYYY
+            phi_tmp[1152 + i] = S0[i] * yc_pow8;
+
+            // Density AM=8 Component=YYYYYYYZ
+            A = yc_pow7 * zc[i];
+            phi_tmp[1184 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYYYYYZZ
+            A = yc_pow6 * zc_pow2;
+            phi_tmp[1216 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYYYYZZZ
+            A = yc_pow5 * zc_pow3;
+            phi_tmp[1248 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYYYZZZZ
+            A = yc_pow4 * zc_pow4;
+            phi_tmp[1280 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYYZZZZZ
+            A = yc_pow3 * zc_pow5;
+            phi_tmp[1312 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YYZZZZZZ
+            A = yc_pow2 * zc_pow6;
+            phi_tmp[1344 + i] = S0[i] * A;
+
+            // Density AM=8 Component=YZZZZZZZ
+            A = yc[i] * zc_pow7;
+            phi_tmp[1376 + i] = S0[i] * A;
+
+            // Density AM=8 Component=ZZZZZZZZ
+            phi_tmp[1408 + i] = S0[i] * zc_pow8;
+        }
+
+        // Copy data back into outer temps
+        if (order == GG_SPHERICAL_CCA) {
+            // Phi, transform data to outer temps
+            gg_cca_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_SPHERICAL_GAUSSIAN) {
+            // Phi, transform data to outer temps
+            gg_gaussian_cart_to_spherical_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_CCA) {
+            // Phi, transform data to outer temps
+            gg_cca_cart_copy_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        } else if (order == GG_CARTESIAN_MOLDEN) {
+            // Phi, transform data to outer temps
+            gg_molden_cart_copy_L8(remain, phi_tmp, 32, (phi_out + start), npoints);
+        }
+    }
+
+    // Free S temporaries
+    ALIGNED_FREE(cache_data);
+    ALIGNED_FREE(expn1);
+
+    // Free inner temporaries
+    ALIGNED_FREE(phi_tmp);
 }

--- a/external/gau2grid/generated_source/gau2grid_phi.c
+++ b/external/gau2grid/generated_source/gau2grid_phi.c
@@ -62,9 +62,10 @@ void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRIC
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -113,7 +114,7 @@ void gg_collocation_L0(const unsigned long npoints, const double* PRAGMA_RESTRIC
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -182,9 +183,10 @@ void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRIC
     const double center_x = center[0];
     const double center_y = center[1];
     const double center_z = center[2];
+    double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -233,7 +235,7 @@ void gg_collocation_L1(const unsigned long npoints, const double* PRAGMA_RESTRIC
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -327,7 +329,7 @@ void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRIC
     double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -376,7 +378,7 @@ void gg_collocation_L2(const unsigned long npoints, const double* PRAGMA_RESTRIC
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -487,7 +489,7 @@ void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRIC
     double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -536,7 +538,7 @@ void gg_collocation_L3(const unsigned long npoints, const double* PRAGMA_RESTRIC
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -667,7 +669,7 @@ void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRIC
     double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -716,7 +718,7 @@ void gg_collocation_L4(const unsigned long npoints, const double* PRAGMA_RESTRIC
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -871,7 +873,7 @@ void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRIC
     double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -920,7 +922,7 @@ void gg_collocation_L5(const unsigned long npoints, const double* PRAGMA_RESTRIC
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 
@@ -1103,7 +1105,7 @@ void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRIC
     double A;
 
     // Build negative exponents
-    for (unsigned long i = 0; i < (unsigned long)nprim; i++) {
+    for (unsigned long i = 0; i < nprim; i++) {
         expn1[i] = -1.0 * exponents[i];
     }
 
@@ -1152,7 +1154,7 @@ void gg_collocation_L6(const unsigned long npoints, const double* PRAGMA_RESTRIC
         }
 
         // Start exponential block loop
-        for (unsigned long n = 0; n < (unsigned long)nprim; n++) {
+        for (unsigned long n = 0; n < nprim; n++) {
             const double coef = coeffs[n];
             const double alpha_n1 = expn1[n];
 

--- a/external/gau2grid/generated_source/gau2grid_transform.c
+++ b/external/gau2grid/generated_source/gau2grid_transform.c
@@ -20,1822 +20,3163 @@
 #include "gau2grid/gau2grid_utility.h"
 #include "gau2grid/gau2grid_pragma.h"
 
-void gg_cca_cart_to_spherical_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
-    (void)ncart;
-    (void)nspherical;
+void gg_cca_cart_to_spherical_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_00 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  = cart[i];
-
+        spherical[i] = cart[i];
     }
-
 }
-void gg_cca_cart_to_spherical_sum_L0(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)ncart;
-    (void)nspherical;
+void gg_cca_cart_to_spherical_sum_L0(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_00 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = cart[i];
+        tmp = cart[i];
         output[i] += tmp * vector[0];
-
     }
-
 }
-void gg_cca_cart_to_spherical_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
+void gg_cca_cart_to_spherical_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_10 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  = cart[ncart + i];
-
+        spherical[i] = cart[ncart + i];
     }
 
     // R_11c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  = cart[2 * ncart + i];
-
+        spherical[nspherical + i] = cart[2 * ncart + i];
     }
     // R_11s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  = cart[i];
-
+        spherical[2 * nspherical + i] = cart[i];
     }
-
 }
-void gg_cca_cart_to_spherical_sum_L1(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
+void gg_cca_cart_to_spherical_sum_L1(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_10 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = cart[ncart + i];
+        tmp = cart[ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
     // R_11c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = cart[2 * ncart + i];
+        tmp = cart[2 * ncart + i];
         output[i] += tmp * vector[1];
-
     }
     // R_11s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = cart[i];
+        tmp = cart[i];
         output[i] += tmp * vector[2];
-
     }
-
 }
-void gg_cca_cart_to_spherical_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
+void gg_cca_cart_to_spherical_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_20 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  =  1.7320508075688772 * cart[ncart + i];
-
+        spherical[i] = 1.7320508075688772 * cart[ncart + i];
     }
 
     // R_21c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  =  1.7320508075688772 * cart[4 * ncart + i];
-
+        spherical[nspherical + i] = 1.7320508075688772 * cart[4 * ncart + i];
     }
     // R_21s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  = -0.5000000000000000 * cart[i];
+        spherical[2 * nspherical + i] = -0.5000000000000000 * cart[i];
         spherical[2 * nspherical + i] += -0.5000000000000000 * cart[3 * ncart + i];
         spherical[2 * nspherical + i] += cart[5 * ncart + i];
-
     }
 
     // R_22c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[3 * nspherical + i]  =  1.7320508075688772 * cart[2 * ncart + i];
-
+        spherical[3 * nspherical + i] = 1.7320508075688772 * cart[2 * ncart + i];
     }
     // R_22s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[4 * nspherical + i]  =  0.8660254037844386 * cart[i];
+        spherical[4 * nspherical + i] = 0.8660254037844386 * cart[i];
         spherical[4 * nspherical + i] += -0.8660254037844386 * cart[3 * ncart + i];
-
     }
-
 }
-void gg_cca_cart_to_spherical_sum_L2(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
+void gg_cca_cart_to_spherical_sum_L2(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_20 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  1.7320508075688772 * cart[ncart + i];
+        tmp = 1.7320508075688772 * cart[ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
     // R_21c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  1.7320508075688772 * cart[4 * ncart + i];
+        tmp = 1.7320508075688772 * cart[4 * ncart + i];
         output[i] += tmp * vector[1];
-
     }
     // R_21s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.5000000000000000 * cart[i];
+        tmp = -0.5000000000000000 * cart[i];
         tmp += -0.5000000000000000 * cart[3 * ncart + i];
         tmp += cart[5 * ncart + i];
         output[i] += tmp * vector[2];
-
     }
 
     // R_22c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  1.7320508075688772 * cart[2 * ncart + i];
+        tmp = 1.7320508075688772 * cart[2 * ncart + i];
         output[i] += tmp * vector[3];
-
     }
     // R_22s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.8660254037844386 * cart[i];
+        tmp = 0.8660254037844386 * cart[i];
         tmp += -0.8660254037844386 * cart[3 * ncart + i];
         output[i] += tmp * vector[4];
-
     }
-
 }
-void gg_cca_cart_to_spherical_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
+void gg_cca_cart_to_spherical_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_30 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  =  2.3717082451262845 * cart[ncart + i];
+        spherical[i] = 2.3717082451262845 * cart[ncart + i];
         spherical[i] += -0.7905694150420949 * cart[6 * ncart + i];
-
     }
 
     // R_31c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  =  3.8729833462074170 * cart[4 * ncart + i];
-
+        spherical[nspherical + i] = 3.8729833462074170 * cart[4 * ncart + i];
     }
     // R_31s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  = -0.6123724356957945 * cart[ncart + i];
+        spherical[2 * nspherical + i] = -0.6123724356957945 * cart[ncart + i];
         spherical[2 * nspherical + i] += -0.6123724356957945 * cart[6 * ncart + i];
-        spherical[2 * nspherical + i] +=  2.4494897427831779 * cart[8 * ncart + i];
-
+        spherical[2 * nspherical + i] += 2.4494897427831779 * cart[8 * ncart + i];
     }
 
     // R_32c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[3 * nspherical + i]  = -1.5000000000000000 * cart[2 * ncart + i];
+        spherical[3 * nspherical + i] = -1.5000000000000000 * cart[2 * ncart + i];
         spherical[3 * nspherical + i] += -1.5000000000000000 * cart[7 * ncart + i];
         spherical[3 * nspherical + i] += cart[9 * ncart + i];
-
     }
     // R_32s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[4 * nspherical + i]  = -0.6123724356957945 * cart[i];
+        spherical[4 * nspherical + i] = -0.6123724356957945 * cart[i];
         spherical[4 * nspherical + i] += -0.6123724356957945 * cart[3 * ncart + i];
-        spherical[4 * nspherical + i] +=  2.4494897427831779 * cart[5 * ncart + i];
-
+        spherical[4 * nspherical + i] += 2.4494897427831779 * cart[5 * ncart + i];
     }
 
     // R_33c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[5 * nspherical + i]  =  1.9364916731037085 * cart[2 * ncart + i];
+        spherical[5 * nspherical + i] = 1.9364916731037085 * cart[2 * ncart + i];
         spherical[5 * nspherical + i] += -1.9364916731037085 * cart[7 * ncart + i];
-
     }
     // R_33s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[6 * nspherical + i]  =  0.7905694150420949 * cart[i];
+        spherical[6 * nspherical + i] = 0.7905694150420949 * cart[i];
         spherical[6 * nspherical + i] += -2.3717082451262845 * cart[3 * ncart + i];
-
     }
-
 }
-void gg_cca_cart_to_spherical_sum_L3(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
+void gg_cca_cart_to_spherical_sum_L3(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_30 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.3717082451262845 * cart[ncart + i];
+        tmp = 2.3717082451262845 * cart[ncart + i];
         tmp += -0.7905694150420949 * cart[6 * ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
     // R_31c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  3.8729833462074170 * cart[4 * ncart + i];
+        tmp = 3.8729833462074170 * cart[4 * ncart + i];
         output[i] += tmp * vector[1];
-
     }
     // R_31s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.6123724356957945 * cart[ncart + i];
+        tmp = -0.6123724356957945 * cart[ncart + i];
         tmp += -0.6123724356957945 * cart[6 * ncart + i];
-        tmp +=  2.4494897427831779 * cart[8 * ncart + i];
+        tmp += 2.4494897427831779 * cart[8 * ncart + i];
         output[i] += tmp * vector[2];
-
     }
 
     // R_32c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -1.5000000000000000 * cart[2 * ncart + i];
+        tmp = -1.5000000000000000 * cart[2 * ncart + i];
         tmp += -1.5000000000000000 * cart[7 * ncart + i];
         tmp += cart[9 * ncart + i];
         output[i] += tmp * vector[3];
-
     }
     // R_32s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.6123724356957945 * cart[i];
+        tmp = -0.6123724356957945 * cart[i];
         tmp += -0.6123724356957945 * cart[3 * ncart + i];
-        tmp +=  2.4494897427831779 * cart[5 * ncart + i];
+        tmp += 2.4494897427831779 * cart[5 * ncart + i];
         output[i] += tmp * vector[4];
-
     }
 
     // R_33c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  1.9364916731037085 * cart[2 * ncart + i];
+        tmp = 1.9364916731037085 * cart[2 * ncart + i];
         tmp += -1.9364916731037085 * cart[7 * ncart + i];
         output[i] += tmp * vector[5];
-
     }
     // R_33s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.7905694150420949 * cart[i];
+        tmp = 0.7905694150420949 * cart[i];
         tmp += -2.3717082451262845 * cart[3 * ncart + i];
         output[i] += tmp * vector[6];
-
     }
-
 }
-void gg_cca_cart_to_spherical_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
+void gg_cca_cart_to_spherical_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_40 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  =  2.9580398915498081 * cart[ncart + i];
+        spherical[i] = 2.9580398915498081 * cart[ncart + i];
         spherical[i] += -2.9580398915498081 * cart[6 * ncart + i];
-
     }
 
     // R_41c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  =  6.2749501990055663 * cart[4 * ncart + i];
+        spherical[nspherical + i] = 6.2749501990055663 * cart[4 * ncart + i];
         spherical[nspherical + i] += -2.0916500663351889 * cart[11 * ncart + i];
-
     }
     // R_41s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  = -1.1180339887498949 * cart[ncart + i];
+        spherical[2 * nspherical + i] = -1.1180339887498949 * cart[ncart + i];
         spherical[2 * nspherical + i] += -1.1180339887498949 * cart[6 * ncart + i];
-        spherical[2 * nspherical + i] +=  6.7082039324993694 * cart[8 * ncart + i];
-
+        spherical[2 * nspherical + i] += 6.7082039324993694 * cart[8 * ncart + i];
     }
 
     // R_42c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[3 * nspherical + i]  = -2.3717082451262845 * cart[4 * ncart + i];
+        spherical[3 * nspherical + i] = -2.3717082451262845 * cart[4 * ncart + i];
         spherical[3 * nspherical + i] += -2.3717082451262845 * cart[11 * ncart + i];
-        spherical[3 * nspherical + i] +=  3.1622776601683795 * cart[13 * ncart + i];
-
+        spherical[3 * nspherical + i] += 3.1622776601683795 * cart[13 * ncart + i];
     }
     // R_42s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[4 * nspherical + i]  =  0.3750000000000000 * cart[i];
-        spherical[4 * nspherical + i] +=  0.7500000000000000 * cart[3 * ncart + i];
-        spherical[4 * nspherical + i] +=  0.3750000000000000 * cart[10 * ncart + i];
+        spherical[4 * nspherical + i] = 0.3750000000000000 * cart[i];
+        spherical[4 * nspherical + i] += 0.7500000000000000 * cart[3 * ncart + i];
+        spherical[4 * nspherical + i] += 0.3750000000000000 * cart[10 * ncart + i];
         spherical[4 * nspherical + i] += -3.0000000000000000 * cart[5 * ncart + i];
         spherical[4 * nspherical + i] += -3.0000000000000000 * cart[12 * ncart + i];
         spherical[4 * nspherical + i] += cart[14 * ncart + i];
-
     }
 
     // R_43c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[5 * nspherical + i]  = -2.3717082451262845 * cart[2 * ncart + i];
+        spherical[5 * nspherical + i] = -2.3717082451262845 * cart[2 * ncart + i];
         spherical[5 * nspherical + i] += -2.3717082451262845 * cart[7 * ncart + i];
-        spherical[5 * nspherical + i] +=  3.1622776601683795 * cart[9 * ncart + i];
-
+        spherical[5 * nspherical + i] += 3.1622776601683795 * cart[9 * ncart + i];
     }
     // R_43s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[6 * nspherical + i]  = -0.5590169943749475 * cart[i];
-        spherical[6 * nspherical + i] +=  0.5590169943749475 * cart[10 * ncart + i];
-        spherical[6 * nspherical + i] +=  3.3541019662496847 * cart[5 * ncart + i];
+        spherical[6 * nspherical + i] = -0.5590169943749475 * cart[i];
+        spherical[6 * nspherical + i] += 0.5590169943749475 * cart[10 * ncart + i];
+        spherical[6 * nspherical + i] += 3.3541019662496847 * cart[5 * ncart + i];
         spherical[6 * nspherical + i] += -3.3541019662496847 * cart[12 * ncart + i];
-
     }
 
     // R_44c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[7 * nspherical + i]  =  2.0916500663351889 * cart[2 * ncart + i];
+        spherical[7 * nspherical + i] = 2.0916500663351889 * cart[2 * ncart + i];
         spherical[7 * nspherical + i] += -6.2749501990055663 * cart[7 * ncart + i];
-
     }
     // R_44s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[8 * nspherical + i]  =  0.7395099728874520 * cart[i];
+        spherical[8 * nspherical + i] = 0.7395099728874520 * cart[i];
         spherical[8 * nspherical + i] += -4.4370598373247123 * cart[3 * ncart + i];
-        spherical[8 * nspherical + i] +=  0.7395099728874520 * cart[10 * ncart + i];
-
+        spherical[8 * nspherical + i] += 0.7395099728874520 * cart[10 * ncart + i];
     }
-
 }
-void gg_cca_cart_to_spherical_sum_L4(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
+void gg_cca_cart_to_spherical_sum_L4(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_40 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.9580398915498081 * cart[ncart + i];
+        tmp = 2.9580398915498081 * cart[ncart + i];
         tmp += -2.9580398915498081 * cart[6 * ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
     // R_41c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  6.2749501990055663 * cart[4 * ncart + i];
+        tmp = 6.2749501990055663 * cart[4 * ncart + i];
         tmp += -2.0916500663351889 * cart[11 * ncart + i];
         output[i] += tmp * vector[1];
-
     }
     // R_41s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -1.1180339887498949 * cart[ncart + i];
+        tmp = -1.1180339887498949 * cart[ncart + i];
         tmp += -1.1180339887498949 * cart[6 * ncart + i];
-        tmp +=  6.7082039324993694 * cart[8 * ncart + i];
+        tmp += 6.7082039324993694 * cart[8 * ncart + i];
         output[i] += tmp * vector[2];
-
     }
 
     // R_42c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -2.3717082451262845 * cart[4 * ncart + i];
+        tmp = -2.3717082451262845 * cart[4 * ncart + i];
         tmp += -2.3717082451262845 * cart[11 * ncart + i];
-        tmp +=  3.1622776601683795 * cart[13 * ncart + i];
+        tmp += 3.1622776601683795 * cart[13 * ncart + i];
         output[i] += tmp * vector[3];
-
     }
     // R_42s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.3750000000000000 * cart[i];
-        tmp +=  0.7500000000000000 * cart[3 * ncart + i];
-        tmp +=  0.3750000000000000 * cart[10 * ncart + i];
+        tmp = 0.3750000000000000 * cart[i];
+        tmp += 0.7500000000000000 * cart[3 * ncart + i];
+        tmp += 0.3750000000000000 * cart[10 * ncart + i];
         tmp += -3.0000000000000000 * cart[5 * ncart + i];
         tmp += -3.0000000000000000 * cart[12 * ncart + i];
         tmp += cart[14 * ncart + i];
         output[i] += tmp * vector[4];
-
     }
 
     // R_43c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -2.3717082451262845 * cart[2 * ncart + i];
+        tmp = -2.3717082451262845 * cart[2 * ncart + i];
         tmp += -2.3717082451262845 * cart[7 * ncart + i];
-        tmp +=  3.1622776601683795 * cart[9 * ncart + i];
+        tmp += 3.1622776601683795 * cart[9 * ncart + i];
         output[i] += tmp * vector[5];
-
     }
     // R_43s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.5590169943749475 * cart[i];
-        tmp +=  0.5590169943749475 * cart[10 * ncart + i];
-        tmp +=  3.3541019662496847 * cart[5 * ncart + i];
+        tmp = -0.5590169943749475 * cart[i];
+        tmp += 0.5590169943749475 * cart[10 * ncart + i];
+        tmp += 3.3541019662496847 * cart[5 * ncart + i];
         tmp += -3.3541019662496847 * cart[12 * ncart + i];
         output[i] += tmp * vector[6];
-
     }
 
     // R_44c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.0916500663351889 * cart[2 * ncart + i];
+        tmp = 2.0916500663351889 * cart[2 * ncart + i];
         tmp += -6.2749501990055663 * cart[7 * ncart + i];
         output[i] += tmp * vector[7];
-
     }
     // R_44s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.7395099728874520 * cart[i];
+        tmp = 0.7395099728874520 * cart[i];
         tmp += -4.4370598373247123 * cart[3 * ncart + i];
-        tmp +=  0.7395099728874520 * cart[10 * ncart + i];
+        tmp += 0.7395099728874520 * cart[10 * ncart + i];
         output[i] += tmp * vector[8];
-
     }
-
 }
-void gg_cca_cart_to_spherical_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
+void gg_cca_cart_to_spherical_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_50 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  =  3.5078038001005702 * cart[ncart + i];
+        spherical[i] = 3.5078038001005702 * cart[ncart + i];
         spherical[i] += -7.0156076002011405 * cart[6 * ncart + i];
-        spherical[i] +=  0.7015607600201140 * cart[15 * ncart + i];
-
+        spherical[i] += 0.7015607600201140 * cart[15 * ncart + i];
     }
 
     // R_51c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  =  8.8741196746494246 * cart[4 * ncart + i];
+        spherical[nspherical + i] = 8.8741196746494246 * cart[4 * ncart + i];
         spherical[nspherical + i] += -8.8741196746494246 * cart[11 * ncart + i];
-
     }
     // R_51s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  = -1.5687375497513916 * cart[ncart + i];
+        spherical[2 * nspherical + i] = -1.5687375497513916 * cart[ncart + i];
         spherical[2 * nspherical + i] += -1.0458250331675945 * cart[6 * ncart + i];
-        spherical[2 * nspherical + i] +=  0.5229125165837972 * cart[15 * ncart + i];
-        spherical[2 * nspherical + i] +=  12.5499003980111326 * cart[8 * ncart + i];
+        spherical[2 * nspherical + i] += 0.5229125165837972 * cart[15 * ncart + i];
+        spherical[2 * nspherical + i] += 12.5499003980111326 * cart[8 * ncart + i];
         spherical[2 * nspherical + i] += -4.1833001326703778 * cart[17 * ncart + i];
-
     }
 
     // R_52c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[3 * nspherical + i]  = -5.1234753829797990 * cart[4 * ncart + i];
+        spherical[3 * nspherical + i] = -5.1234753829797990 * cart[4 * ncart + i];
         spherical[3 * nspherical + i] += -5.1234753829797990 * cart[11 * ncart + i];
-        spherical[3 * nspherical + i] +=  10.2469507659595980 * cart[13 * ncart + i];
-
+        spherical[3 * nspherical + i] += 10.2469507659595980 * cart[13 * ncart + i];
     }
     // R_52s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[4 * nspherical + i]  =  0.4841229182759271 * cart[ncart + i];
-        spherical[4 * nspherical + i] +=  0.9682458365518543 * cart[6 * ncart + i];
-        spherical[4 * nspherical + i] +=  0.4841229182759271 * cart[15 * ncart + i];
+        spherical[4 * nspherical + i] = 0.4841229182759271 * cart[ncart + i];
+        spherical[4 * nspherical + i] += 0.9682458365518543 * cart[6 * ncart + i];
+        spherical[4 * nspherical + i] += 0.4841229182759271 * cart[15 * ncart + i];
         spherical[4 * nspherical + i] += -5.8094750193111251 * cart[8 * ncart + i];
         spherical[4 * nspherical + i] += -5.8094750193111251 * cart[17 * ncart + i];
-        spherical[4 * nspherical + i] +=  3.8729833462074170 * cart[19 * ncart + i];
-
+        spherical[4 * nspherical + i] += 3.8729833462074170 * cart[19 * ncart + i];
     }
 
     // R_53c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[5 * nspherical + i]  =  1.8750000000000000 * cart[2 * ncart + i];
-        spherical[5 * nspherical + i] +=  3.7500000000000000 * cart[7 * ncart + i];
-        spherical[5 * nspherical + i] +=  1.8750000000000000 * cart[16 * ncart + i];
+        spherical[5 * nspherical + i] = 1.8750000000000000 * cart[2 * ncart + i];
+        spherical[5 * nspherical + i] += 3.7500000000000000 * cart[7 * ncart + i];
+        spherical[5 * nspherical + i] += 1.8750000000000000 * cart[16 * ncart + i];
         spherical[5 * nspherical + i] += -5.0000000000000000 * cart[9 * ncart + i];
         spherical[5 * nspherical + i] += -5.0000000000000000 * cart[18 * ncart + i];
         spherical[5 * nspherical + i] += cart[20 * ncart + i];
-
     }
     // R_53s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[6 * nspherical + i]  =  0.4841229182759271 * cart[i];
-        spherical[6 * nspherical + i] +=  0.9682458365518543 * cart[3 * ncart + i];
-        spherical[6 * nspherical + i] +=  0.4841229182759271 * cart[10 * ncart + i];
+        spherical[6 * nspherical + i] = 0.4841229182759271 * cart[i];
+        spherical[6 * nspherical + i] += 0.9682458365518543 * cart[3 * ncart + i];
+        spherical[6 * nspherical + i] += 0.4841229182759271 * cart[10 * ncart + i];
         spherical[6 * nspherical + i] += -5.8094750193111251 * cart[5 * ncart + i];
         spherical[6 * nspherical + i] += -5.8094750193111251 * cart[12 * ncart + i];
-        spherical[6 * nspherical + i] +=  3.8729833462074170 * cart[14 * ncart + i];
-
+        spherical[6 * nspherical + i] += 3.8729833462074170 * cart[14 * ncart + i];
     }
 
     // R_54c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[7 * nspherical + i]  = -2.5617376914898995 * cart[2 * ncart + i];
-        spherical[7 * nspherical + i] +=  2.5617376914898995 * cart[16 * ncart + i];
-        spherical[7 * nspherical + i] +=  5.1234753829797990 * cart[9 * ncart + i];
+        spherical[7 * nspherical + i] = -2.5617376914898995 * cart[2 * ncart + i];
+        spherical[7 * nspherical + i] += 2.5617376914898995 * cart[16 * ncart + i];
+        spherical[7 * nspherical + i] += 5.1234753829797990 * cart[9 * ncart + i];
         spherical[7 * nspherical + i] += -5.1234753829797990 * cart[18 * ncart + i];
-
     }
     // R_54s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[8 * nspherical + i]  = -0.5229125165837972 * cart[i];
-        spherical[8 * nspherical + i] +=  1.0458250331675945 * cart[3 * ncart + i];
-        spherical[8 * nspherical + i] +=  1.5687375497513916 * cart[10 * ncart + i];
-        spherical[8 * nspherical + i] +=  4.1833001326703778 * cart[5 * ncart + i];
+        spherical[8 * nspherical + i] = -0.5229125165837972 * cart[i];
+        spherical[8 * nspherical + i] += 1.0458250331675945 * cart[3 * ncart + i];
+        spherical[8 * nspherical + i] += 1.5687375497513916 * cart[10 * ncart + i];
+        spherical[8 * nspherical + i] += 4.1833001326703778 * cart[5 * ncart + i];
         spherical[8 * nspherical + i] += -12.5499003980111326 * cart[12 * ncart + i];
-
     }
 
     // R_55c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[9 * nspherical + i]  =  2.2185299186623562 * cart[2 * ncart + i];
+        spherical[9 * nspherical + i] = 2.2185299186623562 * cart[2 * ncart + i];
         spherical[9 * nspherical + i] += -13.3111795119741370 * cart[7 * ncart + i];
-        spherical[9 * nspherical + i] +=  2.2185299186623562 * cart[16 * ncart + i];
-
+        spherical[9 * nspherical + i] += 2.2185299186623562 * cart[16 * ncart + i];
     }
     // R_55s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[10 * nspherical + i]  =  0.7015607600201140 * cart[i];
+        spherical[10 * nspherical + i] = 0.7015607600201140 * cart[i];
         spherical[10 * nspherical + i] += -7.0156076002011405 * cart[3 * ncart + i];
-        spherical[10 * nspherical + i] +=  3.5078038001005702 * cart[10 * ncart + i];
-
+        spherical[10 * nspherical + i] += 3.5078038001005702 * cart[10 * ncart + i];
     }
-
 }
-void gg_cca_cart_to_spherical_sum_L5(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
+void gg_cca_cart_to_spherical_sum_L5(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_50 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  3.5078038001005702 * cart[ncart + i];
+        tmp = 3.5078038001005702 * cart[ncart + i];
         tmp += -7.0156076002011405 * cart[6 * ncart + i];
-        tmp +=  0.7015607600201140 * cart[15 * ncart + i];
+        tmp += 0.7015607600201140 * cart[15 * ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
     // R_51c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  8.8741196746494246 * cart[4 * ncart + i];
+        tmp = 8.8741196746494246 * cart[4 * ncart + i];
         tmp += -8.8741196746494246 * cart[11 * ncart + i];
         output[i] += tmp * vector[1];
-
     }
     // R_51s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -1.5687375497513916 * cart[ncart + i];
+        tmp = -1.5687375497513916 * cart[ncart + i];
         tmp += -1.0458250331675945 * cart[6 * ncart + i];
-        tmp +=  0.5229125165837972 * cart[15 * ncart + i];
-        tmp +=  12.5499003980111326 * cart[8 * ncart + i];
+        tmp += 0.5229125165837972 * cart[15 * ncart + i];
+        tmp += 12.5499003980111326 * cart[8 * ncart + i];
         tmp += -4.1833001326703778 * cart[17 * ncart + i];
         output[i] += tmp * vector[2];
-
     }
 
     // R_52c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -5.1234753829797990 * cart[4 * ncart + i];
+        tmp = -5.1234753829797990 * cart[4 * ncart + i];
         tmp += -5.1234753829797990 * cart[11 * ncart + i];
-        tmp +=  10.2469507659595980 * cart[13 * ncart + i];
+        tmp += 10.2469507659595980 * cart[13 * ncart + i];
         output[i] += tmp * vector[3];
-
     }
     // R_52s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.4841229182759271 * cart[ncart + i];
-        tmp +=  0.9682458365518543 * cart[6 * ncart + i];
-        tmp +=  0.4841229182759271 * cart[15 * ncart + i];
+        tmp = 0.4841229182759271 * cart[ncart + i];
+        tmp += 0.9682458365518543 * cart[6 * ncart + i];
+        tmp += 0.4841229182759271 * cart[15 * ncart + i];
         tmp += -5.8094750193111251 * cart[8 * ncart + i];
         tmp += -5.8094750193111251 * cart[17 * ncart + i];
-        tmp +=  3.8729833462074170 * cart[19 * ncart + i];
+        tmp += 3.8729833462074170 * cart[19 * ncart + i];
         output[i] += tmp * vector[4];
-
     }
 
     // R_53c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  1.8750000000000000 * cart[2 * ncart + i];
-        tmp +=  3.7500000000000000 * cart[7 * ncart + i];
-        tmp +=  1.8750000000000000 * cart[16 * ncart + i];
+        tmp = 1.8750000000000000 * cart[2 * ncart + i];
+        tmp += 3.7500000000000000 * cart[7 * ncart + i];
+        tmp += 1.8750000000000000 * cart[16 * ncart + i];
         tmp += -5.0000000000000000 * cart[9 * ncart + i];
         tmp += -5.0000000000000000 * cart[18 * ncart + i];
         tmp += cart[20 * ncart + i];
         output[i] += tmp * vector[5];
-
     }
     // R_53s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.4841229182759271 * cart[i];
-        tmp +=  0.9682458365518543 * cart[3 * ncart + i];
-        tmp +=  0.4841229182759271 * cart[10 * ncart + i];
+        tmp = 0.4841229182759271 * cart[i];
+        tmp += 0.9682458365518543 * cart[3 * ncart + i];
+        tmp += 0.4841229182759271 * cart[10 * ncart + i];
         tmp += -5.8094750193111251 * cart[5 * ncart + i];
         tmp += -5.8094750193111251 * cart[12 * ncart + i];
-        tmp +=  3.8729833462074170 * cart[14 * ncart + i];
+        tmp += 3.8729833462074170 * cart[14 * ncart + i];
         output[i] += tmp * vector[6];
-
     }
 
     // R_54c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -2.5617376914898995 * cart[2 * ncart + i];
-        tmp +=  2.5617376914898995 * cart[16 * ncart + i];
-        tmp +=  5.1234753829797990 * cart[9 * ncart + i];
+        tmp = -2.5617376914898995 * cart[2 * ncart + i];
+        tmp += 2.5617376914898995 * cart[16 * ncart + i];
+        tmp += 5.1234753829797990 * cart[9 * ncart + i];
         tmp += -5.1234753829797990 * cart[18 * ncart + i];
         output[i] += tmp * vector[7];
-
     }
     // R_54s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.5229125165837972 * cart[i];
-        tmp +=  1.0458250331675945 * cart[3 * ncart + i];
-        tmp +=  1.5687375497513916 * cart[10 * ncart + i];
-        tmp +=  4.1833001326703778 * cart[5 * ncart + i];
+        tmp = -0.5229125165837972 * cart[i];
+        tmp += 1.0458250331675945 * cart[3 * ncart + i];
+        tmp += 1.5687375497513916 * cart[10 * ncart + i];
+        tmp += 4.1833001326703778 * cart[5 * ncart + i];
         tmp += -12.5499003980111326 * cart[12 * ncart + i];
         output[i] += tmp * vector[8];
-
     }
 
     // R_55c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.2185299186623562 * cart[2 * ncart + i];
+        tmp = 2.2185299186623562 * cart[2 * ncart + i];
         tmp += -13.3111795119741370 * cart[7 * ncart + i];
-        tmp +=  2.2185299186623562 * cart[16 * ncart + i];
+        tmp += 2.2185299186623562 * cart[16 * ncart + i];
         output[i] += tmp * vector[9];
-
     }
     // R_55s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.7015607600201140 * cart[i];
+        tmp = 0.7015607600201140 * cart[i];
         tmp += -7.0156076002011405 * cart[3 * ncart + i];
-        tmp +=  3.5078038001005702 * cart[10 * ncart + i];
+        tmp += 3.5078038001005702 * cart[10 * ncart + i];
         output[i] += tmp * vector[10];
-
     }
-
 }
-void gg_cca_cart_to_spherical_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
+void gg_cca_cart_to_spherical_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_60 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  =  4.0301597362883772 * cart[ncart + i];
+        spherical[i] = 4.0301597362883772 * cart[ncart + i];
         spherical[i] += -13.4338657876279228 * cart[6 * ncart + i];
-        spherical[i] +=  4.0301597362883772 * cart[15 * ncart + i];
-
+        spherical[i] += 4.0301597362883772 * cart[15 * ncart + i];
     }
 
     // R_61c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  =  11.6340690431164280 * cart[4 * ncart + i];
+        spherical[nspherical + i] = 11.6340690431164280 * cart[4 * ncart + i];
         spherical[nspherical + i] += -23.2681380862328560 * cart[11 * ncart + i];
-        spherical[nspherical + i] +=  2.3268138086232857 * cart[22 * ncart + i];
-
+        spherical[nspherical + i] += 2.3268138086232857 * cart[22 * ncart + i];
     }
     // R_61s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  = -1.9843134832984430 * cart[ncart + i];
-        spherical[2 * nspherical + i] +=  1.9843134832984430 * cart[15 * ncart + i];
-        spherical[2 * nspherical + i] +=  19.8431348329844290 * cart[8 * ncart + i];
+        spherical[2 * nspherical + i] = -1.9843134832984430 * cart[ncart + i];
+        spherical[2 * nspherical + i] += 1.9843134832984430 * cart[15 * ncart + i];
+        spherical[2 * nspherical + i] += 19.8431348329844290 * cart[8 * ncart + i];
         spherical[2 * nspherical + i] += -19.8431348329844290 * cart[17 * ncart + i];
-
     }
 
     // R_62c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[3 * nspherical + i]  = -8.1513994197315593 * cart[4 * ncart + i];
+        spherical[3 * nspherical + i] = -8.1513994197315593 * cart[4 * ncart + i];
         spherical[3 * nspherical + i] += -5.4342662798210393 * cart[11 * ncart + i];
-        spherical[3 * nspherical + i] +=  2.7171331399105196 * cart[22 * ncart + i];
-        spherical[3 * nspherical + i] +=  21.7370651192841571 * cart[13 * ncart + i];
+        spherical[3 * nspherical + i] += 2.7171331399105196 * cart[22 * ncart + i];
+        spherical[3 * nspherical + i] += 21.7370651192841571 * cart[13 * ncart + i];
         spherical[3 * nspherical + i] += -7.2456883730947190 * cart[24 * ncart + i];
-
     }
     // R_62s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[4 * nspherical + i]  =  0.9057110466368399 * cart[ncart + i];
-        spherical[4 * nspherical + i] +=  1.8114220932736798 * cart[6 * ncart + i];
-        spherical[4 * nspherical + i] +=  0.9057110466368399 * cart[15 * ncart + i];
+        spherical[4 * nspherical + i] = 0.9057110466368399 * cart[ncart + i];
+        spherical[4 * nspherical + i] += 1.8114220932736798 * cart[6 * ncart + i];
+        spherical[4 * nspherical + i] += 0.9057110466368399 * cart[15 * ncart + i];
         spherical[4 * nspherical + i] += -14.4913767461894381 * cart[8 * ncart + i];
         spherical[4 * nspherical + i] += -14.4913767461894381 * cart[17 * ncart + i];
-        spherical[4 * nspherical + i] +=  14.4913767461894381 * cart[19 * ncart + i];
-
+        spherical[4 * nspherical + i] += 14.4913767461894381 * cart[19 * ncart + i];
     }
 
     // R_63c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[5 * nspherical + i]  =  2.8641098093473998 * cart[4 * ncart + i];
-        spherical[5 * nspherical + i] +=  5.7282196186947996 * cart[11 * ncart + i];
-        spherical[5 * nspherical + i] +=  2.8641098093473998 * cart[22 * ncart + i];
+        spherical[5 * nspherical + i] = 2.8641098093473998 * cart[4 * ncart + i];
+        spherical[5 * nspherical + i] += 5.7282196186947996 * cart[11 * ncart + i];
+        spherical[5 * nspherical + i] += 2.8641098093473998 * cart[22 * ncart + i];
         spherical[5 * nspherical + i] += -11.4564392373895991 * cart[13 * ncart + i];
         spherical[5 * nspherical + i] += -11.4564392373895991 * cart[24 * ncart + i];
-        spherical[5 * nspherical + i] +=  4.5825756949558398 * cart[26 * ncart + i];
-
+        spherical[5 * nspherical + i] += 4.5825756949558398 * cart[26 * ncart + i];
     }
     // R_63s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[6 * nspherical + i]  = -0.3125000000000000 * cart[i];
+        spherical[6 * nspherical + i] = -0.3125000000000000 * cart[i];
         spherical[6 * nspherical + i] += -0.9375000000000000 * cart[3 * ncart + i];
         spherical[6 * nspherical + i] += -0.9375000000000000 * cart[10 * ncart + i];
         spherical[6 * nspherical + i] += -0.3125000000000000 * cart[21 * ncart + i];
-        spherical[6 * nspherical + i] +=  5.6250000000000000 * cart[5 * ncart + i];
-        spherical[6 * nspherical + i] +=  11.2500000000000000 * cart[12 * ncart + i];
-        spherical[6 * nspherical + i] +=  5.6250000000000000 * cart[23 * ncart + i];
+        spherical[6 * nspherical + i] += 5.6250000000000000 * cart[5 * ncart + i];
+        spherical[6 * nspherical + i] += 11.2500000000000000 * cart[12 * ncart + i];
+        spherical[6 * nspherical + i] += 5.6250000000000000 * cart[23 * ncart + i];
         spherical[6 * nspherical + i] += -7.5000000000000000 * cart[14 * ncart + i];
         spherical[6 * nspherical + i] += -7.5000000000000000 * cart[25 * ncart + i];
         spherical[6 * nspherical + i] += cart[27 * ncart + i];
-
     }
 
     // R_64c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[7 * nspherical + i]  =  2.8641098093473998 * cart[2 * ncart + i];
-        spherical[7 * nspherical + i] +=  5.7282196186947996 * cart[7 * ncart + i];
-        spherical[7 * nspherical + i] +=  2.8641098093473998 * cart[16 * ncart + i];
+        spherical[7 * nspherical + i] = 2.8641098093473998 * cart[2 * ncart + i];
+        spherical[7 * nspherical + i] += 5.7282196186947996 * cart[7 * ncart + i];
+        spherical[7 * nspherical + i] += 2.8641098093473998 * cart[16 * ncart + i];
         spherical[7 * nspherical + i] += -11.4564392373895991 * cart[9 * ncart + i];
         spherical[7 * nspherical + i] += -11.4564392373895991 * cart[18 * ncart + i];
-        spherical[7 * nspherical + i] +=  4.5825756949558398 * cart[20 * ncart + i];
-
+        spherical[7 * nspherical + i] += 4.5825756949558398 * cart[20 * ncart + i];
     }
     // R_64s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[8 * nspherical + i]  =  0.4528555233184199 * cart[i];
-        spherical[8 * nspherical + i] +=  0.4528555233184199 * cart[3 * ncart + i];
+        spherical[8 * nspherical + i] = 0.4528555233184199 * cart[i];
+        spherical[8 * nspherical + i] += 0.4528555233184199 * cart[3 * ncart + i];
         spherical[8 * nspherical + i] += -0.4528555233184199 * cart[10 * ncart + i];
         spherical[8 * nspherical + i] += -0.4528555233184199 * cart[21 * ncart + i];
         spherical[8 * nspherical + i] += -7.2456883730947190 * cart[5 * ncart + i];
-        spherical[8 * nspherical + i] +=  7.2456883730947190 * cart[23 * ncart + i];
-        spherical[8 * nspherical + i] +=  7.2456883730947190 * cart[14 * ncart + i];
+        spherical[8 * nspherical + i] += 7.2456883730947190 * cart[23 * ncart + i];
+        spherical[8 * nspherical + i] += 7.2456883730947190 * cart[14 * ncart + i];
         spherical[8 * nspherical + i] += -7.2456883730947190 * cart[25 * ncart + i];
-
     }
 
     // R_65c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[9 * nspherical + i]  = -2.7171331399105196 * cart[2 * ncart + i];
-        spherical[9 * nspherical + i] +=  5.4342662798210393 * cart[7 * ncart + i];
-        spherical[9 * nspherical + i] +=  8.1513994197315593 * cart[16 * ncart + i];
-        spherical[9 * nspherical + i] +=  7.2456883730947190 * cart[9 * ncart + i];
+        spherical[9 * nspherical + i] = -2.7171331399105196 * cart[2 * ncart + i];
+        spherical[9 * nspherical + i] += 5.4342662798210393 * cart[7 * ncart + i];
+        spherical[9 * nspherical + i] += 8.1513994197315593 * cart[16 * ncart + i];
+        spherical[9 * nspherical + i] += 7.2456883730947190 * cart[9 * ncart + i];
         spherical[9 * nspherical + i] += -21.7370651192841571 * cart[18 * ncart + i];
-
     }
     // R_65s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[10 * nspherical + i]  = -0.4960783708246108 * cart[i];
-        spherical[10 * nspherical + i] +=  2.4803918541230536 * cart[3 * ncart + i];
-        spherical[10 * nspherical + i] +=  2.4803918541230536 * cart[10 * ncart + i];
+        spherical[10 * nspherical + i] = -0.4960783708246108 * cart[i];
+        spherical[10 * nspherical + i] += 2.4803918541230536 * cart[3 * ncart + i];
+        spherical[10 * nspherical + i] += 2.4803918541230536 * cart[10 * ncart + i];
         spherical[10 * nspherical + i] += -0.4960783708246108 * cart[21 * ncart + i];
-        spherical[10 * nspherical + i] +=  4.9607837082461073 * cart[5 * ncart + i];
+        spherical[10 * nspherical + i] += 4.9607837082461073 * cart[5 * ncart + i];
         spherical[10 * nspherical + i] += -29.7647022494766453 * cart[12 * ncart + i];
-        spherical[10 * nspherical + i] +=  4.9607837082461073 * cart[23 * ncart + i];
-
+        spherical[10 * nspherical + i] += 4.9607837082461073 * cart[23 * ncart + i];
     }
 
     // R_66c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[11 * nspherical + i]  =  2.3268138086232857 * cart[2 * ncart + i];
+        spherical[11 * nspherical + i] = 2.3268138086232857 * cart[2 * ncart + i];
         spherical[11 * nspherical + i] += -23.2681380862328560 * cart[7 * ncart + i];
-        spherical[11 * nspherical + i] +=  11.6340690431164280 * cart[16 * ncart + i];
-
+        spherical[11 * nspherical + i] += 11.6340690431164280 * cart[16 * ncart + i];
     }
     // R_66s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[12 * nspherical + i]  =  0.6716932893813962 * cart[i];
+        spherical[12 * nspherical + i] = 0.6716932893813962 * cart[i];
         spherical[12 * nspherical + i] += -10.0753993407209421 * cart[3 * ncart + i];
-        spherical[12 * nspherical + i] +=  10.0753993407209421 * cart[10 * ncart + i];
+        spherical[12 * nspherical + i] += 10.0753993407209421 * cart[10 * ncart + i];
         spherical[12 * nspherical + i] += -0.6716932893813962 * cart[21 * ncart + i];
-
     }
-
 }
-void gg_cca_cart_to_spherical_sum_L6(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
+void gg_cca_cart_to_spherical_sum_L6(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_60 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  4.0301597362883772 * cart[ncart + i];
+        tmp = 4.0301597362883772 * cart[ncart + i];
         tmp += -13.4338657876279228 * cart[6 * ncart + i];
-        tmp +=  4.0301597362883772 * cart[15 * ncart + i];
+        tmp += 4.0301597362883772 * cart[15 * ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
     // R_61c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  11.6340690431164280 * cart[4 * ncart + i];
+        tmp = 11.6340690431164280 * cart[4 * ncart + i];
         tmp += -23.2681380862328560 * cart[11 * ncart + i];
-        tmp +=  2.3268138086232857 * cart[22 * ncart + i];
+        tmp += 2.3268138086232857 * cart[22 * ncart + i];
         output[i] += tmp * vector[1];
-
     }
     // R_61s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -1.9843134832984430 * cart[ncart + i];
-        tmp +=  1.9843134832984430 * cart[15 * ncart + i];
-        tmp +=  19.8431348329844290 * cart[8 * ncart + i];
+        tmp = -1.9843134832984430 * cart[ncart + i];
+        tmp += 1.9843134832984430 * cart[15 * ncart + i];
+        tmp += 19.8431348329844290 * cart[8 * ncart + i];
         tmp += -19.8431348329844290 * cart[17 * ncart + i];
         output[i] += tmp * vector[2];
-
     }
 
     // R_62c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -8.1513994197315593 * cart[4 * ncart + i];
+        tmp = -8.1513994197315593 * cart[4 * ncart + i];
         tmp += -5.4342662798210393 * cart[11 * ncart + i];
-        tmp +=  2.7171331399105196 * cart[22 * ncart + i];
-        tmp +=  21.7370651192841571 * cart[13 * ncart + i];
+        tmp += 2.7171331399105196 * cart[22 * ncart + i];
+        tmp += 21.7370651192841571 * cart[13 * ncart + i];
         tmp += -7.2456883730947190 * cart[24 * ncart + i];
         output[i] += tmp * vector[3];
-
     }
     // R_62s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.9057110466368399 * cart[ncart + i];
-        tmp +=  1.8114220932736798 * cart[6 * ncart + i];
-        tmp +=  0.9057110466368399 * cart[15 * ncart + i];
+        tmp = 0.9057110466368399 * cart[ncart + i];
+        tmp += 1.8114220932736798 * cart[6 * ncart + i];
+        tmp += 0.9057110466368399 * cart[15 * ncart + i];
         tmp += -14.4913767461894381 * cart[8 * ncart + i];
         tmp += -14.4913767461894381 * cart[17 * ncart + i];
-        tmp +=  14.4913767461894381 * cart[19 * ncart + i];
+        tmp += 14.4913767461894381 * cart[19 * ncart + i];
         output[i] += tmp * vector[4];
-
     }
 
     // R_63c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.8641098093473998 * cart[4 * ncart + i];
-        tmp +=  5.7282196186947996 * cart[11 * ncart + i];
-        tmp +=  2.8641098093473998 * cart[22 * ncart + i];
+        tmp = 2.8641098093473998 * cart[4 * ncart + i];
+        tmp += 5.7282196186947996 * cart[11 * ncart + i];
+        tmp += 2.8641098093473998 * cart[22 * ncart + i];
         tmp += -11.4564392373895991 * cart[13 * ncart + i];
         tmp += -11.4564392373895991 * cart[24 * ncart + i];
-        tmp +=  4.5825756949558398 * cart[26 * ncart + i];
+        tmp += 4.5825756949558398 * cart[26 * ncart + i];
         output[i] += tmp * vector[5];
-
     }
     // R_63s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.3125000000000000 * cart[i];
+        tmp = -0.3125000000000000 * cart[i];
         tmp += -0.9375000000000000 * cart[3 * ncart + i];
         tmp += -0.9375000000000000 * cart[10 * ncart + i];
         tmp += -0.3125000000000000 * cart[21 * ncart + i];
-        tmp +=  5.6250000000000000 * cart[5 * ncart + i];
-        tmp +=  11.2500000000000000 * cart[12 * ncart + i];
-        tmp +=  5.6250000000000000 * cart[23 * ncart + i];
+        tmp += 5.6250000000000000 * cart[5 * ncart + i];
+        tmp += 11.2500000000000000 * cart[12 * ncart + i];
+        tmp += 5.6250000000000000 * cart[23 * ncart + i];
         tmp += -7.5000000000000000 * cart[14 * ncart + i];
         tmp += -7.5000000000000000 * cart[25 * ncart + i];
         tmp += cart[27 * ncart + i];
         output[i] += tmp * vector[6];
-
     }
 
     // R_64c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.8641098093473998 * cart[2 * ncart + i];
-        tmp +=  5.7282196186947996 * cart[7 * ncart + i];
-        tmp +=  2.8641098093473998 * cart[16 * ncart + i];
+        tmp = 2.8641098093473998 * cart[2 * ncart + i];
+        tmp += 5.7282196186947996 * cart[7 * ncart + i];
+        tmp += 2.8641098093473998 * cart[16 * ncart + i];
         tmp += -11.4564392373895991 * cart[9 * ncart + i];
         tmp += -11.4564392373895991 * cart[18 * ncart + i];
-        tmp +=  4.5825756949558398 * cart[20 * ncart + i];
+        tmp += 4.5825756949558398 * cart[20 * ncart + i];
         output[i] += tmp * vector[7];
-
     }
     // R_64s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.4528555233184199 * cart[i];
-        tmp +=  0.4528555233184199 * cart[3 * ncart + i];
+        tmp = 0.4528555233184199 * cart[i];
+        tmp += 0.4528555233184199 * cart[3 * ncart + i];
         tmp += -0.4528555233184199 * cart[10 * ncart + i];
         tmp += -0.4528555233184199 * cart[21 * ncart + i];
         tmp += -7.2456883730947190 * cart[5 * ncart + i];
-        tmp +=  7.2456883730947190 * cart[23 * ncart + i];
-        tmp +=  7.2456883730947190 * cart[14 * ncart + i];
+        tmp += 7.2456883730947190 * cart[23 * ncart + i];
+        tmp += 7.2456883730947190 * cart[14 * ncart + i];
         tmp += -7.2456883730947190 * cart[25 * ncart + i];
         output[i] += tmp * vector[8];
-
     }
 
     // R_65c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -2.7171331399105196 * cart[2 * ncart + i];
-        tmp +=  5.4342662798210393 * cart[7 * ncart + i];
-        tmp +=  8.1513994197315593 * cart[16 * ncart + i];
-        tmp +=  7.2456883730947190 * cart[9 * ncart + i];
+        tmp = -2.7171331399105196 * cart[2 * ncart + i];
+        tmp += 5.4342662798210393 * cart[7 * ncart + i];
+        tmp += 8.1513994197315593 * cart[16 * ncart + i];
+        tmp += 7.2456883730947190 * cart[9 * ncart + i];
         tmp += -21.7370651192841571 * cart[18 * ncart + i];
         output[i] += tmp * vector[9];
-
     }
     // R_65s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.4960783708246108 * cart[i];
-        tmp +=  2.4803918541230536 * cart[3 * ncart + i];
-        tmp +=  2.4803918541230536 * cart[10 * ncart + i];
+        tmp = -0.4960783708246108 * cart[i];
+        tmp += 2.4803918541230536 * cart[3 * ncart + i];
+        tmp += 2.4803918541230536 * cart[10 * ncart + i];
         tmp += -0.4960783708246108 * cart[21 * ncart + i];
-        tmp +=  4.9607837082461073 * cart[5 * ncart + i];
+        tmp += 4.9607837082461073 * cart[5 * ncart + i];
         tmp += -29.7647022494766453 * cart[12 * ncart + i];
-        tmp +=  4.9607837082461073 * cart[23 * ncart + i];
+        tmp += 4.9607837082461073 * cart[23 * ncart + i];
         output[i] += tmp * vector[10];
-
     }
 
     // R_66c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.3268138086232857 * cart[2 * ncart + i];
+        tmp = 2.3268138086232857 * cart[2 * ncart + i];
         tmp += -23.2681380862328560 * cart[7 * ncart + i];
-        tmp +=  11.6340690431164280 * cart[16 * ncart + i];
+        tmp += 11.6340690431164280 * cart[16 * ncart + i];
         output[i] += tmp * vector[11];
-
     }
     // R_66s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.6716932893813962 * cart[i];
+        tmp = 0.6716932893813962 * cart[i];
         tmp += -10.0753993407209421 * cart[3 * ncart + i];
-        tmp +=  10.0753993407209421 * cart[10 * ncart + i];
+        tmp += 10.0753993407209421 * cart[10 * ncart + i];
         tmp += -0.6716932893813962 * cart[21 * ncart + i];
         output[i] += tmp * vector[12];
-
     }
-
 }
-void gg_gaussian_cart_to_spherical_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
-    (void)ncart;
-    (void)nspherical;
+void gg_cca_cart_to_spherical_L7(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
-    // R_00 Transform
+    // R_70 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  = cart[i];
-
+        spherical[i] = 4.5308189450142455 * cart[ncart + i];
+        spherical[i] += -22.6540947250712286 * cart[6 * ncart + i];
+        spherical[i] += 13.5924568350427357 * cart[15 * ncart + i];
+        spherical[i] += -0.6472598492877494 * cart[28 * ncart + i];
     }
 
+    // R_71c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[nspherical + i] = 14.5309475774981713 * cart[4 * ncart + i];
+        spherical[nspherical + i] += -48.4364919249939092 * cart[11 * ncart + i];
+        spherical[nspherical + i] += 14.5309475774981713 * cart[22 * ncart + i];
+    }
+    // R_71s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[2 * nspherical + i] = -2.3747943989954163 * cart[ncart + i];
+        spherical[2 * nspherical + i] += 2.3747943989954163 * cart[6 * ncart + i];
+        spherical[2 * nspherical + i] += 4.2746299181917493 * cart[15 * ncart + i];
+        spherical[2 * nspherical + i] += -0.4749588797990832 * cart[28 * ncart + i];
+        spherical[2 * nspherical + i] += 28.4975327879449942 * cart[8 * ncart + i];
+        spherical[2 * nspherical + i] += -56.9950655758899885 * cart[17 * ncart + i];
+        spherical[2 * nspherical + i] += 5.6995065575889985 * cart[30 * ncart + i];
+    }
+
+    // R_72c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[3 * nspherical + i] = -11.3990131151779970 * cart[4 * ncart + i];
+        spherical[3 * nspherical + i] += 11.3990131151779970 * cart[22 * ncart + i];
+        spherical[3 * nspherical + i] += 37.9967103839266613 * cart[13 * ncart + i];
+        spherical[3 * nspherical + i] += -37.9967103839266613 * cart[24 * ncart + i];
+    }
+    // R_72s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[4 * nspherical + i] = 1.2888494142063300 * cart[ncart + i];
+        spherical[4 * nspherical + i] += 2.1480823570105501 * cart[6 * ncart + i];
+        spherical[4 * nspherical + i] += 0.4296164714021100 * cart[15 * ncart + i];
+        spherical[4 * nspherical + i] += -0.4296164714021100 * cart[28 * ncart + i];
+        spherical[4 * nspherical + i] += -25.7769882841265989 * cart[8 * ncart + i];
+        spherical[4 * nspherical + i] += -17.1846588560844005 * cart[17 * ncart + i];
+        spherical[4 * nspherical + i] += 8.5923294280422002 * cart[30 * ncart + i];
+        spherical[4 * nspherical + i] += 34.3693177121688009 * cart[19 * ncart + i];
+        spherical[4 * nspherical + i] += -11.4564392373895991 * cart[32 * ncart + i];
+    }
+
+    // R_73c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[5 * nspherical + i] = 6.0756944047573693 * cart[4 * ncart + i];
+        spherical[5 * nspherical + i] += 12.1513888095147387 * cart[11 * ncart + i];
+        spherical[5 * nspherical + i] += 6.0756944047573693 * cart[22 * ncart + i];
+        spherical[5 * nspherical + i] += -32.4037034920392983 * cart[13 * ncart + i];
+        spherical[5 * nspherical + i] += -32.4037034920392983 * cart[24 * ncart + i];
+        spherical[5 * nspherical + i] += 19.4422220952235811 * cart[26 * ncart + i];
+    }
+    // R_73s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[6 * nspherical + i] = -0.4133986423538423 * cart[ncart + i];
+        spherical[6 * nspherical + i] += -1.2401959270615268 * cart[6 * ncart + i];
+        spherical[6 * nspherical + i] += -1.2401959270615268 * cart[15 * ncart + i];
+        spherical[6 * nspherical + i] += -0.4133986423538423 * cart[28 * ncart + i];
+        spherical[6 * nspherical + i] += 9.9215674164922145 * cart[8 * ncart + i];
+        spherical[6 * nspherical + i] += 19.8431348329844290 * cart[17 * ncart + i];
+        spherical[6 * nspherical + i] += 9.9215674164922145 * cart[30 * ncart + i];
+        spherical[6 * nspherical + i] += -19.8431348329844290 * cart[19 * ncart + i];
+        spherical[6 * nspherical + i] += -19.8431348329844290 * cart[32 * ncart + i];
+        spherical[6 * nspherical + i] += 5.2915026221291814 * cart[34 * ncart + i];
+    }
+
+    // R_74c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[7 * nspherical + i] = -2.1875000000000000 * cart[2 * ncart + i];
+        spherical[7 * nspherical + i] += -6.5625000000000000 * cart[7 * ncart + i];
+        spherical[7 * nspherical + i] += -6.5625000000000000 * cart[16 * ncart + i];
+        spherical[7 * nspherical + i] += -2.1875000000000000 * cart[29 * ncart + i];
+        spherical[7 * nspherical + i] += 13.1250000000000000 * cart[9 * ncart + i];
+        spherical[7 * nspherical + i] += 26.2500000000000000 * cart[18 * ncart + i];
+        spherical[7 * nspherical + i] += 13.1250000000000000 * cart[31 * ncart + i];
+        spherical[7 * nspherical + i] += -10.5000000000000000 * cart[20 * ncart + i];
+        spherical[7 * nspherical + i] += -10.5000000000000000 * cart[33 * ncart + i];
+        spherical[7 * nspherical + i] += cart[35 * ncart + i];
+    }
+    // R_74s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[8 * nspherical + i] = -0.4133986423538423 * cart[i];
+        spherical[8 * nspherical + i] += -1.2401959270615268 * cart[3 * ncart + i];
+        spherical[8 * nspherical + i] += -1.2401959270615268 * cart[10 * ncart + i];
+        spherical[8 * nspherical + i] += -0.4133986423538423 * cart[21 * ncart + i];
+        spherical[8 * nspherical + i] += 9.9215674164922145 * cart[5 * ncart + i];
+        spherical[8 * nspherical + i] += 19.8431348329844290 * cart[12 * ncart + i];
+        spherical[8 * nspherical + i] += 9.9215674164922145 * cart[23 * ncart + i];
+        spherical[8 * nspherical + i] += -19.8431348329844290 * cart[14 * ncart + i];
+        spherical[8 * nspherical + i] += -19.8431348329844290 * cart[25 * ncart + i];
+        spherical[8 * nspherical + i] += 5.2915026221291814 * cart[27 * ncart + i];
+    }
+
+    // R_75c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[9 * nspherical + i] = 3.0378472023786847 * cart[2 * ncart + i];
+        spherical[9 * nspherical + i] += 3.0378472023786847 * cart[7 * ncart + i];
+        spherical[9 * nspherical + i] += -3.0378472023786847 * cart[16 * ncart + i];
+        spherical[9 * nspherical + i] += -3.0378472023786847 * cart[29 * ncart + i];
+        spherical[9 * nspherical + i] += -16.2018517460196492 * cart[9 * ncart + i];
+        spherical[9 * nspherical + i] += 16.2018517460196492 * cart[31 * ncart + i];
+        spherical[9 * nspherical + i] += 9.7211110476117906 * cart[20 * ncart + i];
+        spherical[9 * nspherical + i] += -9.7211110476117906 * cart[33 * ncart + i];
+    }
+    // R_75s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[10 * nspherical + i] = 0.4296164714021100 * cart[i];
+        spherical[10 * nspherical + i] += -0.4296164714021100 * cart[3 * ncart + i];
+        spherical[10 * nspherical + i] += -2.1480823570105501 * cart[10 * ncart + i];
+        spherical[10 * nspherical + i] += -1.2888494142063300 * cart[21 * ncart + i];
+        spherical[10 * nspherical + i] += -8.5923294280422002 * cart[5 * ncart + i];
+        spherical[10 * nspherical + i] += 17.1846588560844005 * cart[12 * ncart + i];
+        spherical[10 * nspherical + i] += 25.7769882841265989 * cart[23 * ncart + i];
+        spherical[10 * nspherical + i] += 11.4564392373895991 * cart[14 * ncart + i];
+        spherical[10 * nspherical + i] += -34.3693177121688009 * cart[25 * ncart + i];
+    }
+
+    // R_76c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[11 * nspherical + i] = -2.8497532787944992 * cart[2 * ncart + i];
+        spherical[11 * nspherical + i] += 14.2487663939724971 * cart[7 * ncart + i];
+        spherical[11 * nspherical + i] += 14.2487663939724971 * cart[16 * ncart + i];
+        spherical[11 * nspherical + i] += -2.8497532787944992 * cart[29 * ncart + i];
+        spherical[11 * nspherical + i] += 9.4991775959816653 * cart[9 * ncart + i];
+        spherical[11 * nspherical + i] += -56.9950655758899885 * cart[18 * ncart + i];
+        spherical[11 * nspherical + i] += 9.4991775959816653 * cart[31 * ncart + i];
+    }
+    // R_76s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[12 * nspherical + i] = -0.4749588797990832 * cart[i];
+        spherical[12 * nspherical + i] += 4.2746299181917493 * cart[3 * ncart + i];
+        spherical[12 * nspherical + i] += 2.3747943989954163 * cart[10 * ncart + i];
+        spherical[12 * nspherical + i] += -2.3747943989954163 * cart[21 * ncart + i];
+        spherical[12 * nspherical + i] += 5.6995065575889985 * cart[5 * ncart + i];
+        spherical[12 * nspherical + i] += -56.9950655758899885 * cart[12 * ncart + i];
+        spherical[12 * nspherical + i] += 28.4975327879449942 * cart[23 * ncart + i];
+    }
+
+    // R_77c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[13 * nspherical + i] = 2.4218245962496954 * cart[2 * ncart + i];
+        spherical[13 * nspherical + i] += -36.3273689437454337 * cart[7 * ncart + i];
+        spherical[13 * nspherical + i] += 36.3273689437454337 * cart[16 * ncart + i];
+        spherical[13 * nspherical + i] += -2.4218245962496954 * cart[29 * ncart + i];
+    }
+    // R_77s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[14 * nspherical + i] = 0.6472598492877494 * cart[i];
+        spherical[14 * nspherical + i] += -13.5924568350427357 * cart[3 * ncart + i];
+        spherical[14 * nspherical + i] += 22.6540947250712286 * cart[10 * ncart + i];
+        spherical[14 * nspherical + i] += -4.5308189450142455 * cart[21 * ncart + i];
+    }
 }
-void gg_gaussian_cart_to_spherical_sum_L0(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)ncart;
-    (void)nspherical;
+void gg_cca_cart_to_spherical_sum_L7(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
-    // R_00 Transform
+    // R_70 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = cart[i];
+        tmp = 4.5308189450142455 * cart[ncart + i];
+        tmp += -22.6540947250712286 * cart[6 * ncart + i];
+        tmp += 13.5924568350427357 * cart[15 * ncart + i];
+        tmp += -0.6472598492877494 * cart[28 * ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
-}
-void gg_gaussian_cart_to_spherical_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
-    ASSUME_ALIGNED(cart, 64);
-    // R_10 Transform
+    // R_71c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  = cart[2 * ncart + i];
-
-    }
-
-    // R_11c Transform
-    for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  = cart[i];
-
-    }
-    // R_11s Transform
-    for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  = cart[ncart + i];
-
-    }
-
-}
-void gg_gaussian_cart_to_spherical_sum_L1(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
-    ASSUME_ALIGNED(cart, 64);
-    // temps
-    double tmp;
-    // R_10 Transform
-    for (unsigned long i = 0; i < size; i++) {
-        tmp  = cart[2 * ncart + i];
-        output[i] += tmp * vector[0];
-
-    }
-
-    // R_11c Transform
-    for (unsigned long i = 0; i < size; i++) {
-        tmp  = cart[i];
+        tmp = 14.5309475774981713 * cart[4 * ncart + i];
+        tmp += -48.4364919249939092 * cart[11 * ncart + i];
+        tmp += 14.5309475774981713 * cart[22 * ncart + i];
         output[i] += tmp * vector[1];
+    }
+    // R_71s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -2.3747943989954163 * cart[ncart + i];
+        tmp += 2.3747943989954163 * cart[6 * ncart + i];
+        tmp += 4.2746299181917493 * cart[15 * ncart + i];
+        tmp += -0.4749588797990832 * cart[28 * ncart + i];
+        tmp += 28.4975327879449942 * cart[8 * ncart + i];
+        tmp += -56.9950655758899885 * cart[17 * ncart + i];
+        tmp += 5.6995065575889985 * cart[30 * ncart + i];
+        output[i] += tmp * vector[2];
+    }
 
+    // R_72c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -11.3990131151779970 * cart[4 * ncart + i];
+        tmp += 11.3990131151779970 * cart[22 * ncart + i];
+        tmp += 37.9967103839266613 * cart[13 * ncart + i];
+        tmp += -37.9967103839266613 * cart[24 * ncart + i];
+        output[i] += tmp * vector[3];
+    }
+    // R_72s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 1.2888494142063300 * cart[ncart + i];
+        tmp += 2.1480823570105501 * cart[6 * ncart + i];
+        tmp += 0.4296164714021100 * cart[15 * ncart + i];
+        tmp += -0.4296164714021100 * cart[28 * ncart + i];
+        tmp += -25.7769882841265989 * cart[8 * ncart + i];
+        tmp += -17.1846588560844005 * cart[17 * ncart + i];
+        tmp += 8.5923294280422002 * cart[30 * ncart + i];
+        tmp += 34.3693177121688009 * cart[19 * ncart + i];
+        tmp += -11.4564392373895991 * cart[32 * ncart + i];
+        output[i] += tmp * vector[4];
+    }
+
+    // R_73c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 6.0756944047573693 * cart[4 * ncart + i];
+        tmp += 12.1513888095147387 * cart[11 * ncart + i];
+        tmp += 6.0756944047573693 * cart[22 * ncart + i];
+        tmp += -32.4037034920392983 * cart[13 * ncart + i];
+        tmp += -32.4037034920392983 * cart[24 * ncart + i];
+        tmp += 19.4422220952235811 * cart[26 * ncart + i];
+        output[i] += tmp * vector[5];
+    }
+    // R_73s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.4133986423538423 * cart[ncart + i];
+        tmp += -1.2401959270615268 * cart[6 * ncart + i];
+        tmp += -1.2401959270615268 * cart[15 * ncart + i];
+        tmp += -0.4133986423538423 * cart[28 * ncart + i];
+        tmp += 9.9215674164922145 * cart[8 * ncart + i];
+        tmp += 19.8431348329844290 * cart[17 * ncart + i];
+        tmp += 9.9215674164922145 * cart[30 * ncart + i];
+        tmp += -19.8431348329844290 * cart[19 * ncart + i];
+        tmp += -19.8431348329844290 * cart[32 * ncart + i];
+        tmp += 5.2915026221291814 * cart[34 * ncart + i];
+        output[i] += tmp * vector[6];
+    }
+
+    // R_74c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -2.1875000000000000 * cart[2 * ncart + i];
+        tmp += -6.5625000000000000 * cart[7 * ncart + i];
+        tmp += -6.5625000000000000 * cart[16 * ncart + i];
+        tmp += -2.1875000000000000 * cart[29 * ncart + i];
+        tmp += 13.1250000000000000 * cart[9 * ncart + i];
+        tmp += 26.2500000000000000 * cart[18 * ncart + i];
+        tmp += 13.1250000000000000 * cart[31 * ncart + i];
+        tmp += -10.5000000000000000 * cart[20 * ncart + i];
+        tmp += -10.5000000000000000 * cart[33 * ncart + i];
+        tmp += cart[35 * ncart + i];
+        output[i] += tmp * vector[7];
+    }
+    // R_74s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.4133986423538423 * cart[i];
+        tmp += -1.2401959270615268 * cart[3 * ncart + i];
+        tmp += -1.2401959270615268 * cart[10 * ncart + i];
+        tmp += -0.4133986423538423 * cart[21 * ncart + i];
+        tmp += 9.9215674164922145 * cart[5 * ncart + i];
+        tmp += 19.8431348329844290 * cart[12 * ncart + i];
+        tmp += 9.9215674164922145 * cart[23 * ncart + i];
+        tmp += -19.8431348329844290 * cart[14 * ncart + i];
+        tmp += -19.8431348329844290 * cart[25 * ncart + i];
+        tmp += 5.2915026221291814 * cart[27 * ncart + i];
+        output[i] += tmp * vector[8];
+    }
+
+    // R_75c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 3.0378472023786847 * cart[2 * ncart + i];
+        tmp += 3.0378472023786847 * cart[7 * ncart + i];
+        tmp += -3.0378472023786847 * cart[16 * ncart + i];
+        tmp += -3.0378472023786847 * cart[29 * ncart + i];
+        tmp += -16.2018517460196492 * cart[9 * ncart + i];
+        tmp += 16.2018517460196492 * cart[31 * ncart + i];
+        tmp += 9.7211110476117906 * cart[20 * ncart + i];
+        tmp += -9.7211110476117906 * cart[33 * ncart + i];
+        output[i] += tmp * vector[9];
+    }
+    // R_75s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 0.4296164714021100 * cart[i];
+        tmp += -0.4296164714021100 * cart[3 * ncart + i];
+        tmp += -2.1480823570105501 * cart[10 * ncart + i];
+        tmp += -1.2888494142063300 * cart[21 * ncart + i];
+        tmp += -8.5923294280422002 * cart[5 * ncart + i];
+        tmp += 17.1846588560844005 * cart[12 * ncart + i];
+        tmp += 25.7769882841265989 * cart[23 * ncart + i];
+        tmp += 11.4564392373895991 * cart[14 * ncart + i];
+        tmp += -34.3693177121688009 * cart[25 * ncart + i];
+        output[i] += tmp * vector[10];
+    }
+
+    // R_76c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -2.8497532787944992 * cart[2 * ncart + i];
+        tmp += 14.2487663939724971 * cart[7 * ncart + i];
+        tmp += 14.2487663939724971 * cart[16 * ncart + i];
+        tmp += -2.8497532787944992 * cart[29 * ncart + i];
+        tmp += 9.4991775959816653 * cart[9 * ncart + i];
+        tmp += -56.9950655758899885 * cart[18 * ncart + i];
+        tmp += 9.4991775959816653 * cart[31 * ncart + i];
+        output[i] += tmp * vector[11];
+    }
+    // R_76s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.4749588797990832 * cart[i];
+        tmp += 4.2746299181917493 * cart[3 * ncart + i];
+        tmp += 2.3747943989954163 * cart[10 * ncart + i];
+        tmp += -2.3747943989954163 * cart[21 * ncart + i];
+        tmp += 5.6995065575889985 * cart[5 * ncart + i];
+        tmp += -56.9950655758899885 * cart[12 * ncart + i];
+        tmp += 28.4975327879449942 * cart[23 * ncart + i];
+        output[i] += tmp * vector[12];
+    }
+
+    // R_77c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 2.4218245962496954 * cart[2 * ncart + i];
+        tmp += -36.3273689437454337 * cart[7 * ncart + i];
+        tmp += 36.3273689437454337 * cart[16 * ncart + i];
+        tmp += -2.4218245962496954 * cart[29 * ncart + i];
+        output[i] += tmp * vector[13];
+    }
+    // R_77s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 0.6472598492877494 * cart[i];
+        tmp += -13.5924568350427357 * cart[3 * ncart + i];
+        tmp += 22.6540947250712286 * cart[10 * ncart + i];
+        tmp += -4.5308189450142455 * cart[21 * ncart + i];
+        output[i] += tmp * vector[14];
+    }
+}
+void gg_cca_cart_to_spherical_L8(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                 const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                 const unsigned long nspherical) {
+    ASSUME_ALIGNED(cart, 64);
+    // R_80 Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[i] = 5.0136532339203512 * cart[ncart + i];
+        spherical[i] += -35.0955726374424586 * cart[6 * ncart + i];
+        spherical[i] += 35.0955726374424586 * cart[15 * ncart + i];
+        spherical[i] += -5.0136532339203512 * cart[28 * ncart + i];
+    }
+
+    // R_81c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[nspherical + i] = 17.5477863187212293 * cart[4 * ncart + i];
+        spherical[nspherical + i] += -87.7389315936061536 * cart[11 * ncart + i];
+        spherical[nspherical + i] += 52.6433589561636950 * cart[22 * ncart + i];
+        spherical[nspherical + i] += -2.5068266169601756 * cart[37 * ncart + i];
+    }
+    // R_81s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[2 * nspherical + i] = -2.7460909717269018 * cart[ncart + i];
+        spherical[2 * nspherical + i] += 6.4075456006961042 * cart[6 * ncart + i];
+        spherical[2 * nspherical + i] += 6.4075456006961042 * cart[15 * ncart + i];
+        spherical[2 * nspherical + i] += -2.7460909717269018 * cart[28 * ncart + i];
+        spherical[2 * nspherical + i] += 38.4452736041766272 * cart[8 * ncart + i];
+        spherical[2 * nspherical + i] += -128.1509120139220954 * cart[17 * ncart + i];
+        spherical[2 * nspherical + i] += 38.4452736041766272 * cart[30 * ncart + i];
+    }
+
+    // R_82c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[3 * nspherical + i] = -14.8305862683341019 * cart[4 * ncart + i];
+        spherical[3 * nspherical + i] += 14.8305862683341019 * cart[11 * ncart + i];
+        spherical[3 * nspherical + i] += 26.6950552830013805 * cart[22 * ncart + i];
+        spherical[3 * nspherical + i] += -2.9661172536668201 * cart[37 * ncart + i];
+        spherical[3 * nspherical + i] += 59.3223450733364075 * cart[13 * ncart + i];
+        spherical[3 * nspherical + i] += -118.6446901466728150 * cart[24 * ncart + i];
+        spherical[3 * nspherical + i] += 11.8644690146672804 * cart[39 * ncart + i];
+    }
+    // R_82s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[4 * nspherical + i] = 1.6453058226360229 * cart[ncart + i];
+        spherical[4 * nspherical + i] += 1.6453058226360229 * cart[6 * ncart + i];
+        spherical[4 * nspherical + i] += -1.6453058226360229 * cart[15 * ncart + i];
+        spherical[4 * nspherical + i] += -1.6453058226360229 * cart[28 * ncart + i];
+        spherical[4 * nspherical + i] += -39.4873397432645490 * cart[8 * ncart + i];
+        spherical[4 * nspherical + i] += 39.4873397432645490 * cart[30 * ncart + i];
+        spherical[4 * nspherical + i] += 65.8122329054409221 * cart[19 * ncart + i];
+        spherical[4 * nspherical + i] += -65.8122329054409221 * cart[32 * ncart + i];
+    }
+
+    // R_83c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[5 * nspherical + i] = 9.5583630757311155 * cart[4 * ncart + i];
+        spherical[5 * nspherical + i] += 15.9306051262185271 * cart[11 * ncart + i];
+        spherical[5 * nspherical + i] += 3.1861210252437053 * cart[22 * ncart + i];
+        spherical[5 * nspherical + i] += -3.1861210252437053 * cart[37 * ncart + i];
+        spherical[5 * nspherical + i] += -63.7224205048741084 * cart[13 * ncart + i];
+        spherical[5 * nspherical + i] += -42.4816136699160722 * cart[24 * ncart + i];
+        spherical[5 * nspherical + i] += 21.2408068349580361 * cart[39 * ncart + i];
+        spherical[5 * nspherical + i] += 50.9779364038992853 * cart[26 * ncart + i];
+        spherical[5 * nspherical + i] += -16.9926454679664296 * cart[41 * ncart + i];
+    }
+    // R_83s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[6 * nspherical + i] = -0.7843687748756958 * cart[ncart + i];
+        spherical[6 * nspherical + i] += -2.3531063246270874 * cart[6 * ncart + i];
+        spherical[6 * nspherical + i] += -2.3531063246270874 * cart[15 * ncart + i];
+        spherical[6 * nspherical + i] += -0.7843687748756958 * cart[28 * ncart + i];
+        spherical[6 * nspherical + i] += 23.5310632462708753 * cart[8 * ncart + i];
+        spherical[6 * nspherical + i] += 47.0621264925417506 * cart[17 * ncart + i];
+        spherical[6 * nspherical + i] += 23.5310632462708753 * cart[30 * ncart + i];
+        spherical[6 * nspherical + i] += -62.7495019900556628 * cart[19 * ncart + i];
+        spherical[6 * nspherical + i] += -62.7495019900556628 * cart[32 * ncart + i];
+        spherical[6 * nspherical + i] += 25.0998007960222651 * cart[34 * ncart + i];
+    }
+
+    // R_84c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[7 * nspherical + i] = -3.2812500000000000 * cart[4 * ncart + i];
+        spherical[7 * nspherical + i] += -9.8437500000000000 * cart[11 * ncart + i];
+        spherical[7 * nspherical + i] += -9.8437500000000000 * cart[22 * ncart + i];
+        spherical[7 * nspherical + i] += -3.2812500000000000 * cart[37 * ncart + i];
+        spherical[7 * nspherical + i] += 26.2500000000000000 * cart[13 * ncart + i];
+        spherical[7 * nspherical + i] += 52.5000000000000000 * cart[24 * ncart + i];
+        spherical[7 * nspherical + i] += 26.2500000000000000 * cart[39 * ncart + i];
+        spherical[7 * nspherical + i] += -31.5000000000000000 * cart[26 * ncart + i];
+        spherical[7 * nspherical + i] += -31.5000000000000000 * cart[41 * ncart + i];
+        spherical[7 * nspherical + i] += 6.0000000000000000 * cart[43 * ncart + i];
+    }
+    // R_84s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[8 * nspherical + i] = 0.2734375000000000 * cart[i];
+        spherical[8 * nspherical + i] += 1.0937500000000000 * cart[3 * ncart + i];
+        spherical[8 * nspherical + i] += 1.6406250000000000 * cart[10 * ncart + i];
+        spherical[8 * nspherical + i] += 1.0937500000000000 * cart[21 * ncart + i];
+        spherical[8 * nspherical + i] += 0.2734375000000000 * cart[36 * ncart + i];
+        spherical[8 * nspherical + i] += -8.7500000000000000 * cart[5 * ncart + i];
+        spherical[8 * nspherical + i] += -26.2500000000000000 * cart[12 * ncart + i];
+        spherical[8 * nspherical + i] += -26.2500000000000000 * cart[23 * ncart + i];
+        spherical[8 * nspherical + i] += -8.7500000000000000 * cart[38 * ncart + i];
+        spherical[8 * nspherical + i] += 26.2500000000000000 * cart[14 * ncart + i];
+        spherical[8 * nspherical + i] += 52.5000000000000000 * cart[25 * ncart + i];
+        spherical[8 * nspherical + i] += 26.2500000000000000 * cart[40 * ncart + i];
+        spherical[8 * nspherical + i] += -14.0000000000000000 * cart[27 * ncart + i];
+        spherical[8 * nspherical + i] += -14.0000000000000000 * cart[42 * ncart + i];
+        spherical[8 * nspherical + i] += cart[44 * ncart + i];
+    }
+
+    // R_85c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[9 * nspherical + i] = -3.2812500000000000 * cart[2 * ncart + i];
+        spherical[9 * nspherical + i] += -9.8437500000000000 * cart[7 * ncart + i];
+        spherical[9 * nspherical + i] += -9.8437500000000000 * cart[16 * ncart + i];
+        spherical[9 * nspherical + i] += -3.2812500000000000 * cart[29 * ncart + i];
+        spherical[9 * nspherical + i] += 26.2500000000000000 * cart[9 * ncart + i];
+        spherical[9 * nspherical + i] += 52.5000000000000000 * cart[18 * ncart + i];
+        spherical[9 * nspherical + i] += 26.2500000000000000 * cart[31 * ncart + i];
+        spherical[9 * nspherical + i] += -31.5000000000000000 * cart[20 * ncart + i];
+        spherical[9 * nspherical + i] += -31.5000000000000000 * cart[33 * ncart + i];
+        spherical[9 * nspherical + i] += 6.0000000000000000 * cart[35 * ncart + i];
+    }
+    // R_85s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[10 * nspherical + i] = -0.3921843874378479 * cart[i];
+        spherical[10 * nspherical + i] += -0.7843687748756958 * cart[3 * ncart + i];
+        spherical[10 * nspherical + i] += 0.7843687748756958 * cart[21 * ncart + i];
+        spherical[10 * nspherical + i] += 0.3921843874378479 * cart[36 * ncart + i];
+        spherical[10 * nspherical + i] += 11.7655316231354377 * cart[5 * ncart + i];
+        spherical[10 * nspherical + i] += 11.7655316231354377 * cart[12 * ncart + i];
+        spherical[10 * nspherical + i] += -11.7655316231354377 * cart[23 * ncart + i];
+        spherical[10 * nspherical + i] += -11.7655316231354377 * cart[38 * ncart + i];
+        spherical[10 * nspherical + i] += -31.3747509950278314 * cart[14 * ncart + i];
+        spherical[10 * nspherical + i] += 31.3747509950278314 * cart[40 * ncart + i];
+        spherical[10 * nspherical + i] += 12.5499003980111326 * cart[27 * ncart + i];
+        spherical[10 * nspherical + i] += -12.5499003980111326 * cart[42 * ncart + i];
+    }
+
+    // R_86c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[11 * nspherical + i] = 3.1861210252437053 * cart[2 * ncart + i];
+        spherical[11 * nspherical + i] += -3.1861210252437053 * cart[7 * ncart + i];
+        spherical[11 * nspherical + i] += -15.9306051262185271 * cart[16 * ncart + i];
+        spherical[11 * nspherical + i] += -9.5583630757311155 * cart[29 * ncart + i];
+        spherical[11 * nspherical + i] += -21.2408068349580361 * cart[9 * ncart + i];
+        spherical[11 * nspherical + i] += 42.4816136699160722 * cart[18 * ncart + i];
+        spherical[11 * nspherical + i] += 63.7224205048741084 * cart[31 * ncart + i];
+        spherical[11 * nspherical + i] += 16.9926454679664296 * cart[20 * ncart + i];
+        spherical[11 * nspherical + i] += -50.9779364038992853 * cart[33 * ncart + i];
+    }
+    // R_86s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[12 * nspherical + i] = 0.4113264556590057 * cart[i];
+        spherical[12 * nspherical + i] += -1.6453058226360229 * cart[3 * ncart + i];
+        spherical[12 * nspherical + i] += -4.1132645565900576 * cart[10 * ncart + i];
+        spherical[12 * nspherical + i] += -1.6453058226360229 * cart[21 * ncart + i];
+        spherical[12 * nspherical + i] += 0.4113264556590057 * cart[36 * ncart + i];
+        spherical[12 * nspherical + i] += -9.8718349358161372 * cart[5 * ncart + i];
+        spherical[12 * nspherical + i] += 49.3591746790806880 * cart[12 * ncart + i];
+        spherical[12 * nspherical + i] += 49.3591746790806880 * cart[23 * ncart + i];
+        spherical[12 * nspherical + i] += -9.8718349358161372 * cart[38 * ncart + i];
+        spherical[12 * nspherical + i] += 16.4530582263602305 * cart[14 * ncart + i];
+        spherical[12 * nspherical + i] += -98.7183493581613760 * cart[25 * ncart + i];
+        spherical[12 * nspherical + i] += 16.4530582263602305 * cart[40 * ncart + i];
+    }
+
+    // R_87c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[13 * nspherical + i] = -2.9661172536668201 * cart[2 * ncart + i];
+        spherical[13 * nspherical + i] += 26.6950552830013805 * cart[7 * ncart + i];
+        spherical[13 * nspherical + i] += 14.8305862683341019 * cart[16 * ncart + i];
+        spherical[13 * nspherical + i] += -14.8305862683341019 * cart[29 * ncart + i];
+        spherical[13 * nspherical + i] += 11.8644690146672804 * cart[9 * ncart + i];
+        spherical[13 * nspherical + i] += -118.6446901466728150 * cart[18 * ncart + i];
+        spherical[13 * nspherical + i] += 59.3223450733364075 * cart[31 * ncart + i];
+    }
+    // R_87s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[14 * nspherical + i] = -0.4576818286211503 * cart[i];
+        spherical[14 * nspherical + i] += 6.4075456006961042 * cart[3 * ncart + i];
+        spherical[14 * nspherical + i] += -6.4075456006961042 * cart[21 * ncart + i];
+        spherical[14 * nspherical + i] += 0.4576818286211503 * cart[36 * ncart + i];
+        spherical[14 * nspherical + i] += 6.4075456006961042 * cart[5 * ncart + i];
+        spherical[14 * nspherical + i] += -96.1131840104415573 * cart[12 * ncart + i];
+        spherical[14 * nspherical + i] += 96.1131840104415573 * cart[23 * ncart + i];
+        spherical[14 * nspherical + i] += -6.4075456006961042 * cart[38 * ncart + i];
+    }
+
+    // R_88c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[15 * nspherical + i] = 2.5068266169601756 * cart[2 * ncart + i];
+        spherical[15 * nspherical + i] += -52.6433589561636950 * cart[7 * ncart + i];
+        spherical[15 * nspherical + i] += 87.7389315936061536 * cart[16 * ncart + i];
+        spherical[15 * nspherical + i] += -17.5477863187212293 * cart[29 * ncart + i];
+    }
+    // R_88s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[16 * nspherical + i] = 0.6267066542400439 * cart[i];
+        spherical[16 * nspherical + i] += -17.5477863187212293 * cart[3 * ncart + i];
+        spherical[16 * nspherical + i] += 43.8694657968030768 * cart[10 * ncart + i];
+        spherical[16 * nspherical + i] += -17.5477863187212293 * cart[21 * ncart + i];
+        spherical[16 * nspherical + i] += 0.6267066542400439 * cart[36 * ncart + i];
+    }
+}
+void gg_cca_cart_to_spherical_sum_L8(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart,
+                                     const unsigned long ncart, double* PRAGMA_RESTRICT output,
+                                     const unsigned long nspherical) {
+    ASSUME_ALIGNED(cart, 64);
+    // temps
+    double tmp;
+    // R_80 Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 5.0136532339203512 * cart[ncart + i];
+        tmp += -35.0955726374424586 * cart[6 * ncart + i];
+        tmp += 35.0955726374424586 * cart[15 * ncart + i];
+        tmp += -5.0136532339203512 * cart[28 * ncart + i];
+        output[i] += tmp * vector[0];
+    }
+
+    // R_81c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 17.5477863187212293 * cart[4 * ncart + i];
+        tmp += -87.7389315936061536 * cart[11 * ncart + i];
+        tmp += 52.6433589561636950 * cart[22 * ncart + i];
+        tmp += -2.5068266169601756 * cart[37 * ncart + i];
+        output[i] += tmp * vector[1];
+    }
+    // R_81s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -2.7460909717269018 * cart[ncart + i];
+        tmp += 6.4075456006961042 * cart[6 * ncart + i];
+        tmp += 6.4075456006961042 * cart[15 * ncart + i];
+        tmp += -2.7460909717269018 * cart[28 * ncart + i];
+        tmp += 38.4452736041766272 * cart[8 * ncart + i];
+        tmp += -128.1509120139220954 * cart[17 * ncart + i];
+        tmp += 38.4452736041766272 * cart[30 * ncart + i];
+        output[i] += tmp * vector[2];
+    }
+
+    // R_82c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -14.8305862683341019 * cart[4 * ncart + i];
+        tmp += 14.8305862683341019 * cart[11 * ncart + i];
+        tmp += 26.6950552830013805 * cart[22 * ncart + i];
+        tmp += -2.9661172536668201 * cart[37 * ncart + i];
+        tmp += 59.3223450733364075 * cart[13 * ncart + i];
+        tmp += -118.6446901466728150 * cart[24 * ncart + i];
+        tmp += 11.8644690146672804 * cart[39 * ncart + i];
+        output[i] += tmp * vector[3];
+    }
+    // R_82s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 1.6453058226360229 * cart[ncart + i];
+        tmp += 1.6453058226360229 * cart[6 * ncart + i];
+        tmp += -1.6453058226360229 * cart[15 * ncart + i];
+        tmp += -1.6453058226360229 * cart[28 * ncart + i];
+        tmp += -39.4873397432645490 * cart[8 * ncart + i];
+        tmp += 39.4873397432645490 * cart[30 * ncart + i];
+        tmp += 65.8122329054409221 * cart[19 * ncart + i];
+        tmp += -65.8122329054409221 * cart[32 * ncart + i];
+        output[i] += tmp * vector[4];
+    }
+
+    // R_83c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 9.5583630757311155 * cart[4 * ncart + i];
+        tmp += 15.9306051262185271 * cart[11 * ncart + i];
+        tmp += 3.1861210252437053 * cart[22 * ncart + i];
+        tmp += -3.1861210252437053 * cart[37 * ncart + i];
+        tmp += -63.7224205048741084 * cart[13 * ncart + i];
+        tmp += -42.4816136699160722 * cart[24 * ncart + i];
+        tmp += 21.2408068349580361 * cart[39 * ncart + i];
+        tmp += 50.9779364038992853 * cart[26 * ncart + i];
+        tmp += -16.9926454679664296 * cart[41 * ncart + i];
+        output[i] += tmp * vector[5];
+    }
+    // R_83s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.7843687748756958 * cart[ncart + i];
+        tmp += -2.3531063246270874 * cart[6 * ncart + i];
+        tmp += -2.3531063246270874 * cart[15 * ncart + i];
+        tmp += -0.7843687748756958 * cart[28 * ncart + i];
+        tmp += 23.5310632462708753 * cart[8 * ncart + i];
+        tmp += 47.0621264925417506 * cart[17 * ncart + i];
+        tmp += 23.5310632462708753 * cart[30 * ncart + i];
+        tmp += -62.7495019900556628 * cart[19 * ncart + i];
+        tmp += -62.7495019900556628 * cart[32 * ncart + i];
+        tmp += 25.0998007960222651 * cart[34 * ncart + i];
+        output[i] += tmp * vector[6];
+    }
+
+    // R_84c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -3.2812500000000000 * cart[4 * ncart + i];
+        tmp += -9.8437500000000000 * cart[11 * ncart + i];
+        tmp += -9.8437500000000000 * cart[22 * ncart + i];
+        tmp += -3.2812500000000000 * cart[37 * ncart + i];
+        tmp += 26.2500000000000000 * cart[13 * ncart + i];
+        tmp += 52.5000000000000000 * cart[24 * ncart + i];
+        tmp += 26.2500000000000000 * cart[39 * ncart + i];
+        tmp += -31.5000000000000000 * cart[26 * ncart + i];
+        tmp += -31.5000000000000000 * cart[41 * ncart + i];
+        tmp += 6.0000000000000000 * cart[43 * ncart + i];
+        output[i] += tmp * vector[7];
+    }
+    // R_84s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 0.2734375000000000 * cart[i];
+        tmp += 1.0937500000000000 * cart[3 * ncart + i];
+        tmp += 1.6406250000000000 * cart[10 * ncart + i];
+        tmp += 1.0937500000000000 * cart[21 * ncart + i];
+        tmp += 0.2734375000000000 * cart[36 * ncart + i];
+        tmp += -8.7500000000000000 * cart[5 * ncart + i];
+        tmp += -26.2500000000000000 * cart[12 * ncart + i];
+        tmp += -26.2500000000000000 * cart[23 * ncart + i];
+        tmp += -8.7500000000000000 * cart[38 * ncart + i];
+        tmp += 26.2500000000000000 * cart[14 * ncart + i];
+        tmp += 52.5000000000000000 * cart[25 * ncart + i];
+        tmp += 26.2500000000000000 * cart[40 * ncart + i];
+        tmp += -14.0000000000000000 * cart[27 * ncart + i];
+        tmp += -14.0000000000000000 * cart[42 * ncart + i];
+        tmp += cart[44 * ncart + i];
+        output[i] += tmp * vector[8];
+    }
+
+    // R_85c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -3.2812500000000000 * cart[2 * ncart + i];
+        tmp += -9.8437500000000000 * cart[7 * ncart + i];
+        tmp += -9.8437500000000000 * cart[16 * ncart + i];
+        tmp += -3.2812500000000000 * cart[29 * ncart + i];
+        tmp += 26.2500000000000000 * cart[9 * ncart + i];
+        tmp += 52.5000000000000000 * cart[18 * ncart + i];
+        tmp += 26.2500000000000000 * cart[31 * ncart + i];
+        tmp += -31.5000000000000000 * cart[20 * ncart + i];
+        tmp += -31.5000000000000000 * cart[33 * ncart + i];
+        tmp += 6.0000000000000000 * cart[35 * ncart + i];
+        output[i] += tmp * vector[9];
+    }
+    // R_85s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.3921843874378479 * cart[i];
+        tmp += -0.7843687748756958 * cart[3 * ncart + i];
+        tmp += 0.7843687748756958 * cart[21 * ncart + i];
+        tmp += 0.3921843874378479 * cart[36 * ncart + i];
+        tmp += 11.7655316231354377 * cart[5 * ncart + i];
+        tmp += 11.7655316231354377 * cart[12 * ncart + i];
+        tmp += -11.7655316231354377 * cart[23 * ncart + i];
+        tmp += -11.7655316231354377 * cart[38 * ncart + i];
+        tmp += -31.3747509950278314 * cart[14 * ncart + i];
+        tmp += 31.3747509950278314 * cart[40 * ncart + i];
+        tmp += 12.5499003980111326 * cart[27 * ncart + i];
+        tmp += -12.5499003980111326 * cart[42 * ncart + i];
+        output[i] += tmp * vector[10];
+    }
+
+    // R_86c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 3.1861210252437053 * cart[2 * ncart + i];
+        tmp += -3.1861210252437053 * cart[7 * ncart + i];
+        tmp += -15.9306051262185271 * cart[16 * ncart + i];
+        tmp += -9.5583630757311155 * cart[29 * ncart + i];
+        tmp += -21.2408068349580361 * cart[9 * ncart + i];
+        tmp += 42.4816136699160722 * cart[18 * ncart + i];
+        tmp += 63.7224205048741084 * cart[31 * ncart + i];
+        tmp += 16.9926454679664296 * cart[20 * ncart + i];
+        tmp += -50.9779364038992853 * cart[33 * ncart + i];
+        output[i] += tmp * vector[11];
+    }
+    // R_86s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 0.4113264556590057 * cart[i];
+        tmp += -1.6453058226360229 * cart[3 * ncart + i];
+        tmp += -4.1132645565900576 * cart[10 * ncart + i];
+        tmp += -1.6453058226360229 * cart[21 * ncart + i];
+        tmp += 0.4113264556590057 * cart[36 * ncart + i];
+        tmp += -9.8718349358161372 * cart[5 * ncart + i];
+        tmp += 49.3591746790806880 * cart[12 * ncart + i];
+        tmp += 49.3591746790806880 * cart[23 * ncart + i];
+        tmp += -9.8718349358161372 * cart[38 * ncart + i];
+        tmp += 16.4530582263602305 * cart[14 * ncart + i];
+        tmp += -98.7183493581613760 * cart[25 * ncart + i];
+        tmp += 16.4530582263602305 * cart[40 * ncart + i];
+        output[i] += tmp * vector[12];
+    }
+
+    // R_87c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -2.9661172536668201 * cart[2 * ncart + i];
+        tmp += 26.6950552830013805 * cart[7 * ncart + i];
+        tmp += 14.8305862683341019 * cart[16 * ncart + i];
+        tmp += -14.8305862683341019 * cart[29 * ncart + i];
+        tmp += 11.8644690146672804 * cart[9 * ncart + i];
+        tmp += -118.6446901466728150 * cart[18 * ncart + i];
+        tmp += 59.3223450733364075 * cart[31 * ncart + i];
+        output[i] += tmp * vector[13];
+    }
+    // R_87s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.4576818286211503 * cart[i];
+        tmp += 6.4075456006961042 * cart[3 * ncart + i];
+        tmp += -6.4075456006961042 * cart[21 * ncart + i];
+        tmp += 0.4576818286211503 * cart[36 * ncart + i];
+        tmp += 6.4075456006961042 * cart[5 * ncart + i];
+        tmp += -96.1131840104415573 * cart[12 * ncart + i];
+        tmp += 96.1131840104415573 * cart[23 * ncart + i];
+        tmp += -6.4075456006961042 * cart[38 * ncart + i];
+        output[i] += tmp * vector[14];
+    }
+
+    // R_88c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 2.5068266169601756 * cart[2 * ncart + i];
+        tmp += -52.6433589561636950 * cart[7 * ncart + i];
+        tmp += 87.7389315936061536 * cart[16 * ncart + i];
+        tmp += -17.5477863187212293 * cart[29 * ncart + i];
+        output[i] += tmp * vector[15];
+    }
+    // R_88s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 0.6267066542400439 * cart[i];
+        tmp += -17.5477863187212293 * cart[3 * ncart + i];
+        tmp += 43.8694657968030768 * cart[10 * ncart + i];
+        tmp += -17.5477863187212293 * cart[21 * ncart + i];
+        tmp += 0.6267066542400439 * cart[36 * ncart + i];
+        output[i] += tmp * vector[16];
+    }
+}
+void gg_gaussian_cart_to_spherical_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical) {
+    ASSUME_ALIGNED(cart, 64);
+    // R_00 Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[i] = cart[i];
+    }
+}
+void gg_gaussian_cart_to_spherical_sum_L0(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
+    ASSUME_ALIGNED(cart, 64);
+    // temps
+    double tmp;
+    // R_00 Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = cart[i];
+        output[i] += tmp * vector[0];
+    }
+}
+void gg_gaussian_cart_to_spherical_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical) {
+    ASSUME_ALIGNED(cart, 64);
+    // R_10 Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[i] = cart[2 * ncart + i];
+    }
+
+    // R_11c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[nspherical + i] = cart[i];
     }
     // R_11s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = cart[ncart + i];
-        output[i] += tmp * vector[2];
-
+        spherical[2 * nspherical + i] = cart[ncart + i];
+    }
+}
+void gg_gaussian_cart_to_spherical_sum_L1(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
+    ASSUME_ALIGNED(cart, 64);
+    // temps
+    double tmp;
+    // R_10 Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = cart[2 * ncart + i];
+        output[i] += tmp * vector[0];
     }
 
+    // R_11c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = cart[i];
+        output[i] += tmp * vector[1];
+    }
+    // R_11s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = cart[ncart + i];
+        output[i] += tmp * vector[2];
+    }
 }
-void gg_gaussian_cart_to_spherical_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
+void gg_gaussian_cart_to_spherical_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_20 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  = -0.5000000000000000 * cart[i];
+        spherical[i] = -0.5000000000000000 * cart[i];
         spherical[i] += -0.5000000000000000 * cart[3 * ncart + i];
         spherical[i] += cart[5 * ncart + i];
-
     }
 
     // R_21c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  =  1.7320508075688772 * cart[2 * ncart + i];
-
+        spherical[nspherical + i] = 1.7320508075688772 * cart[2 * ncart + i];
     }
     // R_21s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  =  1.7320508075688772 * cart[4 * ncart + i];
-
+        spherical[2 * nspherical + i] = 1.7320508075688772 * cart[4 * ncart + i];
     }
 
     // R_22c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[3 * nspherical + i]  =  0.8660254037844386 * cart[i];
+        spherical[3 * nspherical + i] = 0.8660254037844386 * cart[i];
         spherical[3 * nspherical + i] += -0.8660254037844386 * cart[3 * ncart + i];
-
     }
     // R_22s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[4 * nspherical + i]  =  1.7320508075688772 * cart[ncart + i];
-
+        spherical[4 * nspherical + i] = 1.7320508075688772 * cart[ncart + i];
     }
-
 }
-void gg_gaussian_cart_to_spherical_sum_L2(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
+void gg_gaussian_cart_to_spherical_sum_L2(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_20 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.5000000000000000 * cart[i];
+        tmp = -0.5000000000000000 * cart[i];
         tmp += -0.5000000000000000 * cart[3 * ncart + i];
         tmp += cart[5 * ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
     // R_21c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  1.7320508075688772 * cart[2 * ncart + i];
+        tmp = 1.7320508075688772 * cart[2 * ncart + i];
         output[i] += tmp * vector[1];
-
     }
     // R_21s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  1.7320508075688772 * cart[4 * ncart + i];
+        tmp = 1.7320508075688772 * cart[4 * ncart + i];
         output[i] += tmp * vector[2];
-
     }
 
     // R_22c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.8660254037844386 * cart[i];
+        tmp = 0.8660254037844386 * cart[i];
         tmp += -0.8660254037844386 * cart[3 * ncart + i];
         output[i] += tmp * vector[3];
-
     }
     // R_22s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  1.7320508075688772 * cart[ncart + i];
+        tmp = 1.7320508075688772 * cart[ncart + i];
         output[i] += tmp * vector[4];
-
     }
-
 }
-void gg_gaussian_cart_to_spherical_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
+void gg_gaussian_cart_to_spherical_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_30 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  = -1.5000000000000000 * cart[2 * ncart + i];
+        spherical[i] = -1.5000000000000000 * cart[2 * ncart + i];
         spherical[i] += -1.5000000000000000 * cart[7 * ncart + i];
         spherical[i] += cart[9 * ncart + i];
-
     }
 
     // R_31c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  = -0.6123724356957945 * cart[i];
+        spherical[nspherical + i] = -0.6123724356957945 * cart[i];
         spherical[nspherical + i] += -0.6123724356957945 * cart[3 * ncart + i];
-        spherical[nspherical + i] +=  2.4494897427831779 * cart[5 * ncart + i];
-
+        spherical[nspherical + i] += 2.4494897427831779 * cart[5 * ncart + i];
     }
     // R_31s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  = -0.6123724356957945 * cart[ncart + i];
+        spherical[2 * nspherical + i] = -0.6123724356957945 * cart[ncart + i];
         spherical[2 * nspherical + i] += -0.6123724356957945 * cart[6 * ncart + i];
-        spherical[2 * nspherical + i] +=  2.4494897427831779 * cart[8 * ncart + i];
-
+        spherical[2 * nspherical + i] += 2.4494897427831779 * cart[8 * ncart + i];
     }
 
     // R_32c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[3 * nspherical + i]  =  1.9364916731037085 * cart[2 * ncart + i];
+        spherical[3 * nspherical + i] = 1.9364916731037085 * cart[2 * ncart + i];
         spherical[3 * nspherical + i] += -1.9364916731037085 * cart[7 * ncart + i];
-
     }
     // R_32s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[4 * nspherical + i]  =  3.8729833462074170 * cart[4 * ncart + i];
-
+        spherical[4 * nspherical + i] = 3.8729833462074170 * cart[4 * ncart + i];
     }
 
     // R_33c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[5 * nspherical + i]  =  0.7905694150420949 * cart[i];
+        spherical[5 * nspherical + i] = 0.7905694150420949 * cart[i];
         spherical[5 * nspherical + i] += -2.3717082451262845 * cart[3 * ncart + i];
-
     }
     // R_33s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[6 * nspherical + i]  =  2.3717082451262845 * cart[ncart + i];
+        spherical[6 * nspherical + i] = 2.3717082451262845 * cart[ncart + i];
         spherical[6 * nspherical + i] += -0.7905694150420949 * cart[6 * ncart + i];
-
     }
-
 }
-void gg_gaussian_cart_to_spherical_sum_L3(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
+void gg_gaussian_cart_to_spherical_sum_L3(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_30 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -1.5000000000000000 * cart[2 * ncart + i];
+        tmp = -1.5000000000000000 * cart[2 * ncart + i];
         tmp += -1.5000000000000000 * cart[7 * ncart + i];
         tmp += cart[9 * ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
     // R_31c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.6123724356957945 * cart[i];
+        tmp = -0.6123724356957945 * cart[i];
         tmp += -0.6123724356957945 * cart[3 * ncart + i];
-        tmp +=  2.4494897427831779 * cart[5 * ncart + i];
+        tmp += 2.4494897427831779 * cart[5 * ncart + i];
         output[i] += tmp * vector[1];
-
     }
     // R_31s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.6123724356957945 * cart[ncart + i];
+        tmp = -0.6123724356957945 * cart[ncart + i];
         tmp += -0.6123724356957945 * cart[6 * ncart + i];
-        tmp +=  2.4494897427831779 * cart[8 * ncart + i];
+        tmp += 2.4494897427831779 * cart[8 * ncart + i];
         output[i] += tmp * vector[2];
-
     }
 
     // R_32c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  1.9364916731037085 * cart[2 * ncart + i];
+        tmp = 1.9364916731037085 * cart[2 * ncart + i];
         tmp += -1.9364916731037085 * cart[7 * ncart + i];
         output[i] += tmp * vector[3];
-
     }
     // R_32s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  3.8729833462074170 * cart[4 * ncart + i];
+        tmp = 3.8729833462074170 * cart[4 * ncart + i];
         output[i] += tmp * vector[4];
-
     }
 
     // R_33c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.7905694150420949 * cart[i];
+        tmp = 0.7905694150420949 * cart[i];
         tmp += -2.3717082451262845 * cart[3 * ncart + i];
         output[i] += tmp * vector[5];
-
     }
     // R_33s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.3717082451262845 * cart[ncart + i];
+        tmp = 2.3717082451262845 * cart[ncart + i];
         tmp += -0.7905694150420949 * cart[6 * ncart + i];
         output[i] += tmp * vector[6];
-
     }
-
 }
-void gg_gaussian_cart_to_spherical_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
+void gg_gaussian_cart_to_spherical_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_40 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  =  0.3750000000000000 * cart[i];
-        spherical[i] +=  0.7500000000000000 * cart[3 * ncart + i];
-        spherical[i] +=  0.3750000000000000 * cart[10 * ncart + i];
+        spherical[i] = 0.3750000000000000 * cart[i];
+        spherical[i] += 0.7500000000000000 * cart[3 * ncart + i];
+        spherical[i] += 0.3750000000000000 * cart[10 * ncart + i];
         spherical[i] += -3.0000000000000000 * cart[5 * ncart + i];
         spherical[i] += -3.0000000000000000 * cart[12 * ncart + i];
         spherical[i] += cart[14 * ncart + i];
-
     }
 
     // R_41c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  = -2.3717082451262845 * cart[2 * ncart + i];
+        spherical[nspherical + i] = -2.3717082451262845 * cart[2 * ncart + i];
         spherical[nspherical + i] += -2.3717082451262845 * cart[7 * ncart + i];
-        spherical[nspherical + i] +=  3.1622776601683795 * cart[9 * ncart + i];
-
+        spherical[nspherical + i] += 3.1622776601683795 * cart[9 * ncart + i];
     }
     // R_41s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  = -2.3717082451262845 * cart[4 * ncart + i];
+        spherical[2 * nspherical + i] = -2.3717082451262845 * cart[4 * ncart + i];
         spherical[2 * nspherical + i] += -2.3717082451262845 * cart[11 * ncart + i];
-        spherical[2 * nspherical + i] +=  3.1622776601683795 * cart[13 * ncart + i];
-
+        spherical[2 * nspherical + i] += 3.1622776601683795 * cart[13 * ncart + i];
     }
 
     // R_42c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[3 * nspherical + i]  = -0.5590169943749475 * cart[i];
-        spherical[3 * nspherical + i] +=  0.5590169943749475 * cart[10 * ncart + i];
-        spherical[3 * nspherical + i] +=  3.3541019662496847 * cart[5 * ncart + i];
+        spherical[3 * nspherical + i] = -0.5590169943749475 * cart[i];
+        spherical[3 * nspherical + i] += 0.5590169943749475 * cart[10 * ncart + i];
+        spherical[3 * nspherical + i] += 3.3541019662496847 * cart[5 * ncart + i];
         spherical[3 * nspherical + i] += -3.3541019662496847 * cart[12 * ncart + i];
-
     }
     // R_42s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[4 * nspherical + i]  = -1.1180339887498949 * cart[ncart + i];
+        spherical[4 * nspherical + i] = -1.1180339887498949 * cart[ncart + i];
         spherical[4 * nspherical + i] += -1.1180339887498949 * cart[6 * ncart + i];
-        spherical[4 * nspherical + i] +=  6.7082039324993694 * cart[8 * ncart + i];
-
+        spherical[4 * nspherical + i] += 6.7082039324993694 * cart[8 * ncart + i];
     }
 
     // R_43c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[5 * nspherical + i]  =  2.0916500663351889 * cart[2 * ncart + i];
+        spherical[5 * nspherical + i] = 2.0916500663351889 * cart[2 * ncart + i];
         spherical[5 * nspherical + i] += -6.2749501990055663 * cart[7 * ncart + i];
-
     }
     // R_43s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[6 * nspherical + i]  =  6.2749501990055663 * cart[4 * ncart + i];
+        spherical[6 * nspherical + i] = 6.2749501990055663 * cart[4 * ncart + i];
         spherical[6 * nspherical + i] += -2.0916500663351889 * cart[11 * ncart + i];
-
     }
 
     // R_44c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[7 * nspherical + i]  =  0.7395099728874520 * cart[i];
+        spherical[7 * nspherical + i] = 0.7395099728874520 * cart[i];
         spherical[7 * nspherical + i] += -4.4370598373247123 * cart[3 * ncart + i];
-        spherical[7 * nspherical + i] +=  0.7395099728874520 * cart[10 * ncart + i];
-
+        spherical[7 * nspherical + i] += 0.7395099728874520 * cart[10 * ncart + i];
     }
     // R_44s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[8 * nspherical + i]  =  2.9580398915498081 * cart[ncart + i];
+        spherical[8 * nspherical + i] = 2.9580398915498081 * cart[ncart + i];
         spherical[8 * nspherical + i] += -2.9580398915498081 * cart[6 * ncart + i];
-
     }
-
 }
-void gg_gaussian_cart_to_spherical_sum_L4(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
+void gg_gaussian_cart_to_spherical_sum_L4(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_40 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.3750000000000000 * cart[i];
-        tmp +=  0.7500000000000000 * cart[3 * ncart + i];
-        tmp +=  0.3750000000000000 * cart[10 * ncart + i];
+        tmp = 0.3750000000000000 * cart[i];
+        tmp += 0.7500000000000000 * cart[3 * ncart + i];
+        tmp += 0.3750000000000000 * cart[10 * ncart + i];
         tmp += -3.0000000000000000 * cart[5 * ncart + i];
         tmp += -3.0000000000000000 * cart[12 * ncart + i];
         tmp += cart[14 * ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
     // R_41c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -2.3717082451262845 * cart[2 * ncart + i];
+        tmp = -2.3717082451262845 * cart[2 * ncart + i];
         tmp += -2.3717082451262845 * cart[7 * ncart + i];
-        tmp +=  3.1622776601683795 * cart[9 * ncart + i];
+        tmp += 3.1622776601683795 * cart[9 * ncart + i];
         output[i] += tmp * vector[1];
-
     }
     // R_41s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -2.3717082451262845 * cart[4 * ncart + i];
+        tmp = -2.3717082451262845 * cart[4 * ncart + i];
         tmp += -2.3717082451262845 * cart[11 * ncart + i];
-        tmp +=  3.1622776601683795 * cart[13 * ncart + i];
+        tmp += 3.1622776601683795 * cart[13 * ncart + i];
         output[i] += tmp * vector[2];
-
     }
 
     // R_42c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.5590169943749475 * cart[i];
-        tmp +=  0.5590169943749475 * cart[10 * ncart + i];
-        tmp +=  3.3541019662496847 * cart[5 * ncart + i];
+        tmp = -0.5590169943749475 * cart[i];
+        tmp += 0.5590169943749475 * cart[10 * ncart + i];
+        tmp += 3.3541019662496847 * cart[5 * ncart + i];
         tmp += -3.3541019662496847 * cart[12 * ncart + i];
         output[i] += tmp * vector[3];
-
     }
     // R_42s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -1.1180339887498949 * cart[ncart + i];
+        tmp = -1.1180339887498949 * cart[ncart + i];
         tmp += -1.1180339887498949 * cart[6 * ncart + i];
-        tmp +=  6.7082039324993694 * cart[8 * ncart + i];
+        tmp += 6.7082039324993694 * cart[8 * ncart + i];
         output[i] += tmp * vector[4];
-
     }
 
     // R_43c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.0916500663351889 * cart[2 * ncart + i];
+        tmp = 2.0916500663351889 * cart[2 * ncart + i];
         tmp += -6.2749501990055663 * cart[7 * ncart + i];
         output[i] += tmp * vector[5];
-
     }
     // R_43s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  6.2749501990055663 * cart[4 * ncart + i];
+        tmp = 6.2749501990055663 * cart[4 * ncart + i];
         tmp += -2.0916500663351889 * cart[11 * ncart + i];
         output[i] += tmp * vector[6];
-
     }
 
     // R_44c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.7395099728874520 * cart[i];
+        tmp = 0.7395099728874520 * cart[i];
         tmp += -4.4370598373247123 * cart[3 * ncart + i];
-        tmp +=  0.7395099728874520 * cart[10 * ncart + i];
+        tmp += 0.7395099728874520 * cart[10 * ncart + i];
         output[i] += tmp * vector[7];
-
     }
     // R_44s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.9580398915498081 * cart[ncart + i];
+        tmp = 2.9580398915498081 * cart[ncart + i];
         tmp += -2.9580398915498081 * cart[6 * ncart + i];
         output[i] += tmp * vector[8];
-
     }
-
 }
-void gg_gaussian_cart_to_spherical_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
+void gg_gaussian_cart_to_spherical_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_50 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  =  1.8750000000000000 * cart[2 * ncart + i];
-        spherical[i] +=  3.7500000000000000 * cart[7 * ncart + i];
-        spherical[i] +=  1.8750000000000000 * cart[16 * ncart + i];
+        spherical[i] = 1.8750000000000000 * cart[2 * ncart + i];
+        spherical[i] += 3.7500000000000000 * cart[7 * ncart + i];
+        spherical[i] += 1.8750000000000000 * cart[16 * ncart + i];
         spherical[i] += -5.0000000000000000 * cart[9 * ncart + i];
         spherical[i] += -5.0000000000000000 * cart[18 * ncart + i];
         spherical[i] += cart[20 * ncart + i];
-
     }
 
     // R_51c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  =  0.4841229182759271 * cart[i];
-        spherical[nspherical + i] +=  0.9682458365518543 * cart[3 * ncart + i];
-        spherical[nspherical + i] +=  0.4841229182759271 * cart[10 * ncart + i];
+        spherical[nspherical + i] = 0.4841229182759271 * cart[i];
+        spherical[nspherical + i] += 0.9682458365518543 * cart[3 * ncart + i];
+        spherical[nspherical + i] += 0.4841229182759271 * cart[10 * ncart + i];
         spherical[nspherical + i] += -5.8094750193111251 * cart[5 * ncart + i];
         spherical[nspherical + i] += -5.8094750193111251 * cart[12 * ncart + i];
-        spherical[nspherical + i] +=  3.8729833462074170 * cart[14 * ncart + i];
-
+        spherical[nspherical + i] += 3.8729833462074170 * cart[14 * ncart + i];
     }
     // R_51s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  =  0.4841229182759271 * cart[ncart + i];
-        spherical[2 * nspherical + i] +=  0.9682458365518543 * cart[6 * ncart + i];
-        spherical[2 * nspherical + i] +=  0.4841229182759271 * cart[15 * ncart + i];
+        spherical[2 * nspherical + i] = 0.4841229182759271 * cart[ncart + i];
+        spherical[2 * nspherical + i] += 0.9682458365518543 * cart[6 * ncart + i];
+        spherical[2 * nspherical + i] += 0.4841229182759271 * cart[15 * ncart + i];
         spherical[2 * nspherical + i] += -5.8094750193111251 * cart[8 * ncart + i];
         spherical[2 * nspherical + i] += -5.8094750193111251 * cart[17 * ncart + i];
-        spherical[2 * nspherical + i] +=  3.8729833462074170 * cart[19 * ncart + i];
-
+        spherical[2 * nspherical + i] += 3.8729833462074170 * cart[19 * ncart + i];
     }
 
     // R_52c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[3 * nspherical + i]  = -2.5617376914898995 * cart[2 * ncart + i];
-        spherical[3 * nspherical + i] +=  2.5617376914898995 * cart[16 * ncart + i];
-        spherical[3 * nspherical + i] +=  5.1234753829797990 * cart[9 * ncart + i];
+        spherical[3 * nspherical + i] = -2.5617376914898995 * cart[2 * ncart + i];
+        spherical[3 * nspherical + i] += 2.5617376914898995 * cart[16 * ncart + i];
+        spherical[3 * nspherical + i] += 5.1234753829797990 * cart[9 * ncart + i];
         spherical[3 * nspherical + i] += -5.1234753829797990 * cart[18 * ncart + i];
-
     }
     // R_52s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[4 * nspherical + i]  = -5.1234753829797990 * cart[4 * ncart + i];
+        spherical[4 * nspherical + i] = -5.1234753829797990 * cart[4 * ncart + i];
         spherical[4 * nspherical + i] += -5.1234753829797990 * cart[11 * ncart + i];
-        spherical[4 * nspherical + i] +=  10.2469507659595980 * cart[13 * ncart + i];
-
+        spherical[4 * nspherical + i] += 10.2469507659595980 * cart[13 * ncart + i];
     }
 
     // R_53c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[5 * nspherical + i]  = -0.5229125165837972 * cart[i];
-        spherical[5 * nspherical + i] +=  1.0458250331675945 * cart[3 * ncart + i];
-        spherical[5 * nspherical + i] +=  1.5687375497513916 * cart[10 * ncart + i];
-        spherical[5 * nspherical + i] +=  4.1833001326703778 * cart[5 * ncart + i];
+        spherical[5 * nspherical + i] = -0.5229125165837972 * cart[i];
+        spherical[5 * nspherical + i] += 1.0458250331675945 * cart[3 * ncart + i];
+        spherical[5 * nspherical + i] += 1.5687375497513916 * cart[10 * ncart + i];
+        spherical[5 * nspherical + i] += 4.1833001326703778 * cart[5 * ncart + i];
         spherical[5 * nspherical + i] += -12.5499003980111326 * cart[12 * ncart + i];
-
     }
     // R_53s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[6 * nspherical + i]  = -1.5687375497513916 * cart[ncart + i];
+        spherical[6 * nspherical + i] = -1.5687375497513916 * cart[ncart + i];
         spherical[6 * nspherical + i] += -1.0458250331675945 * cart[6 * ncart + i];
-        spherical[6 * nspherical + i] +=  0.5229125165837972 * cart[15 * ncart + i];
-        spherical[6 * nspherical + i] +=  12.5499003980111326 * cart[8 * ncart + i];
+        spherical[6 * nspherical + i] += 0.5229125165837972 * cart[15 * ncart + i];
+        spherical[6 * nspherical + i] += 12.5499003980111326 * cart[8 * ncart + i];
         spherical[6 * nspherical + i] += -4.1833001326703778 * cart[17 * ncart + i];
-
     }
 
     // R_54c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[7 * nspherical + i]  =  2.2185299186623562 * cart[2 * ncart + i];
+        spherical[7 * nspherical + i] = 2.2185299186623562 * cart[2 * ncart + i];
         spherical[7 * nspherical + i] += -13.3111795119741370 * cart[7 * ncart + i];
-        spherical[7 * nspherical + i] +=  2.2185299186623562 * cart[16 * ncart + i];
-
+        spherical[7 * nspherical + i] += 2.2185299186623562 * cart[16 * ncart + i];
     }
     // R_54s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[8 * nspherical + i]  =  8.8741196746494246 * cart[4 * ncart + i];
+        spherical[8 * nspherical + i] = 8.8741196746494246 * cart[4 * ncart + i];
         spherical[8 * nspherical + i] += -8.8741196746494246 * cart[11 * ncart + i];
-
     }
 
     // R_55c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[9 * nspherical + i]  =  0.7015607600201140 * cart[i];
+        spherical[9 * nspherical + i] = 0.7015607600201140 * cart[i];
         spherical[9 * nspherical + i] += -7.0156076002011405 * cart[3 * ncart + i];
-        spherical[9 * nspherical + i] +=  3.5078038001005702 * cart[10 * ncart + i];
-
+        spherical[9 * nspherical + i] += 3.5078038001005702 * cart[10 * ncart + i];
     }
     // R_55s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[10 * nspherical + i]  =  3.5078038001005702 * cart[ncart + i];
+        spherical[10 * nspherical + i] = 3.5078038001005702 * cart[ncart + i];
         spherical[10 * nspherical + i] += -7.0156076002011405 * cart[6 * ncart + i];
-        spherical[10 * nspherical + i] +=  0.7015607600201140 * cart[15 * ncart + i];
-
+        spherical[10 * nspherical + i] += 0.7015607600201140 * cart[15 * ncart + i];
     }
-
 }
-void gg_gaussian_cart_to_spherical_sum_L5(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
+void gg_gaussian_cart_to_spherical_sum_L5(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_50 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  1.8750000000000000 * cart[2 * ncart + i];
-        tmp +=  3.7500000000000000 * cart[7 * ncart + i];
-        tmp +=  1.8750000000000000 * cart[16 * ncart + i];
+        tmp = 1.8750000000000000 * cart[2 * ncart + i];
+        tmp += 3.7500000000000000 * cart[7 * ncart + i];
+        tmp += 1.8750000000000000 * cart[16 * ncart + i];
         tmp += -5.0000000000000000 * cart[9 * ncart + i];
         tmp += -5.0000000000000000 * cart[18 * ncart + i];
         tmp += cart[20 * ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
     // R_51c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.4841229182759271 * cart[i];
-        tmp +=  0.9682458365518543 * cart[3 * ncart + i];
-        tmp +=  0.4841229182759271 * cart[10 * ncart + i];
+        tmp = 0.4841229182759271 * cart[i];
+        tmp += 0.9682458365518543 * cart[3 * ncart + i];
+        tmp += 0.4841229182759271 * cart[10 * ncart + i];
         tmp += -5.8094750193111251 * cart[5 * ncart + i];
         tmp += -5.8094750193111251 * cart[12 * ncart + i];
-        tmp +=  3.8729833462074170 * cart[14 * ncart + i];
+        tmp += 3.8729833462074170 * cart[14 * ncart + i];
         output[i] += tmp * vector[1];
-
     }
     // R_51s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.4841229182759271 * cart[ncart + i];
-        tmp +=  0.9682458365518543 * cart[6 * ncart + i];
-        tmp +=  0.4841229182759271 * cart[15 * ncart + i];
+        tmp = 0.4841229182759271 * cart[ncart + i];
+        tmp += 0.9682458365518543 * cart[6 * ncart + i];
+        tmp += 0.4841229182759271 * cart[15 * ncart + i];
         tmp += -5.8094750193111251 * cart[8 * ncart + i];
         tmp += -5.8094750193111251 * cart[17 * ncart + i];
-        tmp +=  3.8729833462074170 * cart[19 * ncart + i];
+        tmp += 3.8729833462074170 * cart[19 * ncart + i];
         output[i] += tmp * vector[2];
-
     }
 
     // R_52c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -2.5617376914898995 * cart[2 * ncart + i];
-        tmp +=  2.5617376914898995 * cart[16 * ncart + i];
-        tmp +=  5.1234753829797990 * cart[9 * ncart + i];
+        tmp = -2.5617376914898995 * cart[2 * ncart + i];
+        tmp += 2.5617376914898995 * cart[16 * ncart + i];
+        tmp += 5.1234753829797990 * cart[9 * ncart + i];
         tmp += -5.1234753829797990 * cart[18 * ncart + i];
         output[i] += tmp * vector[3];
-
     }
     // R_52s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -5.1234753829797990 * cart[4 * ncart + i];
+        tmp = -5.1234753829797990 * cart[4 * ncart + i];
         tmp += -5.1234753829797990 * cart[11 * ncart + i];
-        tmp +=  10.2469507659595980 * cart[13 * ncart + i];
+        tmp += 10.2469507659595980 * cart[13 * ncart + i];
         output[i] += tmp * vector[4];
-
     }
 
     // R_53c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.5229125165837972 * cart[i];
-        tmp +=  1.0458250331675945 * cart[3 * ncart + i];
-        tmp +=  1.5687375497513916 * cart[10 * ncart + i];
-        tmp +=  4.1833001326703778 * cart[5 * ncart + i];
+        tmp = -0.5229125165837972 * cart[i];
+        tmp += 1.0458250331675945 * cart[3 * ncart + i];
+        tmp += 1.5687375497513916 * cart[10 * ncart + i];
+        tmp += 4.1833001326703778 * cart[5 * ncart + i];
         tmp += -12.5499003980111326 * cart[12 * ncart + i];
         output[i] += tmp * vector[5];
-
     }
     // R_53s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -1.5687375497513916 * cart[ncart + i];
+        tmp = -1.5687375497513916 * cart[ncart + i];
         tmp += -1.0458250331675945 * cart[6 * ncart + i];
-        tmp +=  0.5229125165837972 * cart[15 * ncart + i];
-        tmp +=  12.5499003980111326 * cart[8 * ncart + i];
+        tmp += 0.5229125165837972 * cart[15 * ncart + i];
+        tmp += 12.5499003980111326 * cart[8 * ncart + i];
         tmp += -4.1833001326703778 * cart[17 * ncart + i];
         output[i] += tmp * vector[6];
-
     }
 
     // R_54c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.2185299186623562 * cart[2 * ncart + i];
+        tmp = 2.2185299186623562 * cart[2 * ncart + i];
         tmp += -13.3111795119741370 * cart[7 * ncart + i];
-        tmp +=  2.2185299186623562 * cart[16 * ncart + i];
+        tmp += 2.2185299186623562 * cart[16 * ncart + i];
         output[i] += tmp * vector[7];
-
     }
     // R_54s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  8.8741196746494246 * cart[4 * ncart + i];
+        tmp = 8.8741196746494246 * cart[4 * ncart + i];
         tmp += -8.8741196746494246 * cart[11 * ncart + i];
         output[i] += tmp * vector[8];
-
     }
 
     // R_55c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.7015607600201140 * cart[i];
+        tmp = 0.7015607600201140 * cart[i];
         tmp += -7.0156076002011405 * cart[3 * ncart + i];
-        tmp +=  3.5078038001005702 * cart[10 * ncart + i];
+        tmp += 3.5078038001005702 * cart[10 * ncart + i];
         output[i] += tmp * vector[9];
-
     }
     // R_55s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  3.5078038001005702 * cart[ncart + i];
+        tmp = 3.5078038001005702 * cart[ncart + i];
         tmp += -7.0156076002011405 * cart[6 * ncart + i];
-        tmp +=  0.7015607600201140 * cart[15 * ncart + i];
+        tmp += 0.7015607600201140 * cart[15 * ncart + i];
         output[i] += tmp * vector[10];
-
     }
-
 }
-void gg_gaussian_cart_to_spherical_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT spherical, const unsigned long nspherical) {
+void gg_gaussian_cart_to_spherical_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // R_60 Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[i]  = -0.3125000000000000 * cart[i];
+        spherical[i] = -0.3125000000000000 * cart[i];
         spherical[i] += -0.9375000000000000 * cart[3 * ncart + i];
         spherical[i] += -0.9375000000000000 * cart[10 * ncart + i];
         spherical[i] += -0.3125000000000000 * cart[21 * ncart + i];
-        spherical[i] +=  5.6250000000000000 * cart[5 * ncart + i];
-        spherical[i] +=  11.2500000000000000 * cart[12 * ncart + i];
-        spherical[i] +=  5.6250000000000000 * cart[23 * ncart + i];
+        spherical[i] += 5.6250000000000000 * cart[5 * ncart + i];
+        spherical[i] += 11.2500000000000000 * cart[12 * ncart + i];
+        spherical[i] += 5.6250000000000000 * cart[23 * ncart + i];
         spherical[i] += -7.5000000000000000 * cart[14 * ncart + i];
         spherical[i] += -7.5000000000000000 * cart[25 * ncart + i];
         spherical[i] += cart[27 * ncart + i];
-
     }
 
     // R_61c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[nspherical + i]  =  2.8641098093473998 * cart[2 * ncart + i];
-        spherical[nspherical + i] +=  5.7282196186947996 * cart[7 * ncart + i];
-        spherical[nspherical + i] +=  2.8641098093473998 * cart[16 * ncart + i];
+        spherical[nspherical + i] = 2.8641098093473998 * cart[2 * ncart + i];
+        spherical[nspherical + i] += 5.7282196186947996 * cart[7 * ncart + i];
+        spherical[nspherical + i] += 2.8641098093473998 * cart[16 * ncart + i];
         spherical[nspherical + i] += -11.4564392373895991 * cart[9 * ncart + i];
         spherical[nspherical + i] += -11.4564392373895991 * cart[18 * ncart + i];
-        spherical[nspherical + i] +=  4.5825756949558398 * cart[20 * ncart + i];
-
+        spherical[nspherical + i] += 4.5825756949558398 * cart[20 * ncart + i];
     }
     // R_61s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[2 * nspherical + i]  =  2.8641098093473998 * cart[4 * ncart + i];
-        spherical[2 * nspherical + i] +=  5.7282196186947996 * cart[11 * ncart + i];
-        spherical[2 * nspherical + i] +=  2.8641098093473998 * cart[22 * ncart + i];
+        spherical[2 * nspherical + i] = 2.8641098093473998 * cart[4 * ncart + i];
+        spherical[2 * nspherical + i] += 5.7282196186947996 * cart[11 * ncart + i];
+        spherical[2 * nspherical + i] += 2.8641098093473998 * cart[22 * ncart + i];
         spherical[2 * nspherical + i] += -11.4564392373895991 * cart[13 * ncart + i];
         spherical[2 * nspherical + i] += -11.4564392373895991 * cart[24 * ncart + i];
-        spherical[2 * nspherical + i] +=  4.5825756949558398 * cart[26 * ncart + i];
-
+        spherical[2 * nspherical + i] += 4.5825756949558398 * cart[26 * ncart + i];
     }
 
     // R_62c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[3 * nspherical + i]  =  0.4528555233184199 * cart[i];
-        spherical[3 * nspherical + i] +=  0.4528555233184199 * cart[3 * ncart + i];
+        spherical[3 * nspherical + i] = 0.4528555233184199 * cart[i];
+        spherical[3 * nspherical + i] += 0.4528555233184199 * cart[3 * ncart + i];
         spherical[3 * nspherical + i] += -0.4528555233184199 * cart[10 * ncart + i];
         spherical[3 * nspherical + i] += -0.4528555233184199 * cart[21 * ncart + i];
         spherical[3 * nspherical + i] += -7.2456883730947190 * cart[5 * ncart + i];
-        spherical[3 * nspherical + i] +=  7.2456883730947190 * cart[23 * ncart + i];
-        spherical[3 * nspherical + i] +=  7.2456883730947190 * cart[14 * ncart + i];
+        spherical[3 * nspherical + i] += 7.2456883730947190 * cart[23 * ncart + i];
+        spherical[3 * nspherical + i] += 7.2456883730947190 * cart[14 * ncart + i];
         spherical[3 * nspherical + i] += -7.2456883730947190 * cart[25 * ncart + i];
-
     }
     // R_62s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[4 * nspherical + i]  =  0.9057110466368399 * cart[ncart + i];
-        spherical[4 * nspherical + i] +=  1.8114220932736798 * cart[6 * ncart + i];
-        spherical[4 * nspherical + i] +=  0.9057110466368399 * cart[15 * ncart + i];
+        spherical[4 * nspherical + i] = 0.9057110466368399 * cart[ncart + i];
+        spherical[4 * nspherical + i] += 1.8114220932736798 * cart[6 * ncart + i];
+        spherical[4 * nspherical + i] += 0.9057110466368399 * cart[15 * ncart + i];
         spherical[4 * nspherical + i] += -14.4913767461894381 * cart[8 * ncart + i];
         spherical[4 * nspherical + i] += -14.4913767461894381 * cart[17 * ncart + i];
-        spherical[4 * nspherical + i] +=  14.4913767461894381 * cart[19 * ncart + i];
-
+        spherical[4 * nspherical + i] += 14.4913767461894381 * cart[19 * ncart + i];
     }
 
     // R_63c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[5 * nspherical + i]  = -2.7171331399105196 * cart[2 * ncart + i];
-        spherical[5 * nspherical + i] +=  5.4342662798210393 * cart[7 * ncart + i];
-        spherical[5 * nspherical + i] +=  8.1513994197315593 * cart[16 * ncart + i];
-        spherical[5 * nspherical + i] +=  7.2456883730947190 * cart[9 * ncart + i];
+        spherical[5 * nspherical + i] = -2.7171331399105196 * cart[2 * ncart + i];
+        spherical[5 * nspherical + i] += 5.4342662798210393 * cart[7 * ncart + i];
+        spherical[5 * nspherical + i] += 8.1513994197315593 * cart[16 * ncart + i];
+        spherical[5 * nspherical + i] += 7.2456883730947190 * cart[9 * ncart + i];
         spherical[5 * nspherical + i] += -21.7370651192841571 * cart[18 * ncart + i];
-
     }
     // R_63s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[6 * nspherical + i]  = -8.1513994197315593 * cart[4 * ncart + i];
+        spherical[6 * nspherical + i] = -8.1513994197315593 * cart[4 * ncart + i];
         spherical[6 * nspherical + i] += -5.4342662798210393 * cart[11 * ncart + i];
-        spherical[6 * nspherical + i] +=  2.7171331399105196 * cart[22 * ncart + i];
-        spherical[6 * nspherical + i] +=  21.7370651192841571 * cart[13 * ncart + i];
+        spherical[6 * nspherical + i] += 2.7171331399105196 * cart[22 * ncart + i];
+        spherical[6 * nspherical + i] += 21.7370651192841571 * cart[13 * ncart + i];
         spherical[6 * nspherical + i] += -7.2456883730947190 * cart[24 * ncart + i];
-
     }
 
     // R_64c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[7 * nspherical + i]  = -0.4960783708246108 * cart[i];
-        spherical[7 * nspherical + i] +=  2.4803918541230536 * cart[3 * ncart + i];
-        spherical[7 * nspherical + i] +=  2.4803918541230536 * cart[10 * ncart + i];
+        spherical[7 * nspherical + i] = -0.4960783708246108 * cart[i];
+        spherical[7 * nspherical + i] += 2.4803918541230536 * cart[3 * ncart + i];
+        spherical[7 * nspherical + i] += 2.4803918541230536 * cart[10 * ncart + i];
         spherical[7 * nspherical + i] += -0.4960783708246108 * cart[21 * ncart + i];
-        spherical[7 * nspherical + i] +=  4.9607837082461073 * cart[5 * ncart + i];
+        spherical[7 * nspherical + i] += 4.9607837082461073 * cart[5 * ncart + i];
         spherical[7 * nspherical + i] += -29.7647022494766453 * cart[12 * ncart + i];
-        spherical[7 * nspherical + i] +=  4.9607837082461073 * cart[23 * ncart + i];
-
+        spherical[7 * nspherical + i] += 4.9607837082461073 * cart[23 * ncart + i];
     }
     // R_64s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[8 * nspherical + i]  = -1.9843134832984430 * cart[ncart + i];
-        spherical[8 * nspherical + i] +=  1.9843134832984430 * cart[15 * ncart + i];
-        spherical[8 * nspherical + i] +=  19.8431348329844290 * cart[8 * ncart + i];
+        spherical[8 * nspherical + i] = -1.9843134832984430 * cart[ncart + i];
+        spherical[8 * nspherical + i] += 1.9843134832984430 * cart[15 * ncart + i];
+        spherical[8 * nspherical + i] += 19.8431348329844290 * cart[8 * ncart + i];
         spherical[8 * nspherical + i] += -19.8431348329844290 * cart[17 * ncart + i];
-
     }
 
     // R_65c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[9 * nspherical + i]  =  2.3268138086232857 * cart[2 * ncart + i];
+        spherical[9 * nspherical + i] = 2.3268138086232857 * cart[2 * ncart + i];
         spherical[9 * nspherical + i] += -23.2681380862328560 * cart[7 * ncart + i];
-        spherical[9 * nspherical + i] +=  11.6340690431164280 * cart[16 * ncart + i];
-
+        spherical[9 * nspherical + i] += 11.6340690431164280 * cart[16 * ncart + i];
     }
     // R_65s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[10 * nspherical + i]  =  11.6340690431164280 * cart[4 * ncart + i];
+        spherical[10 * nspherical + i] = 11.6340690431164280 * cart[4 * ncart + i];
         spherical[10 * nspherical + i] += -23.2681380862328560 * cart[11 * ncart + i];
-        spherical[10 * nspherical + i] +=  2.3268138086232857 * cart[22 * ncart + i];
-
+        spherical[10 * nspherical + i] += 2.3268138086232857 * cart[22 * ncart + i];
     }
 
     // R_66c Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[11 * nspherical + i]  =  0.6716932893813962 * cart[i];
+        spherical[11 * nspherical + i] = 0.6716932893813962 * cart[i];
         spherical[11 * nspherical + i] += -10.0753993407209421 * cart[3 * ncart + i];
-        spherical[11 * nspherical + i] +=  10.0753993407209421 * cart[10 * ncart + i];
+        spherical[11 * nspherical + i] += 10.0753993407209421 * cart[10 * ncart + i];
         spherical[11 * nspherical + i] += -0.6716932893813962 * cart[21 * ncart + i];
-
     }
     // R_66s Transform
     for (unsigned long i = 0; i < size; i++) {
-        spherical[12 * nspherical + i]  =  4.0301597362883772 * cart[ncart + i];
+        spherical[12 * nspherical + i] = 4.0301597362883772 * cart[ncart + i];
         spherical[12 * nspherical + i] += -13.4338657876279228 * cart[6 * ncart + i];
-        spherical[12 * nspherical + i] +=  4.0301597362883772 * cart[15 * ncart + i];
-
+        spherical[12 * nspherical + i] += 4.0301597362883772 * cart[15 * ncart + i];
     }
-
 }
-void gg_gaussian_cart_to_spherical_sum_L6(const unsigned long size, const double* vector, const double* PRAGMA_RESTRICT cart, const unsigned long ncart, double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
-    (void)nspherical;
+void gg_gaussian_cart_to_spherical_sum_L6(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
     ASSUME_ALIGNED(cart, 64);
     // temps
     double tmp;
     // R_60 Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.3125000000000000 * cart[i];
+        tmp = -0.3125000000000000 * cart[i];
         tmp += -0.9375000000000000 * cart[3 * ncart + i];
         tmp += -0.9375000000000000 * cart[10 * ncart + i];
         tmp += -0.3125000000000000 * cart[21 * ncart + i];
-        tmp +=  5.6250000000000000 * cart[5 * ncart + i];
-        tmp +=  11.2500000000000000 * cart[12 * ncart + i];
-        tmp +=  5.6250000000000000 * cart[23 * ncart + i];
+        tmp += 5.6250000000000000 * cart[5 * ncart + i];
+        tmp += 11.2500000000000000 * cart[12 * ncart + i];
+        tmp += 5.6250000000000000 * cart[23 * ncart + i];
         tmp += -7.5000000000000000 * cart[14 * ncart + i];
         tmp += -7.5000000000000000 * cart[25 * ncart + i];
         tmp += cart[27 * ncart + i];
         output[i] += tmp * vector[0];
-
     }
 
     // R_61c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.8641098093473998 * cart[2 * ncart + i];
-        tmp +=  5.7282196186947996 * cart[7 * ncart + i];
-        tmp +=  2.8641098093473998 * cart[16 * ncart + i];
+        tmp = 2.8641098093473998 * cart[2 * ncart + i];
+        tmp += 5.7282196186947996 * cart[7 * ncart + i];
+        tmp += 2.8641098093473998 * cart[16 * ncart + i];
         tmp += -11.4564392373895991 * cart[9 * ncart + i];
         tmp += -11.4564392373895991 * cart[18 * ncart + i];
-        tmp +=  4.5825756949558398 * cart[20 * ncart + i];
+        tmp += 4.5825756949558398 * cart[20 * ncart + i];
         output[i] += tmp * vector[1];
-
     }
     // R_61s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.8641098093473998 * cart[4 * ncart + i];
-        tmp +=  5.7282196186947996 * cart[11 * ncart + i];
-        tmp +=  2.8641098093473998 * cart[22 * ncart + i];
+        tmp = 2.8641098093473998 * cart[4 * ncart + i];
+        tmp += 5.7282196186947996 * cart[11 * ncart + i];
+        tmp += 2.8641098093473998 * cart[22 * ncart + i];
         tmp += -11.4564392373895991 * cart[13 * ncart + i];
         tmp += -11.4564392373895991 * cart[24 * ncart + i];
-        tmp +=  4.5825756949558398 * cart[26 * ncart + i];
+        tmp += 4.5825756949558398 * cart[26 * ncart + i];
         output[i] += tmp * vector[2];
-
     }
 
     // R_62c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.4528555233184199 * cart[i];
-        tmp +=  0.4528555233184199 * cart[3 * ncart + i];
+        tmp = 0.4528555233184199 * cart[i];
+        tmp += 0.4528555233184199 * cart[3 * ncart + i];
         tmp += -0.4528555233184199 * cart[10 * ncart + i];
         tmp += -0.4528555233184199 * cart[21 * ncart + i];
         tmp += -7.2456883730947190 * cart[5 * ncart + i];
-        tmp +=  7.2456883730947190 * cart[23 * ncart + i];
-        tmp +=  7.2456883730947190 * cart[14 * ncart + i];
+        tmp += 7.2456883730947190 * cart[23 * ncart + i];
+        tmp += 7.2456883730947190 * cart[14 * ncart + i];
         tmp += -7.2456883730947190 * cart[25 * ncart + i];
         output[i] += tmp * vector[3];
-
     }
     // R_62s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.9057110466368399 * cart[ncart + i];
-        tmp +=  1.8114220932736798 * cart[6 * ncart + i];
-        tmp +=  0.9057110466368399 * cart[15 * ncart + i];
+        tmp = 0.9057110466368399 * cart[ncart + i];
+        tmp += 1.8114220932736798 * cart[6 * ncart + i];
+        tmp += 0.9057110466368399 * cart[15 * ncart + i];
         tmp += -14.4913767461894381 * cart[8 * ncart + i];
         tmp += -14.4913767461894381 * cart[17 * ncart + i];
-        tmp +=  14.4913767461894381 * cart[19 * ncart + i];
+        tmp += 14.4913767461894381 * cart[19 * ncart + i];
         output[i] += tmp * vector[4];
-
     }
 
     // R_63c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -2.7171331399105196 * cart[2 * ncart + i];
-        tmp +=  5.4342662798210393 * cart[7 * ncart + i];
-        tmp +=  8.1513994197315593 * cart[16 * ncart + i];
-        tmp +=  7.2456883730947190 * cart[9 * ncart + i];
+        tmp = -2.7171331399105196 * cart[2 * ncart + i];
+        tmp += 5.4342662798210393 * cart[7 * ncart + i];
+        tmp += 8.1513994197315593 * cart[16 * ncart + i];
+        tmp += 7.2456883730947190 * cart[9 * ncart + i];
         tmp += -21.7370651192841571 * cart[18 * ncart + i];
         output[i] += tmp * vector[5];
-
     }
     // R_63s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -8.1513994197315593 * cart[4 * ncart + i];
+        tmp = -8.1513994197315593 * cart[4 * ncart + i];
         tmp += -5.4342662798210393 * cart[11 * ncart + i];
-        tmp +=  2.7171331399105196 * cart[22 * ncart + i];
-        tmp +=  21.7370651192841571 * cart[13 * ncart + i];
+        tmp += 2.7171331399105196 * cart[22 * ncart + i];
+        tmp += 21.7370651192841571 * cart[13 * ncart + i];
         tmp += -7.2456883730947190 * cart[24 * ncart + i];
         output[i] += tmp * vector[6];
-
     }
 
     // R_64c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -0.4960783708246108 * cart[i];
-        tmp +=  2.4803918541230536 * cart[3 * ncart + i];
-        tmp +=  2.4803918541230536 * cart[10 * ncart + i];
+        tmp = -0.4960783708246108 * cart[i];
+        tmp += 2.4803918541230536 * cart[3 * ncart + i];
+        tmp += 2.4803918541230536 * cart[10 * ncart + i];
         tmp += -0.4960783708246108 * cart[21 * ncart + i];
-        tmp +=  4.9607837082461073 * cart[5 * ncart + i];
+        tmp += 4.9607837082461073 * cart[5 * ncart + i];
         tmp += -29.7647022494766453 * cart[12 * ncart + i];
-        tmp +=  4.9607837082461073 * cart[23 * ncart + i];
+        tmp += 4.9607837082461073 * cart[23 * ncart + i];
         output[i] += tmp * vector[7];
-
     }
     // R_64s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  = -1.9843134832984430 * cart[ncart + i];
-        tmp +=  1.9843134832984430 * cart[15 * ncart + i];
-        tmp +=  19.8431348329844290 * cart[8 * ncart + i];
+        tmp = -1.9843134832984430 * cart[ncart + i];
+        tmp += 1.9843134832984430 * cart[15 * ncart + i];
+        tmp += 19.8431348329844290 * cart[8 * ncart + i];
         tmp += -19.8431348329844290 * cart[17 * ncart + i];
         output[i] += tmp * vector[8];
-
     }
 
     // R_65c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  2.3268138086232857 * cart[2 * ncart + i];
+        tmp = 2.3268138086232857 * cart[2 * ncart + i];
         tmp += -23.2681380862328560 * cart[7 * ncart + i];
-        tmp +=  11.6340690431164280 * cart[16 * ncart + i];
+        tmp += 11.6340690431164280 * cart[16 * ncart + i];
         output[i] += tmp * vector[9];
-
     }
     // R_65s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  11.6340690431164280 * cart[4 * ncart + i];
+        tmp = 11.6340690431164280 * cart[4 * ncart + i];
         tmp += -23.2681380862328560 * cart[11 * ncart + i];
-        tmp +=  2.3268138086232857 * cart[22 * ncart + i];
+        tmp += 2.3268138086232857 * cart[22 * ncart + i];
         output[i] += tmp * vector[10];
-
     }
 
     // R_66c Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  0.6716932893813962 * cart[i];
+        tmp = 0.6716932893813962 * cart[i];
         tmp += -10.0753993407209421 * cart[3 * ncart + i];
-        tmp +=  10.0753993407209421 * cart[10 * ncart + i];
+        tmp += 10.0753993407209421 * cart[10 * ncart + i];
         tmp += -0.6716932893813962 * cart[21 * ncart + i];
         output[i] += tmp * vector[11];
-
     }
     // R_66s Transform
     for (unsigned long i = 0; i < size; i++) {
-        tmp  =  4.0301597362883772 * cart[ncart + i];
+        tmp = 4.0301597362883772 * cart[ncart + i];
         tmp += -13.4338657876279228 * cart[6 * ncart + i];
-        tmp +=  4.0301597362883772 * cart[15 * ncart + i];
+        tmp += 4.0301597362883772 * cart[15 * ncart + i];
         output[i] += tmp * vector[12];
-
+    }
+}
+void gg_gaussian_cart_to_spherical_L7(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical) {
+    ASSUME_ALIGNED(cart, 64);
+    // R_70 Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[i] = -2.1875000000000000 * cart[2 * ncart + i];
+        spherical[i] += -6.5625000000000000 * cart[7 * ncart + i];
+        spherical[i] += -6.5625000000000000 * cart[16 * ncart + i];
+        spherical[i] += -2.1875000000000000 * cart[29 * ncart + i];
+        spherical[i] += 13.1250000000000000 * cart[9 * ncart + i];
+        spherical[i] += 26.2500000000000000 * cart[18 * ncart + i];
+        spherical[i] += 13.1250000000000000 * cart[31 * ncart + i];
+        spherical[i] += -10.5000000000000000 * cart[20 * ncart + i];
+        spherical[i] += -10.5000000000000000 * cart[33 * ncart + i];
+        spherical[i] += cart[35 * ncart + i];
     }
 
-}
-void gg_cca_cart_copy_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
+    // R_71c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[nspherical + i] = -0.4133986423538423 * cart[i];
+        spherical[nspherical + i] += -1.2401959270615268 * cart[3 * ncart + i];
+        spherical[nspherical + i] += -1.2401959270615268 * cart[10 * ncart + i];
+        spherical[nspherical + i] += -0.4133986423538423 * cart[21 * ncart + i];
+        spherical[nspherical + i] += 9.9215674164922145 * cart[5 * ncart + i];
+        spherical[nspherical + i] += 19.8431348329844290 * cart[12 * ncart + i];
+        spherical[nspherical + i] += 9.9215674164922145 * cart[23 * ncart + i];
+        spherical[nspherical + i] += -19.8431348329844290 * cart[14 * ncart + i];
+        spherical[nspherical + i] += -19.8431348329844290 * cart[25 * ncart + i];
+        spherical[nspherical + i] += 5.2915026221291814 * cart[27 * ncart + i];
+    }
+    // R_71s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[2 * nspherical + i] = -0.4133986423538423 * cart[ncart + i];
+        spherical[2 * nspherical + i] += -1.2401959270615268 * cart[6 * ncart + i];
+        spherical[2 * nspherical + i] += -1.2401959270615268 * cart[15 * ncart + i];
+        spherical[2 * nspherical + i] += -0.4133986423538423 * cart[28 * ncart + i];
+        spherical[2 * nspherical + i] += 9.9215674164922145 * cart[8 * ncart + i];
+        spherical[2 * nspherical + i] += 19.8431348329844290 * cart[17 * ncart + i];
+        spherical[2 * nspherical + i] += 9.9215674164922145 * cart[30 * ncart + i];
+        spherical[2 * nspherical + i] += -19.8431348329844290 * cart[19 * ncart + i];
+        spherical[2 * nspherical + i] += -19.8431348329844290 * cart[32 * ncart + i];
+        spherical[2 * nspherical + i] += 5.2915026221291814 * cart[34 * ncart + i];
+    }
 
+    // R_72c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[3 * nspherical + i] = 3.0378472023786847 * cart[2 * ncart + i];
+        spherical[3 * nspherical + i] += 3.0378472023786847 * cart[7 * ncart + i];
+        spherical[3 * nspherical + i] += -3.0378472023786847 * cart[16 * ncart + i];
+        spherical[3 * nspherical + i] += -3.0378472023786847 * cart[29 * ncart + i];
+        spherical[3 * nspherical + i] += -16.2018517460196492 * cart[9 * ncart + i];
+        spherical[3 * nspherical + i] += 16.2018517460196492 * cart[31 * ncart + i];
+        spherical[3 * nspherical + i] += 9.7211110476117906 * cart[20 * ncart + i];
+        spherical[3 * nspherical + i] += -9.7211110476117906 * cart[33 * ncart + i];
+    }
+    // R_72s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[4 * nspherical + i] = 6.0756944047573693 * cart[4 * ncart + i];
+        spherical[4 * nspherical + i] += 12.1513888095147387 * cart[11 * ncart + i];
+        spherical[4 * nspherical + i] += 6.0756944047573693 * cart[22 * ncart + i];
+        spherical[4 * nspherical + i] += -32.4037034920392983 * cart[13 * ncart + i];
+        spherical[4 * nspherical + i] += -32.4037034920392983 * cart[24 * ncart + i];
+        spherical[4 * nspherical + i] += 19.4422220952235811 * cart[26 * ncart + i];
+    }
+
+    // R_73c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[5 * nspherical + i] = 0.4296164714021100 * cart[i];
+        spherical[5 * nspherical + i] += -0.4296164714021100 * cart[3 * ncart + i];
+        spherical[5 * nspherical + i] += -2.1480823570105501 * cart[10 * ncart + i];
+        spherical[5 * nspherical + i] += -1.2888494142063300 * cart[21 * ncart + i];
+        spherical[5 * nspherical + i] += -8.5923294280422002 * cart[5 * ncart + i];
+        spherical[5 * nspherical + i] += 17.1846588560844005 * cart[12 * ncart + i];
+        spherical[5 * nspherical + i] += 25.7769882841265989 * cart[23 * ncart + i];
+        spherical[5 * nspherical + i] += 11.4564392373895991 * cart[14 * ncart + i];
+        spherical[5 * nspherical + i] += -34.3693177121688009 * cart[25 * ncart + i];
+    }
+    // R_73s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[6 * nspherical + i] = 1.2888494142063300 * cart[ncart + i];
+        spherical[6 * nspherical + i] += 2.1480823570105501 * cart[6 * ncart + i];
+        spherical[6 * nspherical + i] += 0.4296164714021100 * cart[15 * ncart + i];
+        spherical[6 * nspherical + i] += -0.4296164714021100 * cart[28 * ncart + i];
+        spherical[6 * nspherical + i] += -25.7769882841265989 * cart[8 * ncart + i];
+        spherical[6 * nspherical + i] += -17.1846588560844005 * cart[17 * ncart + i];
+        spherical[6 * nspherical + i] += 8.5923294280422002 * cart[30 * ncart + i];
+        spherical[6 * nspherical + i] += 34.3693177121688009 * cart[19 * ncart + i];
+        spherical[6 * nspherical + i] += -11.4564392373895991 * cart[32 * ncart + i];
+    }
+
+    // R_74c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[7 * nspherical + i] = -2.8497532787944992 * cart[2 * ncart + i];
+        spherical[7 * nspherical + i] += 14.2487663939724971 * cart[7 * ncart + i];
+        spherical[7 * nspherical + i] += 14.2487663939724971 * cart[16 * ncart + i];
+        spherical[7 * nspherical + i] += -2.8497532787944992 * cart[29 * ncart + i];
+        spherical[7 * nspherical + i] += 9.4991775959816653 * cart[9 * ncart + i];
+        spherical[7 * nspherical + i] += -56.9950655758899885 * cart[18 * ncart + i];
+        spherical[7 * nspherical + i] += 9.4991775959816653 * cart[31 * ncart + i];
+    }
+    // R_74s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[8 * nspherical + i] = -11.3990131151779970 * cart[4 * ncart + i];
+        spherical[8 * nspherical + i] += 11.3990131151779970 * cart[22 * ncart + i];
+        spherical[8 * nspherical + i] += 37.9967103839266613 * cart[13 * ncart + i];
+        spherical[8 * nspherical + i] += -37.9967103839266613 * cart[24 * ncart + i];
+    }
+
+    // R_75c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[9 * nspherical + i] = -0.4749588797990832 * cart[i];
+        spherical[9 * nspherical + i] += 4.2746299181917493 * cart[3 * ncart + i];
+        spherical[9 * nspherical + i] += 2.3747943989954163 * cart[10 * ncart + i];
+        spherical[9 * nspherical + i] += -2.3747943989954163 * cart[21 * ncart + i];
+        spherical[9 * nspherical + i] += 5.6995065575889985 * cart[5 * ncart + i];
+        spherical[9 * nspherical + i] += -56.9950655758899885 * cart[12 * ncart + i];
+        spherical[9 * nspherical + i] += 28.4975327879449942 * cart[23 * ncart + i];
+    }
+    // R_75s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[10 * nspherical + i] = -2.3747943989954163 * cart[ncart + i];
+        spherical[10 * nspherical + i] += 2.3747943989954163 * cart[6 * ncart + i];
+        spherical[10 * nspherical + i] += 4.2746299181917493 * cart[15 * ncart + i];
+        spherical[10 * nspherical + i] += -0.4749588797990832 * cart[28 * ncart + i];
+        spherical[10 * nspherical + i] += 28.4975327879449942 * cart[8 * ncart + i];
+        spherical[10 * nspherical + i] += -56.9950655758899885 * cart[17 * ncart + i];
+        spherical[10 * nspherical + i] += 5.6995065575889985 * cart[30 * ncart + i];
+    }
+
+    // R_76c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[11 * nspherical + i] = 2.4218245962496954 * cart[2 * ncart + i];
+        spherical[11 * nspherical + i] += -36.3273689437454337 * cart[7 * ncart + i];
+        spherical[11 * nspherical + i] += 36.3273689437454337 * cart[16 * ncart + i];
+        spherical[11 * nspherical + i] += -2.4218245962496954 * cart[29 * ncart + i];
+    }
+    // R_76s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[12 * nspherical + i] = 14.5309475774981713 * cart[4 * ncart + i];
+        spherical[12 * nspherical + i] += -48.4364919249939092 * cart[11 * ncart + i];
+        spherical[12 * nspherical + i] += 14.5309475774981713 * cart[22 * ncart + i];
+    }
+
+    // R_77c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[13 * nspherical + i] = 0.6472598492877494 * cart[i];
+        spherical[13 * nspherical + i] += -13.5924568350427357 * cart[3 * ncart + i];
+        spherical[13 * nspherical + i] += 22.6540947250712286 * cart[10 * ncart + i];
+        spherical[13 * nspherical + i] += -4.5308189450142455 * cart[21 * ncart + i];
+    }
+    // R_77s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[14 * nspherical + i] = 4.5308189450142455 * cart[ncart + i];
+        spherical[14 * nspherical + i] += -22.6540947250712286 * cart[6 * ncart + i];
+        spherical[14 * nspherical + i] += 13.5924568350427357 * cart[15 * ncart + i];
+        spherical[14 * nspherical + i] += -0.6472598492877494 * cart[28 * ncart + i];
+    }
+}
+void gg_gaussian_cart_to_spherical_sum_L7(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
+    ASSUME_ALIGNED(cart, 64);
+    // temps
+    double tmp;
+    // R_70 Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -2.1875000000000000 * cart[2 * ncart + i];
+        tmp += -6.5625000000000000 * cart[7 * ncart + i];
+        tmp += -6.5625000000000000 * cart[16 * ncart + i];
+        tmp += -2.1875000000000000 * cart[29 * ncart + i];
+        tmp += 13.1250000000000000 * cart[9 * ncart + i];
+        tmp += 26.2500000000000000 * cart[18 * ncart + i];
+        tmp += 13.1250000000000000 * cart[31 * ncart + i];
+        tmp += -10.5000000000000000 * cart[20 * ncart + i];
+        tmp += -10.5000000000000000 * cart[33 * ncart + i];
+        tmp += cart[35 * ncart + i];
+        output[i] += tmp * vector[0];
+    }
+
+    // R_71c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.4133986423538423 * cart[i];
+        tmp += -1.2401959270615268 * cart[3 * ncart + i];
+        tmp += -1.2401959270615268 * cart[10 * ncart + i];
+        tmp += -0.4133986423538423 * cart[21 * ncart + i];
+        tmp += 9.9215674164922145 * cart[5 * ncart + i];
+        tmp += 19.8431348329844290 * cart[12 * ncart + i];
+        tmp += 9.9215674164922145 * cart[23 * ncart + i];
+        tmp += -19.8431348329844290 * cart[14 * ncart + i];
+        tmp += -19.8431348329844290 * cart[25 * ncart + i];
+        tmp += 5.2915026221291814 * cart[27 * ncart + i];
+        output[i] += tmp * vector[1];
+    }
+    // R_71s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.4133986423538423 * cart[ncart + i];
+        tmp += -1.2401959270615268 * cart[6 * ncart + i];
+        tmp += -1.2401959270615268 * cart[15 * ncart + i];
+        tmp += -0.4133986423538423 * cart[28 * ncart + i];
+        tmp += 9.9215674164922145 * cart[8 * ncart + i];
+        tmp += 19.8431348329844290 * cart[17 * ncart + i];
+        tmp += 9.9215674164922145 * cart[30 * ncart + i];
+        tmp += -19.8431348329844290 * cart[19 * ncart + i];
+        tmp += -19.8431348329844290 * cart[32 * ncart + i];
+        tmp += 5.2915026221291814 * cart[34 * ncart + i];
+        output[i] += tmp * vector[2];
+    }
+
+    // R_72c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 3.0378472023786847 * cart[2 * ncart + i];
+        tmp += 3.0378472023786847 * cart[7 * ncart + i];
+        tmp += -3.0378472023786847 * cart[16 * ncart + i];
+        tmp += -3.0378472023786847 * cart[29 * ncart + i];
+        tmp += -16.2018517460196492 * cart[9 * ncart + i];
+        tmp += 16.2018517460196492 * cart[31 * ncart + i];
+        tmp += 9.7211110476117906 * cart[20 * ncart + i];
+        tmp += -9.7211110476117906 * cart[33 * ncart + i];
+        output[i] += tmp * vector[3];
+    }
+    // R_72s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 6.0756944047573693 * cart[4 * ncart + i];
+        tmp += 12.1513888095147387 * cart[11 * ncart + i];
+        tmp += 6.0756944047573693 * cart[22 * ncart + i];
+        tmp += -32.4037034920392983 * cart[13 * ncart + i];
+        tmp += -32.4037034920392983 * cart[24 * ncart + i];
+        tmp += 19.4422220952235811 * cart[26 * ncart + i];
+        output[i] += tmp * vector[4];
+    }
+
+    // R_73c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 0.4296164714021100 * cart[i];
+        tmp += -0.4296164714021100 * cart[3 * ncart + i];
+        tmp += -2.1480823570105501 * cart[10 * ncart + i];
+        tmp += -1.2888494142063300 * cart[21 * ncart + i];
+        tmp += -8.5923294280422002 * cart[5 * ncart + i];
+        tmp += 17.1846588560844005 * cart[12 * ncart + i];
+        tmp += 25.7769882841265989 * cart[23 * ncart + i];
+        tmp += 11.4564392373895991 * cart[14 * ncart + i];
+        tmp += -34.3693177121688009 * cart[25 * ncart + i];
+        output[i] += tmp * vector[5];
+    }
+    // R_73s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 1.2888494142063300 * cart[ncart + i];
+        tmp += 2.1480823570105501 * cart[6 * ncart + i];
+        tmp += 0.4296164714021100 * cart[15 * ncart + i];
+        tmp += -0.4296164714021100 * cart[28 * ncart + i];
+        tmp += -25.7769882841265989 * cart[8 * ncart + i];
+        tmp += -17.1846588560844005 * cart[17 * ncart + i];
+        tmp += 8.5923294280422002 * cart[30 * ncart + i];
+        tmp += 34.3693177121688009 * cart[19 * ncart + i];
+        tmp += -11.4564392373895991 * cart[32 * ncart + i];
+        output[i] += tmp * vector[6];
+    }
+
+    // R_74c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -2.8497532787944992 * cart[2 * ncart + i];
+        tmp += 14.2487663939724971 * cart[7 * ncart + i];
+        tmp += 14.2487663939724971 * cart[16 * ncart + i];
+        tmp += -2.8497532787944992 * cart[29 * ncart + i];
+        tmp += 9.4991775959816653 * cart[9 * ncart + i];
+        tmp += -56.9950655758899885 * cart[18 * ncart + i];
+        tmp += 9.4991775959816653 * cart[31 * ncart + i];
+        output[i] += tmp * vector[7];
+    }
+    // R_74s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -11.3990131151779970 * cart[4 * ncart + i];
+        tmp += 11.3990131151779970 * cart[22 * ncart + i];
+        tmp += 37.9967103839266613 * cart[13 * ncart + i];
+        tmp += -37.9967103839266613 * cart[24 * ncart + i];
+        output[i] += tmp * vector[8];
+    }
+
+    // R_75c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.4749588797990832 * cart[i];
+        tmp += 4.2746299181917493 * cart[3 * ncart + i];
+        tmp += 2.3747943989954163 * cart[10 * ncart + i];
+        tmp += -2.3747943989954163 * cart[21 * ncart + i];
+        tmp += 5.6995065575889985 * cart[5 * ncart + i];
+        tmp += -56.9950655758899885 * cart[12 * ncart + i];
+        tmp += 28.4975327879449942 * cart[23 * ncart + i];
+        output[i] += tmp * vector[9];
+    }
+    // R_75s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -2.3747943989954163 * cart[ncart + i];
+        tmp += 2.3747943989954163 * cart[6 * ncart + i];
+        tmp += 4.2746299181917493 * cart[15 * ncart + i];
+        tmp += -0.4749588797990832 * cart[28 * ncart + i];
+        tmp += 28.4975327879449942 * cart[8 * ncart + i];
+        tmp += -56.9950655758899885 * cart[17 * ncart + i];
+        tmp += 5.6995065575889985 * cart[30 * ncart + i];
+        output[i] += tmp * vector[10];
+    }
+
+    // R_76c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 2.4218245962496954 * cart[2 * ncart + i];
+        tmp += -36.3273689437454337 * cart[7 * ncart + i];
+        tmp += 36.3273689437454337 * cart[16 * ncart + i];
+        tmp += -2.4218245962496954 * cart[29 * ncart + i];
+        output[i] += tmp * vector[11];
+    }
+    // R_76s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 14.5309475774981713 * cart[4 * ncart + i];
+        tmp += -48.4364919249939092 * cart[11 * ncart + i];
+        tmp += 14.5309475774981713 * cart[22 * ncart + i];
+        output[i] += tmp * vector[12];
+    }
+
+    // R_77c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 0.6472598492877494 * cart[i];
+        tmp += -13.5924568350427357 * cart[3 * ncart + i];
+        tmp += 22.6540947250712286 * cart[10 * ncart + i];
+        tmp += -4.5308189450142455 * cart[21 * ncart + i];
+        output[i] += tmp * vector[13];
+    }
+    // R_77s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 4.5308189450142455 * cart[ncart + i];
+        tmp += -22.6540947250712286 * cart[6 * ncart + i];
+        tmp += 13.5924568350427357 * cart[15 * ncart + i];
+        tmp += -0.6472598492877494 * cart[28 * ncart + i];
+        output[i] += tmp * vector[14];
+    }
+}
+void gg_gaussian_cart_to_spherical_L8(const unsigned long size, const double* PRAGMA_RESTRICT cart,
+                                      const unsigned long ncart, double* PRAGMA_RESTRICT spherical,
+                                      const unsigned long nspherical) {
+    ASSUME_ALIGNED(cart, 64);
+    // R_80 Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[i] = 0.2734375000000000 * cart[i];
+        spherical[i] += 1.0937500000000000 * cart[3 * ncart + i];
+        spherical[i] += 1.6406250000000000 * cart[10 * ncart + i];
+        spherical[i] += 1.0937500000000000 * cart[21 * ncart + i];
+        spherical[i] += 0.2734375000000000 * cart[36 * ncart + i];
+        spherical[i] += -8.7500000000000000 * cart[5 * ncart + i];
+        spherical[i] += -26.2500000000000000 * cart[12 * ncart + i];
+        spherical[i] += -26.2500000000000000 * cart[23 * ncart + i];
+        spherical[i] += -8.7500000000000000 * cart[38 * ncart + i];
+        spherical[i] += 26.2500000000000000 * cart[14 * ncart + i];
+        spherical[i] += 52.5000000000000000 * cart[25 * ncart + i];
+        spherical[i] += 26.2500000000000000 * cart[40 * ncart + i];
+        spherical[i] += -14.0000000000000000 * cart[27 * ncart + i];
+        spherical[i] += -14.0000000000000000 * cart[42 * ncart + i];
+        spherical[i] += cart[44 * ncart + i];
+    }
+
+    // R_81c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[nspherical + i] = -3.2812500000000000 * cart[2 * ncart + i];
+        spherical[nspherical + i] += -9.8437500000000000 * cart[7 * ncart + i];
+        spherical[nspherical + i] += -9.8437500000000000 * cart[16 * ncart + i];
+        spherical[nspherical + i] += -3.2812500000000000 * cart[29 * ncart + i];
+        spherical[nspherical + i] += 26.2500000000000000 * cart[9 * ncart + i];
+        spherical[nspherical + i] += 52.5000000000000000 * cart[18 * ncart + i];
+        spherical[nspherical + i] += 26.2500000000000000 * cart[31 * ncart + i];
+        spherical[nspherical + i] += -31.5000000000000000 * cart[20 * ncart + i];
+        spherical[nspherical + i] += -31.5000000000000000 * cart[33 * ncart + i];
+        spherical[nspherical + i] += 6.0000000000000000 * cart[35 * ncart + i];
+    }
+    // R_81s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[2 * nspherical + i] = -3.2812500000000000 * cart[4 * ncart + i];
+        spherical[2 * nspherical + i] += -9.8437500000000000 * cart[11 * ncart + i];
+        spherical[2 * nspherical + i] += -9.8437500000000000 * cart[22 * ncart + i];
+        spherical[2 * nspherical + i] += -3.2812500000000000 * cart[37 * ncart + i];
+        spherical[2 * nspherical + i] += 26.2500000000000000 * cart[13 * ncart + i];
+        spherical[2 * nspherical + i] += 52.5000000000000000 * cart[24 * ncart + i];
+        spherical[2 * nspherical + i] += 26.2500000000000000 * cart[39 * ncart + i];
+        spherical[2 * nspherical + i] += -31.5000000000000000 * cart[26 * ncart + i];
+        spherical[2 * nspherical + i] += -31.5000000000000000 * cart[41 * ncart + i];
+        spherical[2 * nspherical + i] += 6.0000000000000000 * cart[43 * ncart + i];
+    }
+
+    // R_82c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[3 * nspherical + i] = -0.3921843874378479 * cart[i];
+        spherical[3 * nspherical + i] += -0.7843687748756958 * cart[3 * ncart + i];
+        spherical[3 * nspherical + i] += 0.7843687748756958 * cart[21 * ncart + i];
+        spherical[3 * nspherical + i] += 0.3921843874378479 * cart[36 * ncart + i];
+        spherical[3 * nspherical + i] += 11.7655316231354377 * cart[5 * ncart + i];
+        spherical[3 * nspherical + i] += 11.7655316231354377 * cart[12 * ncart + i];
+        spherical[3 * nspherical + i] += -11.7655316231354377 * cart[23 * ncart + i];
+        spherical[3 * nspherical + i] += -11.7655316231354377 * cart[38 * ncart + i];
+        spherical[3 * nspherical + i] += -31.3747509950278314 * cart[14 * ncart + i];
+        spherical[3 * nspherical + i] += 31.3747509950278314 * cart[40 * ncart + i];
+        spherical[3 * nspherical + i] += 12.5499003980111326 * cart[27 * ncart + i];
+        spherical[3 * nspherical + i] += -12.5499003980111326 * cart[42 * ncart + i];
+    }
+    // R_82s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[4 * nspherical + i] = -0.7843687748756958 * cart[ncart + i];
+        spherical[4 * nspherical + i] += -2.3531063246270874 * cart[6 * ncart + i];
+        spherical[4 * nspherical + i] += -2.3531063246270874 * cart[15 * ncart + i];
+        spherical[4 * nspherical + i] += -0.7843687748756958 * cart[28 * ncart + i];
+        spherical[4 * nspherical + i] += 23.5310632462708753 * cart[8 * ncart + i];
+        spherical[4 * nspherical + i] += 47.0621264925417506 * cart[17 * ncart + i];
+        spherical[4 * nspherical + i] += 23.5310632462708753 * cart[30 * ncart + i];
+        spherical[4 * nspherical + i] += -62.7495019900556628 * cart[19 * ncart + i];
+        spherical[4 * nspherical + i] += -62.7495019900556628 * cart[32 * ncart + i];
+        spherical[4 * nspherical + i] += 25.0998007960222651 * cart[34 * ncart + i];
+    }
+
+    // R_83c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[5 * nspherical + i] = 3.1861210252437053 * cart[2 * ncart + i];
+        spherical[5 * nspherical + i] += -3.1861210252437053 * cart[7 * ncart + i];
+        spherical[5 * nspherical + i] += -15.9306051262185271 * cart[16 * ncart + i];
+        spherical[5 * nspherical + i] += -9.5583630757311155 * cart[29 * ncart + i];
+        spherical[5 * nspherical + i] += -21.2408068349580361 * cart[9 * ncart + i];
+        spherical[5 * nspherical + i] += 42.4816136699160722 * cart[18 * ncart + i];
+        spherical[5 * nspherical + i] += 63.7224205048741084 * cart[31 * ncart + i];
+        spherical[5 * nspherical + i] += 16.9926454679664296 * cart[20 * ncart + i];
+        spherical[5 * nspherical + i] += -50.9779364038992853 * cart[33 * ncart + i];
+    }
+    // R_83s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[6 * nspherical + i] = 9.5583630757311155 * cart[4 * ncart + i];
+        spherical[6 * nspherical + i] += 15.9306051262185271 * cart[11 * ncart + i];
+        spherical[6 * nspherical + i] += 3.1861210252437053 * cart[22 * ncart + i];
+        spherical[6 * nspherical + i] += -3.1861210252437053 * cart[37 * ncart + i];
+        spherical[6 * nspherical + i] += -63.7224205048741084 * cart[13 * ncart + i];
+        spherical[6 * nspherical + i] += -42.4816136699160722 * cart[24 * ncart + i];
+        spherical[6 * nspherical + i] += 21.2408068349580361 * cart[39 * ncart + i];
+        spherical[6 * nspherical + i] += 50.9779364038992853 * cart[26 * ncart + i];
+        spherical[6 * nspherical + i] += -16.9926454679664296 * cart[41 * ncart + i];
+    }
+
+    // R_84c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[7 * nspherical + i] = 0.4113264556590057 * cart[i];
+        spherical[7 * nspherical + i] += -1.6453058226360229 * cart[3 * ncart + i];
+        spherical[7 * nspherical + i] += -4.1132645565900576 * cart[10 * ncart + i];
+        spherical[7 * nspherical + i] += -1.6453058226360229 * cart[21 * ncart + i];
+        spherical[7 * nspherical + i] += 0.4113264556590057 * cart[36 * ncart + i];
+        spherical[7 * nspherical + i] += -9.8718349358161372 * cart[5 * ncart + i];
+        spherical[7 * nspherical + i] += 49.3591746790806880 * cart[12 * ncart + i];
+        spherical[7 * nspherical + i] += 49.3591746790806880 * cart[23 * ncart + i];
+        spherical[7 * nspherical + i] += -9.8718349358161372 * cart[38 * ncart + i];
+        spherical[7 * nspherical + i] += 16.4530582263602305 * cart[14 * ncart + i];
+        spherical[7 * nspherical + i] += -98.7183493581613760 * cart[25 * ncart + i];
+        spherical[7 * nspherical + i] += 16.4530582263602305 * cart[40 * ncart + i];
+    }
+    // R_84s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[8 * nspherical + i] = 1.6453058226360229 * cart[ncart + i];
+        spherical[8 * nspherical + i] += 1.6453058226360229 * cart[6 * ncart + i];
+        spherical[8 * nspherical + i] += -1.6453058226360229 * cart[15 * ncart + i];
+        spherical[8 * nspherical + i] += -1.6453058226360229 * cart[28 * ncart + i];
+        spherical[8 * nspherical + i] += -39.4873397432645490 * cart[8 * ncart + i];
+        spherical[8 * nspherical + i] += 39.4873397432645490 * cart[30 * ncart + i];
+        spherical[8 * nspherical + i] += 65.8122329054409221 * cart[19 * ncart + i];
+        spherical[8 * nspherical + i] += -65.8122329054409221 * cart[32 * ncart + i];
+    }
+
+    // R_85c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[9 * nspherical + i] = -2.9661172536668201 * cart[2 * ncart + i];
+        spherical[9 * nspherical + i] += 26.6950552830013805 * cart[7 * ncart + i];
+        spherical[9 * nspherical + i] += 14.8305862683341019 * cart[16 * ncart + i];
+        spherical[9 * nspherical + i] += -14.8305862683341019 * cart[29 * ncart + i];
+        spherical[9 * nspherical + i] += 11.8644690146672804 * cart[9 * ncart + i];
+        spherical[9 * nspherical + i] += -118.6446901466728150 * cart[18 * ncart + i];
+        spherical[9 * nspherical + i] += 59.3223450733364075 * cart[31 * ncart + i];
+    }
+    // R_85s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[10 * nspherical + i] = -14.8305862683341019 * cart[4 * ncart + i];
+        spherical[10 * nspherical + i] += 14.8305862683341019 * cart[11 * ncart + i];
+        spherical[10 * nspherical + i] += 26.6950552830013805 * cart[22 * ncart + i];
+        spherical[10 * nspherical + i] += -2.9661172536668201 * cart[37 * ncart + i];
+        spherical[10 * nspherical + i] += 59.3223450733364075 * cart[13 * ncart + i];
+        spherical[10 * nspherical + i] += -118.6446901466728150 * cart[24 * ncart + i];
+        spherical[10 * nspherical + i] += 11.8644690146672804 * cart[39 * ncart + i];
+    }
+
+    // R_86c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[11 * nspherical + i] = -0.4576818286211503 * cart[i];
+        spherical[11 * nspherical + i] += 6.4075456006961042 * cart[3 * ncart + i];
+        spherical[11 * nspherical + i] += -6.4075456006961042 * cart[21 * ncart + i];
+        spherical[11 * nspherical + i] += 0.4576818286211503 * cart[36 * ncart + i];
+        spherical[11 * nspherical + i] += 6.4075456006961042 * cart[5 * ncart + i];
+        spherical[11 * nspherical + i] += -96.1131840104415573 * cart[12 * ncart + i];
+        spherical[11 * nspherical + i] += 96.1131840104415573 * cart[23 * ncart + i];
+        spherical[11 * nspherical + i] += -6.4075456006961042 * cart[38 * ncart + i];
+    }
+    // R_86s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[12 * nspherical + i] = -2.7460909717269018 * cart[ncart + i];
+        spherical[12 * nspherical + i] += 6.4075456006961042 * cart[6 * ncart + i];
+        spherical[12 * nspherical + i] += 6.4075456006961042 * cart[15 * ncart + i];
+        spherical[12 * nspherical + i] += -2.7460909717269018 * cart[28 * ncart + i];
+        spherical[12 * nspherical + i] += 38.4452736041766272 * cart[8 * ncart + i];
+        spherical[12 * nspherical + i] += -128.1509120139220954 * cart[17 * ncart + i];
+        spherical[12 * nspherical + i] += 38.4452736041766272 * cart[30 * ncart + i];
+    }
+
+    // R_87c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[13 * nspherical + i] = 2.5068266169601756 * cart[2 * ncart + i];
+        spherical[13 * nspherical + i] += -52.6433589561636950 * cart[7 * ncart + i];
+        spherical[13 * nspherical + i] += 87.7389315936061536 * cart[16 * ncart + i];
+        spherical[13 * nspherical + i] += -17.5477863187212293 * cart[29 * ncart + i];
+    }
+    // R_87s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[14 * nspherical + i] = 17.5477863187212293 * cart[4 * ncart + i];
+        spherical[14 * nspherical + i] += -87.7389315936061536 * cart[11 * ncart + i];
+        spherical[14 * nspherical + i] += 52.6433589561636950 * cart[22 * ncart + i];
+        spherical[14 * nspherical + i] += -2.5068266169601756 * cart[37 * ncart + i];
+    }
+
+    // R_88c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[15 * nspherical + i] = 0.6267066542400439 * cart[i];
+        spherical[15 * nspherical + i] += -17.5477863187212293 * cart[3 * ncart + i];
+        spherical[15 * nspherical + i] += 43.8694657968030768 * cart[10 * ncart + i];
+        spherical[15 * nspherical + i] += -17.5477863187212293 * cart[21 * ncart + i];
+        spherical[15 * nspherical + i] += 0.6267066542400439 * cart[36 * ncart + i];
+    }
+    // R_88s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        spherical[16 * nspherical + i] = 5.0136532339203512 * cart[ncart + i];
+        spherical[16 * nspherical + i] += -35.0955726374424586 * cart[6 * ncart + i];
+        spherical[16 * nspherical + i] += 35.0955726374424586 * cart[15 * ncart + i];
+        spherical[16 * nspherical + i] += -5.0136532339203512 * cart[28 * ncart + i];
+    }
+}
+void gg_gaussian_cart_to_spherical_sum_L8(const unsigned long size, const double* vector,
+                                          const double* PRAGMA_RESTRICT cart, const unsigned long ncart,
+                                          double* PRAGMA_RESTRICT output, const unsigned long nspherical) {
+    ASSUME_ALIGNED(cart, 64);
+    // temps
+    double tmp;
+    // R_80 Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 0.2734375000000000 * cart[i];
+        tmp += 1.0937500000000000 * cart[3 * ncart + i];
+        tmp += 1.6406250000000000 * cart[10 * ncart + i];
+        tmp += 1.0937500000000000 * cart[21 * ncart + i];
+        tmp += 0.2734375000000000 * cart[36 * ncart + i];
+        tmp += -8.7500000000000000 * cart[5 * ncart + i];
+        tmp += -26.2500000000000000 * cart[12 * ncart + i];
+        tmp += -26.2500000000000000 * cart[23 * ncart + i];
+        tmp += -8.7500000000000000 * cart[38 * ncart + i];
+        tmp += 26.2500000000000000 * cart[14 * ncart + i];
+        tmp += 52.5000000000000000 * cart[25 * ncart + i];
+        tmp += 26.2500000000000000 * cart[40 * ncart + i];
+        tmp += -14.0000000000000000 * cart[27 * ncart + i];
+        tmp += -14.0000000000000000 * cart[42 * ncart + i];
+        tmp += cart[44 * ncart + i];
+        output[i] += tmp * vector[0];
+    }
+
+    // R_81c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -3.2812500000000000 * cart[2 * ncart + i];
+        tmp += -9.8437500000000000 * cart[7 * ncart + i];
+        tmp += -9.8437500000000000 * cart[16 * ncart + i];
+        tmp += -3.2812500000000000 * cart[29 * ncart + i];
+        tmp += 26.2500000000000000 * cart[9 * ncart + i];
+        tmp += 52.5000000000000000 * cart[18 * ncart + i];
+        tmp += 26.2500000000000000 * cart[31 * ncart + i];
+        tmp += -31.5000000000000000 * cart[20 * ncart + i];
+        tmp += -31.5000000000000000 * cart[33 * ncart + i];
+        tmp += 6.0000000000000000 * cart[35 * ncart + i];
+        output[i] += tmp * vector[1];
+    }
+    // R_81s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -3.2812500000000000 * cart[4 * ncart + i];
+        tmp += -9.8437500000000000 * cart[11 * ncart + i];
+        tmp += -9.8437500000000000 * cart[22 * ncart + i];
+        tmp += -3.2812500000000000 * cart[37 * ncart + i];
+        tmp += 26.2500000000000000 * cart[13 * ncart + i];
+        tmp += 52.5000000000000000 * cart[24 * ncart + i];
+        tmp += 26.2500000000000000 * cart[39 * ncart + i];
+        tmp += -31.5000000000000000 * cart[26 * ncart + i];
+        tmp += -31.5000000000000000 * cart[41 * ncart + i];
+        tmp += 6.0000000000000000 * cart[43 * ncart + i];
+        output[i] += tmp * vector[2];
+    }
+
+    // R_82c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.3921843874378479 * cart[i];
+        tmp += -0.7843687748756958 * cart[3 * ncart + i];
+        tmp += 0.7843687748756958 * cart[21 * ncart + i];
+        tmp += 0.3921843874378479 * cart[36 * ncart + i];
+        tmp += 11.7655316231354377 * cart[5 * ncart + i];
+        tmp += 11.7655316231354377 * cart[12 * ncart + i];
+        tmp += -11.7655316231354377 * cart[23 * ncart + i];
+        tmp += -11.7655316231354377 * cart[38 * ncart + i];
+        tmp += -31.3747509950278314 * cart[14 * ncart + i];
+        tmp += 31.3747509950278314 * cart[40 * ncart + i];
+        tmp += 12.5499003980111326 * cart[27 * ncart + i];
+        tmp += -12.5499003980111326 * cart[42 * ncart + i];
+        output[i] += tmp * vector[3];
+    }
+    // R_82s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.7843687748756958 * cart[ncart + i];
+        tmp += -2.3531063246270874 * cart[6 * ncart + i];
+        tmp += -2.3531063246270874 * cart[15 * ncart + i];
+        tmp += -0.7843687748756958 * cart[28 * ncart + i];
+        tmp += 23.5310632462708753 * cart[8 * ncart + i];
+        tmp += 47.0621264925417506 * cart[17 * ncart + i];
+        tmp += 23.5310632462708753 * cart[30 * ncart + i];
+        tmp += -62.7495019900556628 * cart[19 * ncart + i];
+        tmp += -62.7495019900556628 * cart[32 * ncart + i];
+        tmp += 25.0998007960222651 * cart[34 * ncart + i];
+        output[i] += tmp * vector[4];
+    }
+
+    // R_83c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 3.1861210252437053 * cart[2 * ncart + i];
+        tmp += -3.1861210252437053 * cart[7 * ncart + i];
+        tmp += -15.9306051262185271 * cart[16 * ncart + i];
+        tmp += -9.5583630757311155 * cart[29 * ncart + i];
+        tmp += -21.2408068349580361 * cart[9 * ncart + i];
+        tmp += 42.4816136699160722 * cart[18 * ncart + i];
+        tmp += 63.7224205048741084 * cart[31 * ncart + i];
+        tmp += 16.9926454679664296 * cart[20 * ncart + i];
+        tmp += -50.9779364038992853 * cart[33 * ncart + i];
+        output[i] += tmp * vector[5];
+    }
+    // R_83s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 9.5583630757311155 * cart[4 * ncart + i];
+        tmp += 15.9306051262185271 * cart[11 * ncart + i];
+        tmp += 3.1861210252437053 * cart[22 * ncart + i];
+        tmp += -3.1861210252437053 * cart[37 * ncart + i];
+        tmp += -63.7224205048741084 * cart[13 * ncart + i];
+        tmp += -42.4816136699160722 * cart[24 * ncart + i];
+        tmp += 21.2408068349580361 * cart[39 * ncart + i];
+        tmp += 50.9779364038992853 * cart[26 * ncart + i];
+        tmp += -16.9926454679664296 * cart[41 * ncart + i];
+        output[i] += tmp * vector[6];
+    }
+
+    // R_84c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 0.4113264556590057 * cart[i];
+        tmp += -1.6453058226360229 * cart[3 * ncart + i];
+        tmp += -4.1132645565900576 * cart[10 * ncart + i];
+        tmp += -1.6453058226360229 * cart[21 * ncart + i];
+        tmp += 0.4113264556590057 * cart[36 * ncart + i];
+        tmp += -9.8718349358161372 * cart[5 * ncart + i];
+        tmp += 49.3591746790806880 * cart[12 * ncart + i];
+        tmp += 49.3591746790806880 * cart[23 * ncart + i];
+        tmp += -9.8718349358161372 * cart[38 * ncart + i];
+        tmp += 16.4530582263602305 * cart[14 * ncart + i];
+        tmp += -98.7183493581613760 * cart[25 * ncart + i];
+        tmp += 16.4530582263602305 * cart[40 * ncart + i];
+        output[i] += tmp * vector[7];
+    }
+    // R_84s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 1.6453058226360229 * cart[ncart + i];
+        tmp += 1.6453058226360229 * cart[6 * ncart + i];
+        tmp += -1.6453058226360229 * cart[15 * ncart + i];
+        tmp += -1.6453058226360229 * cart[28 * ncart + i];
+        tmp += -39.4873397432645490 * cart[8 * ncart + i];
+        tmp += 39.4873397432645490 * cart[30 * ncart + i];
+        tmp += 65.8122329054409221 * cart[19 * ncart + i];
+        tmp += -65.8122329054409221 * cart[32 * ncart + i];
+        output[i] += tmp * vector[8];
+    }
+
+    // R_85c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -2.9661172536668201 * cart[2 * ncart + i];
+        tmp += 26.6950552830013805 * cart[7 * ncart + i];
+        tmp += 14.8305862683341019 * cart[16 * ncart + i];
+        tmp += -14.8305862683341019 * cart[29 * ncart + i];
+        tmp += 11.8644690146672804 * cart[9 * ncart + i];
+        tmp += -118.6446901466728150 * cart[18 * ncart + i];
+        tmp += 59.3223450733364075 * cart[31 * ncart + i];
+        output[i] += tmp * vector[9];
+    }
+    // R_85s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -14.8305862683341019 * cart[4 * ncart + i];
+        tmp += 14.8305862683341019 * cart[11 * ncart + i];
+        tmp += 26.6950552830013805 * cart[22 * ncart + i];
+        tmp += -2.9661172536668201 * cart[37 * ncart + i];
+        tmp += 59.3223450733364075 * cart[13 * ncart + i];
+        tmp += -118.6446901466728150 * cart[24 * ncart + i];
+        tmp += 11.8644690146672804 * cart[39 * ncart + i];
+        output[i] += tmp * vector[10];
+    }
+
+    // R_86c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -0.4576818286211503 * cart[i];
+        tmp += 6.4075456006961042 * cart[3 * ncart + i];
+        tmp += -6.4075456006961042 * cart[21 * ncart + i];
+        tmp += 0.4576818286211503 * cart[36 * ncart + i];
+        tmp += 6.4075456006961042 * cart[5 * ncart + i];
+        tmp += -96.1131840104415573 * cart[12 * ncart + i];
+        tmp += 96.1131840104415573 * cart[23 * ncart + i];
+        tmp += -6.4075456006961042 * cart[38 * ncart + i];
+        output[i] += tmp * vector[11];
+    }
+    // R_86s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = -2.7460909717269018 * cart[ncart + i];
+        tmp += 6.4075456006961042 * cart[6 * ncart + i];
+        tmp += 6.4075456006961042 * cart[15 * ncart + i];
+        tmp += -2.7460909717269018 * cart[28 * ncart + i];
+        tmp += 38.4452736041766272 * cart[8 * ncart + i];
+        tmp += -128.1509120139220954 * cart[17 * ncart + i];
+        tmp += 38.4452736041766272 * cart[30 * ncart + i];
+        output[i] += tmp * vector[12];
+    }
+
+    // R_87c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 2.5068266169601756 * cart[2 * ncart + i];
+        tmp += -52.6433589561636950 * cart[7 * ncart + i];
+        tmp += 87.7389315936061536 * cart[16 * ncart + i];
+        tmp += -17.5477863187212293 * cart[29 * ncart + i];
+        output[i] += tmp * vector[13];
+    }
+    // R_87s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 17.5477863187212293 * cart[4 * ncart + i];
+        tmp += -87.7389315936061536 * cart[11 * ncart + i];
+        tmp += 52.6433589561636950 * cart[22 * ncart + i];
+        tmp += -2.5068266169601756 * cart[37 * ncart + i];
+        output[i] += tmp * vector[14];
+    }
+
+    // R_88c Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 0.6267066542400439 * cart[i];
+        tmp += -17.5477863187212293 * cart[3 * ncart + i];
+        tmp += 43.8694657968030768 * cart[10 * ncart + i];
+        tmp += -17.5477863187212293 * cart[21 * ncart + i];
+        tmp += 0.6267066542400439 * cart[36 * ncart + i];
+        output[i] += tmp * vector[15];
+    }
+    // R_88s Transform
+    for (unsigned long i = 0; i < size; i++) {
+        tmp = 5.0136532339203512 * cart[ncart + i];
+        tmp += -35.0955726374424586 * cart[6 * ncart + i];
+        tmp += 35.0955726374424586 * cart[15 * ncart + i];
+        tmp += -5.0136532339203512 * cart[28 * ncart + i];
+        output[i] += tmp * vector[16];
+    }
+}
+void gg_cca_cart_copy_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -1847,9 +3188,9 @@ void gg_cca_cart_copy_L0(const unsigned long size, const double* PRAGMA_RESTRICT
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_cca_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_cca_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -1861,8 +3202,9 @@ void gg_cca_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRICT 
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_cca_cart_copy_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-
+void gg_cca_cart_copy_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -1888,9 +3230,9 @@ void gg_cca_cart_copy_L1(const unsigned long size, const double* PRAGMA_RESTRICT
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_cca_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_cca_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -1916,8 +3258,9 @@ void gg_cca_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRICT 
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_cca_cart_copy_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-
+void gg_cca_cart_copy_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -1964,9 +3307,9 @@ void gg_cca_cart_copy_L2(const unsigned long size, const double* PRAGMA_RESTRICT
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_cca_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_cca_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -2013,8 +3356,9 @@ void gg_cca_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRICT 
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_cca_cart_copy_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-
+void gg_cca_cart_copy_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -2089,9 +3433,9 @@ void gg_cca_cart_copy_L3(const unsigned long size, const double* PRAGMA_RESTRICT
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_cca_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_cca_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -2166,8 +3510,9 @@ void gg_cca_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRICT 
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_cca_cart_copy_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-
+void gg_cca_cart_copy_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -2277,9 +3622,9 @@ void gg_cca_cart_copy_L4(const unsigned long size, const double* PRAGMA_RESTRICT
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_cca_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_cca_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -2389,8 +3734,9 @@ void gg_cca_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRICT 
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_cca_cart_copy_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-
+void gg_cca_cart_copy_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -2542,9 +3888,9 @@ void gg_cca_cart_copy_L5(const unsigned long size, const double* PRAGMA_RESTRICT
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_cca_cart_sum_L5(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_cca_cart_sum_L5(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -2696,8 +4042,9 @@ void gg_cca_cart_sum_L5(const unsigned long size, const double* PRAGMA_RESTRICT 
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_cca_cart_copy_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-
+void gg_cca_cart_copy_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -2898,9 +4245,9 @@ void gg_cca_cart_copy_L6(const unsigned long size, const double* PRAGMA_RESTRICT
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_cca_cart_sum_L6(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_cca_cart_sum_L6(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -3101,8 +4448,1173 @@ void gg_cca_cart_sum_L6(const unsigned long size, const double* PRAGMA_RESTRICT 
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_molden_cart_copy_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
+void gg_cca_cart_copy_L7(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out) {
+    ASSUME_ALIGNED(cart_input, 64);
+    unsigned long inp_shift;
+    unsigned long out_shift;
 
+    // Copy (7, 0, 0)
+    inp_shift = 0 * ncart_input;
+    out_shift = 0 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (6, 1, 0)
+    inp_shift = 1 * ncart_input;
+    out_shift = 1 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (6, 0, 1)
+    inp_shift = 2 * ncart_input;
+    out_shift = 2 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (5, 2, 0)
+    inp_shift = 3 * ncart_input;
+    out_shift = 3 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (5, 1, 1)
+    inp_shift = 4 * ncart_input;
+    out_shift = 4 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (5, 0, 2)
+    inp_shift = 5 * ncart_input;
+    out_shift = 5 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (4, 3, 0)
+    inp_shift = 6 * ncart_input;
+    out_shift = 6 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (4, 2, 1)
+    inp_shift = 7 * ncart_input;
+    out_shift = 7 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (4, 1, 2)
+    inp_shift = 8 * ncart_input;
+    out_shift = 8 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (4, 0, 3)
+    inp_shift = 9 * ncart_input;
+    out_shift = 9 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (3, 4, 0)
+    inp_shift = 10 * ncart_input;
+    out_shift = 10 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (3, 3, 1)
+    inp_shift = 11 * ncart_input;
+    out_shift = 11 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (3, 2, 2)
+    inp_shift = 12 * ncart_input;
+    out_shift = 12 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (3, 1, 3)
+    inp_shift = 13 * ncart_input;
+    out_shift = 13 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (3, 0, 4)
+    inp_shift = 14 * ncart_input;
+    out_shift = 14 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 5, 0)
+    inp_shift = 15 * ncart_input;
+    out_shift = 15 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 4, 1)
+    inp_shift = 16 * ncart_input;
+    out_shift = 16 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 3, 2)
+    inp_shift = 17 * ncart_input;
+    out_shift = 17 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 2, 3)
+    inp_shift = 18 * ncart_input;
+    out_shift = 18 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 1, 4)
+    inp_shift = 19 * ncart_input;
+    out_shift = 19 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 0, 5)
+    inp_shift = 20 * ncart_input;
+    out_shift = 20 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 6, 0)
+    inp_shift = 21 * ncart_input;
+    out_shift = 21 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 5, 1)
+    inp_shift = 22 * ncart_input;
+    out_shift = 22 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 4, 2)
+    inp_shift = 23 * ncart_input;
+    out_shift = 23 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 3, 3)
+    inp_shift = 24 * ncart_input;
+    out_shift = 24 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 2, 4)
+    inp_shift = 25 * ncart_input;
+    out_shift = 25 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 1, 5)
+    inp_shift = 26 * ncart_input;
+    out_shift = 26 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 0, 6)
+    inp_shift = 27 * ncart_input;
+    out_shift = 27 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 7, 0)
+    inp_shift = 28 * ncart_input;
+    out_shift = 28 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 6, 1)
+    inp_shift = 29 * ncart_input;
+    out_shift = 29 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 5, 2)
+    inp_shift = 30 * ncart_input;
+    out_shift = 30 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 4, 3)
+    inp_shift = 31 * ncart_input;
+    out_shift = 31 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 3, 4)
+    inp_shift = 32 * ncart_input;
+    out_shift = 32 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 2, 5)
+    inp_shift = 33 * ncart_input;
+    out_shift = 33 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 1, 6)
+    inp_shift = 34 * ncart_input;
+    out_shift = 34 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 0, 7)
+    inp_shift = 35 * ncart_input;
+    out_shift = 35 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+}
+void gg_cca_cart_sum_L7(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
+    ASSUME_ALIGNED(cart_input, 64);
+    unsigned long in_shift;
+    unsigned long out_shift;
+    double coef;
+
+    // Copy (7, 0, 0)
+    in_shift = 0 * ncart_input;
+    coef = vector[0];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (6, 1, 0)
+    in_shift = 1 * ncart_input;
+    coef = vector[1];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (6, 0, 1)
+    in_shift = 2 * ncart_input;
+    coef = vector[2];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (5, 2, 0)
+    in_shift = 3 * ncart_input;
+    coef = vector[3];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (5, 1, 1)
+    in_shift = 4 * ncart_input;
+    coef = vector[4];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (5, 0, 2)
+    in_shift = 5 * ncart_input;
+    coef = vector[5];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (4, 3, 0)
+    in_shift = 6 * ncart_input;
+    coef = vector[6];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (4, 2, 1)
+    in_shift = 7 * ncart_input;
+    coef = vector[7];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (4, 1, 2)
+    in_shift = 8 * ncart_input;
+    coef = vector[8];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (4, 0, 3)
+    in_shift = 9 * ncart_input;
+    coef = vector[9];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (3, 4, 0)
+    in_shift = 10 * ncart_input;
+    coef = vector[10];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (3, 3, 1)
+    in_shift = 11 * ncart_input;
+    coef = vector[11];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (3, 2, 2)
+    in_shift = 12 * ncart_input;
+    coef = vector[12];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (3, 1, 3)
+    in_shift = 13 * ncart_input;
+    coef = vector[13];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (3, 0, 4)
+    in_shift = 14 * ncart_input;
+    coef = vector[14];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 5, 0)
+    in_shift = 15 * ncart_input;
+    coef = vector[15];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 4, 1)
+    in_shift = 16 * ncart_input;
+    coef = vector[16];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 3, 2)
+    in_shift = 17 * ncart_input;
+    coef = vector[17];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 2, 3)
+    in_shift = 18 * ncart_input;
+    coef = vector[18];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 1, 4)
+    in_shift = 19 * ncart_input;
+    coef = vector[19];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 0, 5)
+    in_shift = 20 * ncart_input;
+    coef = vector[20];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 6, 0)
+    in_shift = 21 * ncart_input;
+    coef = vector[21];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 5, 1)
+    in_shift = 22 * ncart_input;
+    coef = vector[22];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 4, 2)
+    in_shift = 23 * ncart_input;
+    coef = vector[23];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 3, 3)
+    in_shift = 24 * ncart_input;
+    coef = vector[24];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 2, 4)
+    in_shift = 25 * ncart_input;
+    coef = vector[25];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 1, 5)
+    in_shift = 26 * ncart_input;
+    coef = vector[26];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 0, 6)
+    in_shift = 27 * ncart_input;
+    coef = vector[27];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 7, 0)
+    in_shift = 28 * ncart_input;
+    coef = vector[28];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 6, 1)
+    in_shift = 29 * ncart_input;
+    coef = vector[29];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 5, 2)
+    in_shift = 30 * ncart_input;
+    coef = vector[30];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 4, 3)
+    in_shift = 31 * ncart_input;
+    coef = vector[31];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 3, 4)
+    in_shift = 32 * ncart_input;
+    coef = vector[32];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 2, 5)
+    in_shift = 33 * ncart_input;
+    coef = vector[33];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 1, 6)
+    in_shift = 34 * ncart_input;
+    coef = vector[34];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 0, 7)
+    in_shift = 35 * ncart_input;
+    coef = vector[35];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+}
+void gg_cca_cart_copy_L8(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                         const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                         const unsigned long ncart_out) {
+    ASSUME_ALIGNED(cart_input, 64);
+    unsigned long inp_shift;
+    unsigned long out_shift;
+
+    // Copy (8, 0, 0)
+    inp_shift = 0 * ncart_input;
+    out_shift = 0 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (7, 1, 0)
+    inp_shift = 1 * ncart_input;
+    out_shift = 1 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (7, 0, 1)
+    inp_shift = 2 * ncart_input;
+    out_shift = 2 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (6, 2, 0)
+    inp_shift = 3 * ncart_input;
+    out_shift = 3 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (6, 1, 1)
+    inp_shift = 4 * ncart_input;
+    out_shift = 4 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (6, 0, 2)
+    inp_shift = 5 * ncart_input;
+    out_shift = 5 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (5, 3, 0)
+    inp_shift = 6 * ncart_input;
+    out_shift = 6 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (5, 2, 1)
+    inp_shift = 7 * ncart_input;
+    out_shift = 7 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (5, 1, 2)
+    inp_shift = 8 * ncart_input;
+    out_shift = 8 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (5, 0, 3)
+    inp_shift = 9 * ncart_input;
+    out_shift = 9 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (4, 4, 0)
+    inp_shift = 10 * ncart_input;
+    out_shift = 10 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (4, 3, 1)
+    inp_shift = 11 * ncart_input;
+    out_shift = 11 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (4, 2, 2)
+    inp_shift = 12 * ncart_input;
+    out_shift = 12 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (4, 1, 3)
+    inp_shift = 13 * ncart_input;
+    out_shift = 13 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (4, 0, 4)
+    inp_shift = 14 * ncart_input;
+    out_shift = 14 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (3, 5, 0)
+    inp_shift = 15 * ncart_input;
+    out_shift = 15 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (3, 4, 1)
+    inp_shift = 16 * ncart_input;
+    out_shift = 16 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (3, 3, 2)
+    inp_shift = 17 * ncart_input;
+    out_shift = 17 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (3, 2, 3)
+    inp_shift = 18 * ncart_input;
+    out_shift = 18 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (3, 1, 4)
+    inp_shift = 19 * ncart_input;
+    out_shift = 19 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (3, 0, 5)
+    inp_shift = 20 * ncart_input;
+    out_shift = 20 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 6, 0)
+    inp_shift = 21 * ncart_input;
+    out_shift = 21 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 5, 1)
+    inp_shift = 22 * ncart_input;
+    out_shift = 22 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 4, 2)
+    inp_shift = 23 * ncart_input;
+    out_shift = 23 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 3, 3)
+    inp_shift = 24 * ncart_input;
+    out_shift = 24 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 2, 4)
+    inp_shift = 25 * ncart_input;
+    out_shift = 25 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 1, 5)
+    inp_shift = 26 * ncart_input;
+    out_shift = 26 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (2, 0, 6)
+    inp_shift = 27 * ncart_input;
+    out_shift = 27 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 7, 0)
+    inp_shift = 28 * ncart_input;
+    out_shift = 28 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 6, 1)
+    inp_shift = 29 * ncart_input;
+    out_shift = 29 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 5, 2)
+    inp_shift = 30 * ncart_input;
+    out_shift = 30 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 4, 3)
+    inp_shift = 31 * ncart_input;
+    out_shift = 31 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 3, 4)
+    inp_shift = 32 * ncart_input;
+    out_shift = 32 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 2, 5)
+    inp_shift = 33 * ncart_input;
+    out_shift = 33 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 1, 6)
+    inp_shift = 34 * ncart_input;
+    out_shift = 34 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (1, 0, 7)
+    inp_shift = 35 * ncart_input;
+    out_shift = 35 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 8, 0)
+    inp_shift = 36 * ncart_input;
+    out_shift = 36 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 7, 1)
+    inp_shift = 37 * ncart_input;
+    out_shift = 37 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 6, 2)
+    inp_shift = 38 * ncart_input;
+    out_shift = 38 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 5, 3)
+    inp_shift = 39 * ncart_input;
+    out_shift = 39 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 4, 4)
+    inp_shift = 40 * ncart_input;
+    out_shift = 40 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 3, 5)
+    inp_shift = 41 * ncart_input;
+    out_shift = 41 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 2, 6)
+    inp_shift = 42 * ncart_input;
+    out_shift = 42 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 1, 7)
+    inp_shift = 43 * ncart_input;
+    out_shift = 43 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+
+    // Copy (0, 0, 8)
+    inp_shift = 44 * ncart_input;
+    out_shift = 44 * ncart_out;
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[out_shift + i] = cart_input[inp_shift + i];
+    }
+}
+void gg_cca_cart_sum_L8(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                        const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                        double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
+    ASSUME_ALIGNED(cart_input, 64);
+    unsigned long in_shift;
+    unsigned long out_shift;
+    double coef;
+
+    // Copy (8, 0, 0)
+    in_shift = 0 * ncart_input;
+    coef = vector[0];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (7, 1, 0)
+    in_shift = 1 * ncart_input;
+    coef = vector[1];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (7, 0, 1)
+    in_shift = 2 * ncart_input;
+    coef = vector[2];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (6, 2, 0)
+    in_shift = 3 * ncart_input;
+    coef = vector[3];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (6, 1, 1)
+    in_shift = 4 * ncart_input;
+    coef = vector[4];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (6, 0, 2)
+    in_shift = 5 * ncart_input;
+    coef = vector[5];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (5, 3, 0)
+    in_shift = 6 * ncart_input;
+    coef = vector[6];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (5, 2, 1)
+    in_shift = 7 * ncart_input;
+    coef = vector[7];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (5, 1, 2)
+    in_shift = 8 * ncart_input;
+    coef = vector[8];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (5, 0, 3)
+    in_shift = 9 * ncart_input;
+    coef = vector[9];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (4, 4, 0)
+    in_shift = 10 * ncart_input;
+    coef = vector[10];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (4, 3, 1)
+    in_shift = 11 * ncart_input;
+    coef = vector[11];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (4, 2, 2)
+    in_shift = 12 * ncart_input;
+    coef = vector[12];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (4, 1, 3)
+    in_shift = 13 * ncart_input;
+    coef = vector[13];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (4, 0, 4)
+    in_shift = 14 * ncart_input;
+    coef = vector[14];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (3, 5, 0)
+    in_shift = 15 * ncart_input;
+    coef = vector[15];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (3, 4, 1)
+    in_shift = 16 * ncart_input;
+    coef = vector[16];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (3, 3, 2)
+    in_shift = 17 * ncart_input;
+    coef = vector[17];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (3, 2, 3)
+    in_shift = 18 * ncart_input;
+    coef = vector[18];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (3, 1, 4)
+    in_shift = 19 * ncart_input;
+    coef = vector[19];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (3, 0, 5)
+    in_shift = 20 * ncart_input;
+    coef = vector[20];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 6, 0)
+    in_shift = 21 * ncart_input;
+    coef = vector[21];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 5, 1)
+    in_shift = 22 * ncart_input;
+    coef = vector[22];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 4, 2)
+    in_shift = 23 * ncart_input;
+    coef = vector[23];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 3, 3)
+    in_shift = 24 * ncart_input;
+    coef = vector[24];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 2, 4)
+    in_shift = 25 * ncart_input;
+    coef = vector[25];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 1, 5)
+    in_shift = 26 * ncart_input;
+    coef = vector[26];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (2, 0, 6)
+    in_shift = 27 * ncart_input;
+    coef = vector[27];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 7, 0)
+    in_shift = 28 * ncart_input;
+    coef = vector[28];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 6, 1)
+    in_shift = 29 * ncart_input;
+    coef = vector[29];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 5, 2)
+    in_shift = 30 * ncart_input;
+    coef = vector[30];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 4, 3)
+    in_shift = 31 * ncart_input;
+    coef = vector[31];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 3, 4)
+    in_shift = 32 * ncart_input;
+    coef = vector[32];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 2, 5)
+    in_shift = 33 * ncart_input;
+    coef = vector[33];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 1, 6)
+    in_shift = 34 * ncart_input;
+    coef = vector[34];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (1, 0, 7)
+    in_shift = 35 * ncart_input;
+    coef = vector[35];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 8, 0)
+    in_shift = 36 * ncart_input;
+    coef = vector[36];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 7, 1)
+    in_shift = 37 * ncart_input;
+    coef = vector[37];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 6, 2)
+    in_shift = 38 * ncart_input;
+    coef = vector[38];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 5, 3)
+    in_shift = 39 * ncart_input;
+    coef = vector[39];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 4, 4)
+    in_shift = 40 * ncart_input;
+    coef = vector[40];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 3, 5)
+    in_shift = 41 * ncart_input;
+    coef = vector[41];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 2, 6)
+    in_shift = 42 * ncart_input;
+    coef = vector[42];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 1, 7)
+    in_shift = 43 * ncart_input;
+    coef = vector[43];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+
+    // Copy (0, 0, 8)
+    in_shift = 44 * ncart_input;
+    coef = vector[44];
+    for (unsigned long i = 0; i < size; i++) {
+        cart_out[i] += coef * cart_input[in_shift + i];
+    }
+}
+void gg_molden_cart_copy_L0(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -3114,9 +5626,9 @@ void gg_molden_cart_copy_L0(const unsigned long size, const double* PRAGMA_RESTR
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_molden_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_molden_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -3128,8 +5640,9 @@ void gg_molden_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRI
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_molden_cart_copy_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-
+void gg_molden_cart_copy_L1(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -3155,9 +5668,9 @@ void gg_molden_cart_copy_L1(const unsigned long size, const double* PRAGMA_RESTR
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_molden_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_molden_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -3183,8 +5696,9 @@ void gg_molden_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRI
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_molden_cart_copy_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-
+void gg_molden_cart_copy_L2(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -3231,9 +5745,9 @@ void gg_molden_cart_copy_L2(const unsigned long size, const double* PRAGMA_RESTR
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_molden_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_molden_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -3280,8 +5794,9 @@ void gg_molden_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRI
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_molden_cart_copy_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-
+void gg_molden_cart_copy_L3(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -3356,9 +5871,9 @@ void gg_molden_cart_copy_L3(const unsigned long size, const double* PRAGMA_RESTR
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_molden_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_molden_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -3433,8 +5948,9 @@ void gg_molden_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRI
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_molden_cart_copy_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-
+void gg_molden_cart_copy_L4(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long inp_shift;
     unsigned long out_shift;
@@ -3544,9 +6060,9 @@ void gg_molden_cart_copy_L4(const unsigned long size, const double* PRAGMA_RESTR
         cart_out[out_shift + i] = cart_input[inp_shift + i];
     }
 }
-void gg_molden_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)ncart_out;
-
+void gg_molden_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
     double coef;
@@ -3656,37 +6172,32 @@ void gg_molden_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRI
         cart_out[i] += coef * cart_input[in_shift + i];
     }
 }
-void gg_molden_cart_copy_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)size;
-    (void)cart_input;
-    (void)ncart_input;
-    (void)cart_out;
-    (void)ncart_out;
-}
-void gg_molden_cart_sum_L5(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)size;
-    (void)vector;
-    (void)cart_input;
-    (void)ncart_input;
-    (void)cart_out;
-    (void)ncart_out;
-}
-void gg_molden_cart_copy_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)size;
-    (void)cart_input;
-    (void)ncart_input;
-    (void)cart_out;
-    (void)ncart_out;
-}
-void gg_molden_cart_sum_L6(const unsigned long size, const double* PRAGMA_RESTRICT vector, const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
-    (void)size;
-    (void)vector;
-    (void)cart_input;
-    (void)ncart_input;
-    (void)cart_out;
-    (void)ncart_out;
-}
-void gg_naive_transpose(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input, double* PRAGMA_RESTRICT output) {
+void gg_molden_cart_copy_L5(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out) {}
+void gg_molden_cart_sum_L5(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {}
+void gg_molden_cart_copy_L6(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out) {}
+void gg_molden_cart_sum_L6(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {}
+void gg_molden_cart_copy_L7(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out) {}
+void gg_molden_cart_sum_L7(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {}
+void gg_molden_cart_copy_L8(const unsigned long size, const double* PRAGMA_RESTRICT cart_input,
+                            const unsigned long ncart_input, double* PRAGMA_RESTRICT cart_out,
+                            const unsigned long ncart_out) {}
+void gg_molden_cart_sum_L8(const unsigned long size, const double* PRAGMA_RESTRICT vector,
+                           const double* PRAGMA_RESTRICT cart_input, const unsigned long ncart_input,
+                           double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {}
+void gg_naive_transpose(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input,
+                        double* PRAGMA_RESTRICT output) {
     ASSUME_ALIGNED(input, 64);
     for (unsigned long i = 0; i < n; i++) {
         for (unsigned long j = 0; j < m; j++) {
@@ -3694,14 +6205,14 @@ void gg_naive_transpose(unsigned long n, unsigned long m, const double* PRAGMA_R
         }
     }
 }
-void gg_fast_transpose(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input, double* PRAGMA_RESTRICT output) {
-
-    // Temps
-    #ifdef _MSC_VER
+void gg_fast_transpose(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input,
+                       double* PRAGMA_RESTRICT output) {
+// Temps
+#ifdef _MSC_VER
     __declspec(align(64)) double tmp[64];
-    #else
+#else
     double tmp[64] __attribute__((aligned(64)));
-    #endif
+#endif
     ASSUME_ALIGNED(input, 64);
     // Sizing
     unsigned long nblocks = n / 8;
@@ -3732,9 +6243,8 @@ void gg_fast_transpose(unsigned long n, unsigned long m, const double* PRAGMA_RE
         }
     }
 }
-void block_copy(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input, unsigned long is, double* PRAGMA_RESTRICT output, unsigned long os, const int trans) {
-    (void)trans;
-
+void block_copy(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT input, unsigned long is,
+                double* PRAGMA_RESTRICT output, unsigned long os, const int trans) {
     ASSUME_ALIGNED(input, 64);
     for (unsigned long i = 0; i < n; i++) {
         const unsigned long out_shift = i * os;
@@ -3745,8 +6255,8 @@ void block_copy(unsigned long n, unsigned long m, const double* PRAGMA_RESTRICT 
         }
     }
 }
-void block_matrix_vector(unsigned long n, unsigned long m, const double* vector, const double* PRAGMA_RESTRICT input, unsigned long is, double* PRAGMA_RESTRICT output) {
-
+void block_matrix_vector(unsigned long n, unsigned long m, const double* vector, const double* PRAGMA_RESTRICT input,
+                         unsigned long is, double* PRAGMA_RESTRICT output) {
     ASSUME_ALIGNED(input, 64);
     for (unsigned long i = 0; i < n; i++) {
         const unsigned long inp_shift = i * is;

--- a/external/gau2grid/generated_source/gau2grid_transform.c
+++ b/external/gau2grid/generated_source/gau2grid_transform.c
@@ -3193,6 +3193,7 @@ void gg_cca_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRICT 
                         double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (0, 0, 0)
@@ -3235,6 +3236,7 @@ void gg_cca_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRICT 
                         double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (1, 0, 0)
@@ -3312,6 +3314,7 @@ void gg_cca_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRICT 
                         double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (2, 0, 0)
@@ -3438,6 +3441,7 @@ void gg_cca_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRICT 
                         double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (3, 0, 0)
@@ -3627,6 +3631,7 @@ void gg_cca_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRICT 
                         double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (4, 0, 0)
@@ -3893,6 +3898,7 @@ void gg_cca_cart_sum_L5(const unsigned long size, const double* PRAGMA_RESTRICT 
                         double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (5, 0, 0)
@@ -4250,6 +4256,7 @@ void gg_cca_cart_sum_L6(const unsigned long size, const double* PRAGMA_RESTRICT 
                         double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (6, 0, 0)
@@ -5631,6 +5638,7 @@ void gg_molden_cart_sum_L0(const unsigned long size, const double* PRAGMA_RESTRI
                            double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (0, 0, 0)
@@ -5673,6 +5681,7 @@ void gg_molden_cart_sum_L1(const unsigned long size, const double* PRAGMA_RESTRI
                            double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (1, 0, 0)
@@ -5750,6 +5759,7 @@ void gg_molden_cart_sum_L2(const unsigned long size, const double* PRAGMA_RESTRI
                            double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (2, 0, 0)
@@ -5876,6 +5886,7 @@ void gg_molden_cart_sum_L3(const unsigned long size, const double* PRAGMA_RESTRI
                            double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (3, 0, 0)
@@ -6065,6 +6076,7 @@ void gg_molden_cart_sum_L4(const unsigned long size, const double* PRAGMA_RESTRI
                            double* PRAGMA_RESTRICT cart_out, const unsigned long ncart_out) {
     ASSUME_ALIGNED(cart_input, 64);
     unsigned long in_shift;
+    unsigned long out_shift;
     double coef;
 
     // Copy (4, 0, 0)

--- a/external/gau2grid/src/CMakeLists.txt
+++ b/external/gau2grid/src/CMakeLists.txt
@@ -1,17 +1,18 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12...4.0)
 
 project(gau2grid
-        VERSION 2.0.5
+        VERSION 2.0.9
         LANGUAGES C)
 set(gau2grid_AUTHORS      "Daniel G. A. Smith")
 set(gau2grid_DESCRIPTION  "Fast computation of a gaussian and its derivative on a grid")
-set(gau2grid_URL          "https://github.com/dgasmith/gau2grid")
+set(gau2grid_URL          "https://github.com/psi4/gau2grid")
 set(gau2grid_LICENSE      "BSD 3-clause")
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 
 #############################  Options: Build How?  #############################
+include(GNUInstallDirs)
 include(psi4OptionsTools)
 option_with_default(MAX_AM "The maximum gaussian angular momentum to compile" 8)
 option_with_default(CMAKE_BUILD_TYPE "Build type (Release or Debug)" Release)
@@ -33,7 +34,6 @@ if((${BUILD_SHARED_LIBS}) AND NOT ${BUILD_FPIC})
 endif()
 
 # Install
-option_with_default(CMAKE_INSTALL_LIBDIR "Directory to which libraries installed" lib)
 option_with_default(PYMOD_INSTALL_LIBDIR "Location within CMAKE_INSTALL_LIBDIR to which python modules are installed
                                           Must start with: / . Used to imitate python install: /python3.6/site-packages ." /)
 option_with_print(INSTALL_PYMOD "Additionally installs as independent python module in PYMOD_INSTALL_LIBDIR" OFF)
@@ -51,15 +51,14 @@ endif()
 message(STATUS "gau2grid install: ${CMAKE_INSTALL_PREFIX}")
 
 #  <<  Python  >>
-set(Python_ADDITIONAL_VERSIONS 3.9 3.8 3.7 3.6 3.5)  # adjust with CMake minimum FindPythonInterp
-find_package(PythonLibsNew 3.6 REQUIRED)
-message(STATUS "${Cyan}Found Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}${ColourReset}: ${PYTHON_EXECUTABLE} (found version ${PYTHON_VERSION_STRING})")
+find_package(Python 3.6 REQUIRED COMPONENTS Interpreter)
+message(STATUS "${Cyan}Found Python ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}${ColourReset}: ${Python_EXECUTABLE} (found version ${Python_VERSION})")
 
 
 ################################  Main Project  ################################
 add_custom_command(
     OUTPUT  gau2grid/gau2grid.h gau2grid_orbital.c gau2grid_phi.c gau2grid_deriv1.c gau2grid_deriv2.c gau2grid_deriv3.c gau2grid_transform.c gau2grid_helper.c
-    COMMAND ${PYTHON_EXECUTABLE} -c "import sys; \
+    COMMAND Python::Interpreter -c "import sys; \
                                      sys.path.append('${PROJECT_SOURCE_DIR}'); \
                                      import gau2grid as gg; \
                                      gg.c_gen.generate_c_gau2grid(${MAX_AM}, path='${CMAKE_CURRENT_BINARY_DIR}')"
@@ -106,7 +105,6 @@ endif()
 
 
 ###################################  Install  ##################################
-include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 set(PN ${PROJECT_NAME})
@@ -136,7 +134,9 @@ if(${NATIVE_PYTHON_INSTALL_WITH_LIB} OR (NOT(${INSTALL_PYMOD} AND ${NATIVE_PYTHO
     install(TARGETS gg
             EXPORT "${PN}Targets"
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake
                   ${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
@@ -151,21 +151,21 @@ endif()
 
 if(${INSTALL_PYMOD})
     if(${NATIVE_PYTHON_INSTALL})
-        execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+        execute_process(COMMAND ${Python_EXECUTABLE} -c
                         "import sys; print(sys.prefix);"
                         OUTPUT_VARIABLE CMAKE_INSTALL_PREFIX
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
-        execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+        execute_process(COMMAND ${Python_EXECUTABLE} -c
                         "from distutils import sysconfig as s; import os; import sys; cmake_install_prefix = sys.prefix; prefix_lib = s.get_config_var('LIBDIR'); print(prefix_lib.replace(os.path.commonpath([prefix_lib, cmake_install_prefix]), '').strip('/'));"
                         OUTPUT_VARIABLE CMAKE_INSTALL_LIBDIR
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
-        execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+        execute_process(COMMAND ${Python_EXECUTABLE} -c
                         "from distutils import sysconfig as s; import os; prefix_lib = s.get_config_var('LIBDIR'); spdir = s.get_python_lib(plat_specific=True); print(spdir.replace(os.path.commonpath([prefix_lib, spdir]), ''));"
                         OUTPUT_VARIABLE PYMOD_INSTALL_LIBDIR
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
     endif()
 
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+    execute_process(COMMAND ${Python_EXECUTABLE} -c
                     "from numpy import distutils; print(distutils.misc_util.get_shared_lib_extension(is_python_ext=False))"
                     OUTPUT_VARIABLE PYLIB_EXTENSION
                     OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/external/gau2grid/src/docs/source/c_example.rst
+++ b/external/gau2grid/src/docs/source/c_example.rst
@@ -17,7 +17,7 @@ starting at the origin along the ``z`` axis and a ``S`` shell at the origin:
       // Generate grid
       long int npoints = 5;
       double xyz[15] = {0, 0, 0, 0, 0, // x components
-                        0, 0, 0, 0, 0}; // y components
+                        0, 0, 0, 0, 0, // y components
                         0, 1, 2, 3, 4}; // z components
       long int xyz_stride = 1; // This is a contiguous format
 
@@ -89,7 +89,7 @@ The below is an example of usage:
       // Generate grid
       long int npoints = 5;
       double xyz[15] = {0, 0, 0, 0, 0, // x components
-                        0, 0, 0, 0, 0}; // y components
+                        0, 0, 0, 0, 0, // y components
                         0, 1, 2, 3, 4}; // z components
       long int xyz_stride = 1;
 
@@ -98,14 +98,15 @@ The below is an example of usage:
       double coef[1] = {1};
       double exp[1] = {1};
       double center[3] = {0, 0, 0};
-      int order = GG_SPHERICAL_CCA; // Use cartesian components
+      int order = GG_SPHERICAL_GAUSSIAN; // Use spherical components
+      int spherical = 1; // True because spherical
 
       // Size ncomponents * npoints, (1 + 3 + 5) * 5
       double output[45] = {0};
       int row = 0;
       for (int L = 0; L < 3; L++) {
           gg_collocation(L,                                 // The angular momentum
-                         npoints, xyz, xyz_stride            // Grid data
+                         npoints, xyz, xyz_stride,          // Grid data
                          nprim, coef, exp, center, order,   // Gaussian data
                          output + (row * npoints));         // Output, shift pointer
 

--- a/external/gau2grid/src/gau2grid/c_generator.py
+++ b/external/gau2grid/src/gau2grid/c_generator.py
@@ -133,10 +133,10 @@ def generate_c_gau2grid(max_L,
     gg_header.write("// Information helpers")
 
     # Maximum angular momentum
-    gg_helper.write("int gg_max_L() { return %d; }" % max_L, endl="")
+    gg_helper.write("int gg_max_L(void) { return %d; }" % max_L, endl="")
     gg_helper.blankline()
 
-    gg_header.write("int gg_max_L()")
+    gg_header.write("int gg_max_L(void)")
     gg_header.blankline()
 
 
@@ -827,7 +827,13 @@ def _remove_unused_decls(cg, start):
 
 def _malloc(name, size, dtype="double"):
     # return "%s*  %s = (%s*)malloc(%s * sizeof(%s))" % (dtype, name, dtype, str(size), dtype)
-    return "%s* PRAGMA_RESTRICT %s = (%s*)ALIGNED_MALLOC(%d, %s * sizeof(%s))" % (dtype, name, dtype, ALIGN_SIZE, str(size), dtype)
+
+    # The requested memory size of ALIGNED_MALLOC must be a multiple of the alignment width.
+    # This below line rounds the size up to the next multiple of ALIGN_SIZE.
+    # (Note that the arithmetics below are performed by C and are hence integer divisions.)
+    byte_size = "(%s * sizeof(%s))" % (str(size), dtype)
+    rounded_byte_size = "(((%s + %d - 1) / %d) * %d)" % (byte_size, ALIGN_SIZE, ALIGN_SIZE, ALIGN_SIZE)
+    return "%s* PRAGMA_RESTRICT %s = (%s*)ALIGNED_MALLOC(%d, %s)" % (dtype, name, dtype, ALIGN_SIZE, rounded_byte_size)
 
 
 def _block_malloc(cg, block_name, mallocs, dtype="double"):


### PR DESCRIPTION
Gau2grid release 2.0.9 contains [this fix](https://github.com/psi4/gau2grid/pull/76), needed for use in CP2K.

This PR includes:

* Version number 2.0.9 recorded in `gauxc-dep-versions.cmake` for use with FetchContent
* Source tree of gau2grid cloned into `external/gau2grid/src`
* Pregenerated source of gau2grid cloned into `external/gau2grid/generated_source`