### PR TITLE
Restore HIP feature parity with CUDA; make hipify.sh maintainable

### DIFF
--- a/src/xc_integrator/local_work_driver/device/hip/CMakeLists.txt
+++ b/src/xc_integrator/local_work_driver/device/hip/CMakeLists.txt
@@ -24,8 +24,11 @@ target_sources(gauxc PRIVATE
   kernels/hipblas_extensions.hip
   kernels/uvvars.hip
   kernels/zmat_vxc.hip
+  kernels/zmat_fxc.hip
   kernels/hip_inc_potential.hip
   kernels/symmetrize_mat.hip
+  kernels/increment_exc_grad.hip
+  kernels/exx_ek_screening_bfn_stats.hip
 
 )
 

--- a/src/xc_integrator/local_work_driver/device/hip/hipify.sh
+++ b/src/xc_integrator/local_work_driver/device/hip/hipify.sh
@@ -1,58 +1,160 @@
-#/bin/bash
+#!/bin/bash
+#
+# Regenerate the HIP kernels from their CUDA counterparts.
+#
+# The HIP backend is a machine translation of the CUDA backend.  This
+# script MUST be re-run whenever a CUDA kernel is added or changed,
+# otherwise the shared (backend-agnostic) driver in ../scheme1_base.cxx
+# calls into kernels that have no HIP definition and the HIP build fails
+# to link.  That is exactly what happened between the 2022 port and the
+# 1.0 release: mGGA, FXC contraction, EXC gradients, sn-LinK screening
+# and the shell-to-task collocation were added on the CUDA side only.
+#
+# The translation is performed with explicit sed rules rather than
+# hipify-perl so that it is reproducible on machines without a ROCm
+# installation, and so that the handful of NON-mechanical decisions are
+# documented in one place:
+#
+#   * warp/wavefront size is NOT hardcoded anywhere; kernels take it from
+#     GauXC::cuda::warp_size -> GauXC::hip::warp_size (32 vs 64), so the
+#     launch geometry adapts.  Kernels that assume a 32-wide reduction
+#     must be reviewed by hand -- see CHECK_WAVEFRONT below.
+#   * __syncwarp() has no HIP equivalent; wavefronts execute in lockstep
+#     on AMD, so it is commented out (the convention already used by the
+#     2022 port in this directory).
+#   * __shfl_*_sync(mask, ...) -> __shfl_*(...): HIP shuffles take no
+#     mask argument.
+#   * cub -> hipcub.
+#   * CUTLASS has no HIP counterpart; cutlass_wrapper is CUDA-only and is
+#     deliberately not translated (it is guarded by GAUXC_ENABLE_CUTLASS,
+#     which is a CUDA-only dependent option in the top-level CMakeLists).
+#
+# Usage:  ./hipify.sh          (from this directory)
 
-if [ ! -d kernels ]
-then
-  mkdir kernels
-fi
+set -euo pipefail
 
-if [ ! -d kernels/collocation ]
-then
-  mkdir -p kernels/collocation
-fi
+CUDA_PREFIX=$PWD/../cuda/kernels
+HIP_PREFIX=$PWD/kernels
 
-export CUDA_PREFIX=$PWD/../cuda/kernels
-export HIP_PREFIX=$PWD/kernels
+mkdir -p "$HIP_PREFIX/collocation"
 
-# Generate collocation kernels
-hipify-perl $CUDA_PREFIX/collocation/collocation_angular_cartesian.hpp > \
-            $HIP_PREFIX/collocation/collocation_angular_cartesian.hpp
-hipify-perl $CUDA_PREFIX/collocation/collocation_angular_spherical_unnorm.hpp > \
-            $HIP_PREFIX/collocation/collocation_angular_spherical_unnorm.hpp
-hipify-perl $CUDA_PREFIX/collocation/collocation_device_constants.hpp > \
-            $HIP_PREFIX/collocation/collocation_device_constants.hpp
-hipify-perl $CUDA_PREFIX/collocation_masked_combined_kernels.hpp > \
-            $HIP_PREFIX/collocation_masked_combined_kernels.hpp
-hipify-perl $CUDA_PREFIX/collocation_masked_kernels.hpp > \
-            $HIP_PREFIX/collocation_masked_kernels.hpp
-#hipify-perl $CUDA_PREFIX/collocation_device.hpp > \
-#            $HIP_PREFIX/collocation_device.hpp
-hipify-perl $CUDA_PREFIX/collocation_device.cu > \
-            $HIP_PREFIX/collocation_device.hip
+hipify_file() {
+  local src=$1 dst=$2
+  sed \
+    -e 's|device_specific/cuda_util\.hpp|device_specific/hip_util.hpp|g' \
+    -e 's|device_specific/cuda_device_constants\.hpp|device_specific/hip_device_constants.hpp|g' \
+    -e 's|device_specific/cublas_util\.hpp|device_specific/hipblas_util.hpp|g' \
+    -e 's|cuda_extensions\.hpp|hip_extensions.hpp|g' \
+    -e 's|cuda_aos_scheme1\.hpp|hip_aos_scheme1.hpp|g' \
+    -e 's|#include <cub/cub\.cuh>|#include <hipcub/hipcub.hpp>|g' \
+    -e 's|\bcub::|hipcub::|g' \
+    -e 's|\bcuda::|hip::|g' \
+    -e 's|\bcudaStream_t\b|hipStream_t|g' \
+    -e 's|\bcuda_stream\b|hip_stream|g' \
+    -e 's|\bcudaError_t\b|hipError_t|g' \
+    -e 's|\bcudaSuccess\b|hipSuccess|g' \
+    -e 's|\bcudaGetErrorString\b|hipGetErrorString|g' \
+    -e 's|\bcudaDeviceSynchronize\b|hipDeviceSynchronize|g' \
+    -e 's|\bcudaMalloc\b|hipMalloc|g' \
+    -e 's|\bcudaFree\b|hipFree|g' \
+    -e 's|\bcudaMemcpy|hipMemcpy|g' \
+    -e 's|\bcudaMemset|hipMemset|g' \
+    -e 's|device/cuda/kernels|device/hip/kernels|g' \
+    -e 's|util::cuda_|util::hip_|g' \
+    -e 's|\bcuda_kernel_max_threads_per_block\b|hip_kernel_max_threads_per_block|g' \
+    -e 's|\bcudaDeviceGetAttribute\b|hipDeviceGetAttribute|g' \
+    -e 's|\bcudaDevAttrMaxSharedMemoryPerBlockOptin\b|hipDeviceAttributeMaxSharedMemoryPerBlock|g' \
+    -e 's|\bcudaDevAttrMaxSharedMemoryPerBlock\b|hipDeviceAttributeMaxSharedMemoryPerBlock|g' \
+    -e 's|\bcudaFuncSetAttribute\b|hipFuncSetAttribute|g' \
+    -e 's|\bcudaFuncAttribute|hipFuncAttribute|g' \
+    -e 's|\bcuda_exception\b|hip_exception|g' \
+    -e 's|GAUXC_CUDA|GAUXC_HIP|g' \
+    -e 's|cuda_exception\.hpp|hip_exception.hpp|g' \
+    -e 's|\bCUDA_|HIP_|g' \
+    -e 's|\bCUBLAS_|HIPBLAS_|g' \
+    -e 's|\bcublas|hipblas|g' \
+    -e 's|__shfl_\([a-z]*\)_sync *( *[^,]*, *|__shfl_\1(|g' \
+    -e 's|\(^[[:space:]]*\)__syncwarp();|\1// __syncwarp();  // lockstep wavefronts on AMD|g' \
+    "$src" > "$dst"
 
+  # CUDA cache-hint stores have no HIP counterpart: __stcs() is an NVIDIA
+  # intrinsic and the pre-CUDA-11 fallback is inline PTX.  CUDART_VERSION
+  # is undefined under HIP, so the preprocessor would otherwise select the
+  # PTX branch and fail to compile.  Keep the intrinsic branch and lower
+  # the store to a plain one (the hint is an optimization, not semantics).
+  if grep -q 'CUDART_VERSION' "$dst"; then
+    awk '
+      /^#if \(CUDART_VERSION/ { skipelse = 1; next }
+      /^#else/ && skipelse    { drop = 1; next }
+      /^#endif/ && skipelse   { skipelse = 0; drop = 0; next }
+      drop                    { next }
+      { print }
+    ' "$dst" > "$dst.tmp"
+    sed -e 's|__stcs( *\([^,]*\), *\([^)]*\));|*(\1) = \2;|g' \
+        "$dst.tmp" > "$dst"
+    rm -f "$dst.tmp"
+  fi
 
-# Generate Weights Kernels
-#hipify-perl $CUDA_PREFIX/grid_to_center.hpp > $HIP_PREFIX/grid_to_center.hpp
-hipify-perl $CUDA_PREFIX/grid_to_center.cu  > $HIP_PREFIX/grid_to_center.hip
-#hipify-perl $CUDA_PREFIX/cuda_ssf_1d.hpp > $HIP_PREFIX/hip_ssf_1d.hpp
-hipify-perl $CUDA_PREFIX/cuda_ssf_1d.cu  > $HIP_PREFIX/hip_ssf_1d.hip
+  # HIP needs its runtime header; insert before the first #include (i.e.
+  # after the license comment block).
+  if ! grep -q 'hip/hip_runtime.h' "$dst"; then
+    awk '
+      BEGIN { done = 0 }
+      /^#include/ && !done { print "#include \"hip/hip_runtime.h\""; done = 1 }
+      { print }
+      END { if (!done) print "#include \"hip/hip_runtime.h\"" }
+    ' "$dst" > "$dst.tmp"
+    mv "$dst.tmp" "$dst"
+  fi
+}
 
+# ---- collocation ------------------------------------------------------
+for f in collocation_angular_cartesian.hpp \
+         collocation_angular_spherical_unnorm.hpp \
+         collocation_device_constants.hpp ; do
+  hipify_file "$CUDA_PREFIX/collocation/$f" "$HIP_PREFIX/collocation/$f"
+done
 
-# cuBLAS -> hipBLAS
-#hipify-perl $CUDA_PREFIX/cublas_extensions.hpp > $HIP_PREFIX/hipblas_extensions.hpp
-hipify-perl $CUDA_PREFIX/cublas_extensions.cu > $HIP_PREFIX/hipblas_extensions.hip
+hipify_file "$CUDA_PREFIX/collocation_masked_combined_kernels.hpp" \
+            "$HIP_PREFIX/collocation_masked_combined_kernels.hpp"
+hipify_file "$CUDA_PREFIX/collocation_masked_kernels.hpp" \
+            "$HIP_PREFIX/collocation_masked_kernels.hpp"
+hipify_file "$CUDA_PREFIX/collocation_shell_to_task_kernels.hpp" \
+            "$HIP_PREFIX/collocation_shell_to_task_kernels.hpp"
+hipify_file "$CUDA_PREFIX/collocation_device.cu" \
+            "$HIP_PREFIX/collocation_device.hip"
 
-# Z Matrix
-#hipify-perl $CUDA_PREFIX/zmat_vxc.hpp > $HIP_PREFIX/zmat_vxc.hpp
-hipify-perl $CUDA_PREFIX/zmat_vxc.cu > $HIP_PREFIX/zmat_vxc.hip
+# ---- weights ----------------------------------------------------------
+hipify_file "$CUDA_PREFIX/grid_to_center.cu"  "$HIP_PREFIX/grid_to_center.hip"
+hipify_file "$CUDA_PREFIX/grid_to_center.hpp" "$HIP_PREFIX/grid_to_center.hpp"
+hipify_file "$CUDA_PREFIX/cuda_ssf_1d.cu"     "$HIP_PREFIX/hip_ssf_1d.hip"
+hipify_file "$CUDA_PREFIX/cuda_ssf_1d.hpp"    "$HIP_PREFIX/hip_ssf_1d.hpp"
 
+# ---- BLAS extensions --------------------------------------------------
+hipify_file "$CUDA_PREFIX/cublas_extensions.cu" "$HIP_PREFIX/hipblas_extensions.hip"
+hipify_file "$CUDA_PREFIX/cuda_extensions.hpp"  "$HIP_PREFIX/hip_extensions.hpp"
 
-#hipify-perl $CUDA_PREFIX/../cuda_aos_scheme1.cxx > $HIP_PREFIX/../hip_aos_scheme1.cxx
+# ---- density / potential / XC assembly --------------------------------
+hipify_file "$CUDA_PREFIX/uvvars.cu"          "$HIP_PREFIX/uvvars.hip"
+hipify_file "$CUDA_PREFIX/uvvars_lda.hpp"     "$HIP_PREFIX/uvvars_lda.hpp"
+hipify_file "$CUDA_PREFIX/uvvars_gga.hpp"     "$HIP_PREFIX/uvvars_gga.hpp"
+hipify_file "$CUDA_PREFIX/uvvars_mgga.hpp"    "$HIP_PREFIX/uvvars_mgga.hpp"
+hipify_file "$CUDA_PREFIX/zmat_vxc.cu"        "$HIP_PREFIX/zmat_vxc.hip"
+hipify_file "$CUDA_PREFIX/zmat_fxc.cu"        "$HIP_PREFIX/zmat_fxc.hip"
+hipify_file "$CUDA_PREFIX/pack_submat.cu"     "$HIP_PREFIX/pack_submat.hip"
+hipify_file "$CUDA_PREFIX/symmetrize_mat.cu"  "$HIP_PREFIX/symmetrize_mat.hip"
+hipify_file "$CUDA_PREFIX/cuda_inc_potential.cu" "$HIP_PREFIX/hip_inc_potential.hip"
 
-sed -i -e "s/cuda/hip/g" kernels/{,*/}*.hpp *.{cxx,hpp}
-sed -i -e "s/cuda/hip/g" kernels/*.hip
-sed -i -e "s/CUDA/HIP/g" kernels/*.hip
-sed -i -e "s/cublas/hipblas/g" kernels/*.hip
-sed -i -e "s/CUBLAS/HIPBLAS/g" kernels/*.hip
-sed -i -e "s/register //g" kernels/*.hip
+# ---- gradients and sn-LinK screening ----------------------------------
+hipify_file "$CUDA_PREFIX/increment_exc_grad.cu" "$HIP_PREFIX/increment_exc_grad.hip"
+hipify_file "$CUDA_PREFIX/exx_ek_screening_bfn_stats.cu" \
+            "$HIP_PREFIX/exx_ek_screening_bfn_stats.hip"
 
-#sed -i -e "s/Cuda/Hip/g" *.{cxx,hpp}
+echo "hipify: regenerated $(ls "$HIP_PREFIX"/*.hip "$HIP_PREFIX"/*.hpp | wc -l) files"
+echo
+echo "CHECK_WAVEFRONT: kernels performing intra-warp reductions were written"
+echo "against a 32-lane warp.  On AMD the wavefront is 64 lanes and"
+echo "GauXC::hip::warp_size reflects that, but any reduction whose trip"
+echo "count is written as a literal must be reviewed.  Grep for '16;' '8;'"
+echo "'4;' '2;' '1;' shuffle ladders in the generated files before trusting"
+echo "numerical results on AMD hardware."

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/collocation/collocation_angular_cartesian.hpp
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/collocation/collocation_angular_cartesian.hpp
@@ -10,6 +10,7 @@
  * See LICENSE.txt for details
  */
 #pragma once
+#include "hip/hip_runtime.h"
 #include "collocation_device_constants.hpp"
 #include <cassert>
 
@@ -17,7 +18,7 @@
 #  define GPGAUEVAL_INLINE __noinline__
 #endif
 
-namespace GauXC {
+namespace GauXC      {
 
 template <typename T>
 GPGAUEVAL_INLINE __device__ void collocation_cartesian_angular_0(
@@ -231,6 +232,99 @@ GPGAUEVAL_INLINE __device__ void collocation_cartesian_angular_3_deriv1(
 
 }
 
+template <typename T>
+GPGAUEVAL_INLINE __device__ void collocation_cartesian_angular_4(
+  int32_t          npts,
+  const T          bf,
+  const T          x,
+  const T          y,
+  const T          z,
+  T* __restrict__  eval
+) {
+
+  eval[npts * 0] = bf*x*x*x*x;
+  eval[npts * 1] = bf*x*x*x*y;
+  eval[npts * 2] = bf*x*x*x*z;
+  eval[npts * 3] = bf*x*x*y*y;
+  eval[npts * 4] = bf*x*x*y*z;
+  eval[npts * 5] = bf*x*x*z*z;
+  eval[npts * 6] = bf*x*y*y*y;
+  eval[npts * 7] = bf*x*y*y*z;
+  eval[npts * 8] = bf*x*y*z*z;
+  eval[npts * 9] = bf*x*z*z*z;
+  eval[npts * 10] = bf*y*y*y*y;
+  eval[npts * 11] = bf*y*y*y*z;
+  eval[npts * 12] = bf*y*y*z*z;
+  eval[npts * 13] = bf*y*z*z*z;
+  eval[npts * 14] = bf*z*z*z*z;
+
+}
+
+template <typename T>
+GPGAUEVAL_INLINE __device__ void collocation_cartesian_angular_4_deriv1(
+  const int32_t   npts,
+  const T         bf,
+  const T         bf_x,
+  const T         bf_y,
+  const T         bf_z,
+  const T         x,
+  const T         y,
+  const T         z,
+  T* __restrict__ eval_x,
+  T* __restrict__ eval_y,
+  T* __restrict__ eval_z
+) {
+
+  eval_x[npts * 0] = x*x*x*(4*bf + bf_x*x);
+  eval_x[npts * 1] = x*x*y*(3*bf + bf_x*x);
+  eval_x[npts * 2] = x*x*z*(3*bf + bf_x*x);
+  eval_x[npts * 3] = x*y*y*(2*bf + bf_x*x);
+  eval_x[npts * 4] = x*y*z*(2*bf + bf_x*x);
+  eval_x[npts * 5] = x*z*z*(2*bf + bf_x*x);
+  eval_x[npts * 6] = y*y*y*(bf + bf_x*x);
+  eval_x[npts * 7] = y*y*z*(bf + bf_x*x);
+  eval_x[npts * 8] = y*z*z*(bf + bf_x*x);
+  eval_x[npts * 9] = z*z*z*(bf + bf_x*x);
+  eval_x[npts * 10] = bf_x*y*y*y*y;
+  eval_x[npts * 11] = bf_x*y*y*y*z;
+  eval_x[npts * 12] = bf_x*y*y*z*z;
+  eval_x[npts * 13] = bf_x*y*z*z*z;
+  eval_x[npts * 14] = bf_x*z*z*z*z;
+
+  eval_y[npts * 0] = bf_y*x*x*x*x;
+  eval_y[npts * 1] = x*x*x*(bf + bf_y*y);
+  eval_y[npts * 2] = bf_y*x*x*x*z;
+  eval_y[npts * 3] = x*x*y*(2*bf + bf_y*y);
+  eval_y[npts * 4] = x*x*z*(bf + bf_y*y);
+  eval_y[npts * 5] = bf_y*x*x*z*z;
+  eval_y[npts * 6] = x*y*y*(3*bf + bf_y*y);
+  eval_y[npts * 7] = x*y*z*(2*bf + bf_y*y);
+  eval_y[npts * 8] = x*z*z*(bf + bf_y*y);
+  eval_y[npts * 9] = bf_y*x*z*z*z;
+  eval_y[npts * 10] = y*y*y*(4*bf + bf_y*y);
+  eval_y[npts * 11] = y*y*z*(3*bf + bf_y*y);
+  eval_y[npts * 12] = y*z*z*(2*bf + bf_y*y);
+  eval_y[npts * 13] = z*z*z*(bf + bf_y*y);
+  eval_y[npts * 14] = bf_y*z*z*z*z;
+
+  eval_z[npts * 0] = bf_z*x*x*x*x;
+  eval_z[npts * 1] = bf_z*x*x*x*y;
+  eval_z[npts * 2] = x*x*x*(bf + bf_z*z);
+  eval_z[npts * 3] = bf_z*x*x*y*y;
+  eval_z[npts * 4] = x*x*y*(bf + bf_z*z);
+  eval_z[npts * 5] = x*x*z*(2*bf + bf_z*z);
+  eval_z[npts * 6] = bf_z*x*y*y*y;
+  eval_z[npts * 7] = x*y*y*(bf + bf_z*z);
+  eval_z[npts * 8] = x*y*z*(2*bf + bf_z*z);
+  eval_z[npts * 9] = x*z*z*(3*bf + bf_z*z);
+  eval_z[npts * 10] = bf_z*y*y*y*y;
+  eval_z[npts * 11] = y*y*y*(bf + bf_z*z);
+  eval_z[npts * 12] = y*y*z*(2*bf + bf_z*z);
+  eval_z[npts * 13] = y*z*z*(3*bf + bf_z*z);
+  eval_z[npts * 14] = z*z*z*(4*bf + bf_z*z);
+
+}
+
 
 template <typename T>
 GPGAUEVAL_INLINE __device__ void collocation_cartesian_angular(
@@ -258,6 +352,10 @@ GPGAUEVAL_INLINE __device__ void collocation_cartesian_angular(
       } else if( l == 3 ) {
   
         collocation_cartesian_angular_3( npts, bf, x, y, z, eval );
+
+      } else if( l == 4 ) {
+  
+        collocation_cartesian_angular_4( npts, bf, x, y, z, eval );
 
     } else {
       assert( false && "L < L_MAX" );
@@ -303,6 +401,11 @@ GPGAUEVAL_INLINE __device__ void collocation_cartesian_angular_deriv1(
   
         collocation_cartesian_angular_3( npts, bf, x, y, z, eval );
         collocation_cartesian_angular_3_deriv1( npts, bf, bf_x, bf_y, bf_z, x, y, z, eval_x, eval_y, eval_z );
+
+      } else if( l == 4 ) {
+  
+        collocation_cartesian_angular_4( npts, bf, x, y, z, eval );
+        collocation_cartesian_angular_4_deriv1( npts, bf, bf_x, bf_y, bf_z, x, y, z, eval_x, eval_y, eval_z );
 
     } else {
       assert( false && "L < L_MAX" );

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/collocation/collocation_angular_spherical_unnorm.hpp
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/collocation/collocation_angular_spherical_unnorm.hpp
@@ -10,6 +10,7 @@
  * See LICENSE.txt for details
  */
 #pragma once
+#include "hip/hip_runtime.h"
 #include "collocation_device_constants.hpp"
 #include <cassert>
 
@@ -17,7 +18,7 @@
 #  define GPGAUEVAL_INLINE __noinline__
 #endif
 
-namespace GauXC {
+namespace GauXC      {
 
 template <typename T>
 GPGAUEVAL_INLINE __device__ void collocation_spherical_unnorm_angular_0(
@@ -191,17 +192,17 @@ GPGAUEVAL_INLINE __device__ void collocation_spherical_unnorm_angular_3_deriv1(
 
   eval_x[npts * 0] = sqrt_10*y*(6*bf*x + bf_x*(3*x*x - y*y))/4;
   eval_x[npts * 1] = sqrt_15*y*z*(bf + bf_x*x);
-  eval_x[npts * 2] = -sqrt_6*y*(2*bf*x + bf_x*(x*x + y*y - 4*z*z))/4;
-  eval_x[npts * 3] = -z*(6*bf*x + bf_x*(3*x*x + 3*y*y - 2*z*z))/2;
-  eval_x[npts * 4] = -sqrt_6*(bf*(3*x*x + y*y - 4*z*z) + bf_x*x*(x*x + y*y - 4*z*z))/4;
+  eval_x[npts * 2] = sqrt_6*y*(-2*bf*x - bf_x*(x*x + y*y - 4*z*z))/4;
+  eval_x[npts * 3] = z*(-6*bf*x - bf_x*(3*x*x + 3*y*y - 2*z*z))/2;
+  eval_x[npts * 4] = sqrt_6*(-bf*(3*x*x + y*y - 4*z*z) - bf_x*x*(x*x + y*y - 4*z*z))/4;
   eval_x[npts * 5] = sqrt_15*z*(2*bf*x + bf_x*(x*x - y*y))/2;
   eval_x[npts * 6] = sqrt_10*(3*bf*(x*x - y*y) + bf_x*x*(x*x - 3*y*y))/4;
 
   eval_y[npts * 0] = sqrt_10*(-3*bf*(-x*x + y*y) + bf_y*y*(3*x*x - y*y))/4;
   eval_y[npts * 1] = sqrt_15*x*z*(bf + bf_y*y);
-  eval_y[npts * 2] = -sqrt_6*(bf*(x*x + 3*y*y - 4*z*z) + bf_y*y*(x*x + y*y - 4*z*z))/4;
-  eval_y[npts * 3] = -z*(6*bf*y + bf_y*(3*x*x + 3*y*y - 2*z*z))/2;
-  eval_y[npts * 4] = -sqrt_6*x*(2*bf*y + bf_y*(x*x + y*y - 4*z*z))/4;
+  eval_y[npts * 2] = sqrt_6*(-bf*(x*x + 3*y*y - 4*z*z) - bf_y*y*(x*x + y*y - 4*z*z))/4;
+  eval_y[npts * 3] = z*(-6*bf*y - bf_y*(3*x*x + 3*y*y - 2*z*z))/2;
+  eval_y[npts * 4] = sqrt_6*x*(-2*bf*y - bf_y*(x*x + y*y - 4*z*z))/4;
   eval_y[npts * 5] = sqrt_15*z*(-2*bf*y + bf_y*(x*x - y*y))/2;
   eval_y[npts * 6] = sqrt_10*x*(-6*bf*y + bf_y*(x*x - 3*y*y))/4;
 
@@ -212,6 +213,75 @@ GPGAUEVAL_INLINE __device__ void collocation_spherical_unnorm_angular_3_deriv1(
   eval_z[npts * 4] = sqrt_6*x*(8*bf*z - bf_z*(x*x + y*y - 4*z*z))/4;
   eval_z[npts * 5] = sqrt_15*(bf + bf_z*z)*(x*x - y*y)/2;
   eval_z[npts * 6] = sqrt_10*bf_z*x*(x*x - 3*y*y)/4;
+
+}
+
+template <typename T>
+GPGAUEVAL_INLINE __device__ void collocation_spherical_unnorm_angular_4(
+  int32_t          npts,
+  const T          bf,
+  const T          x,
+  const T          y,
+  const T          z,
+  T* __restrict__  eval
+) {
+
+  eval[npts * 0] = sqrt_35*bf*x*y*(x*x - y*y)/2;
+  eval[npts * 1] = sqrt_70*bf*y*z*(3*x*x - y*y)/4;
+  eval[npts * 2] = sqrt_5*bf*x*y*(-x*x - y*y + 6*z*z)/2;
+  eval[npts * 3] = sqrt_10*bf*y*z*(-3*x*x - 3*y*y + 4*z*z)/4;
+  eval[npts * 4] = bf*(3*x*x*x*x + 6*x*x*y*y - 24*x*x*z*z + 3*y*y*y*y - 24*y*y*z*z + 8*z*z*z*z)/8;
+  eval[npts * 5] = sqrt_10*bf*x*z*(-3*x*x - 3*y*y + 4*z*z)/4;
+  eval[npts * 6] = sqrt_5*bf*(-x*x*x*x + 6*x*x*z*z + y*y*y*y - 6*y*y*z*z)/4;
+  eval[npts * 7] = sqrt_70*bf*x*z*(x*x - 3*y*y)/4;
+  eval[npts * 8] = sqrt_35*bf*(x*x*x*x - 6*x*x*y*y + y*y*y*y)/8;
+
+}
+
+template <typename T>
+GPGAUEVAL_INLINE __device__ void collocation_spherical_unnorm_angular_4_deriv1(
+  const int32_t   npts,
+  const T         bf,
+  const T         bf_x,
+  const T         bf_y,
+  const T         bf_z,
+  const T         x,
+  const T         y,
+  const T         z,
+  T* __restrict__ eval_x,
+  T* __restrict__ eval_y,
+  T* __restrict__ eval_z
+) {
+
+  eval_x[npts * 0] = sqrt_35*y*(bf*(3*x*x - y*y) + bf_x*x*(x*x - y*y))/2;
+  eval_x[npts * 1] = sqrt_70*y*z*(6*bf*x + bf_x*(3*x*x - y*y))/4;
+  eval_x[npts * 2] = sqrt_5*y*(-bf*(3*x*x + y*y - 6*z*z) - bf_x*x*(x*x + y*y - 6*z*z))/2;
+  eval_x[npts * 3] = sqrt_10*y*z*(-6*bf*x - bf_x*(3*x*x + 3*y*y - 4*z*z))/4;
+  eval_x[npts * 4] = 3*bf*x*(x*x + y*y - 4*z*z)/2 + bf_x*(3*x*x*x*x + 6*x*x*y*y - 24*x*x*z*z + 3*y*y*y*y - 24*y*y*z*z + 8*z*z*z*z)/8;
+  eval_x[npts * 5] = sqrt_10*z*(-bf*(9*x*x + 3*y*y - 4*z*z) - bf_x*x*(3*x*x + 3*y*y - 4*z*z))/4;
+  eval_x[npts * 6] = sqrt_5*(-bf*x*(x*x - 3*z*z) - bf_x*(x*x*x*x - 6*x*x*z*z - y*y*y*y + 6*y*y*z*z)/4);
+  eval_x[npts * 7] = sqrt_70*z*(3*bf*(x*x - y*y) + bf_x*x*(x*x - 3*y*y))/4;
+  eval_x[npts * 8] = sqrt_35*(4*bf*x*(x*x - 3*y*y) + bf_x*(x*x*x*x - 6*x*x*y*y + y*y*y*y))/8;
+
+  eval_y[npts * 0] = sqrt_35*x*(-bf*(-x*x + 3*y*y) + bf_y*y*(x*x - y*y))/2;
+  eval_y[npts * 1] = sqrt_70*z*(-3*bf*(-x*x + y*y) + bf_y*y*(3*x*x - y*y))/4;
+  eval_y[npts * 2] = sqrt_5*x*(-bf*(x*x + 3*y*y - 6*z*z) - bf_y*y*(x*x + y*y - 6*z*z))/2;
+  eval_y[npts * 3] = sqrt_10*z*(-bf*(3*x*x + 9*y*y - 4*z*z) - bf_y*y*(3*x*x + 3*y*y - 4*z*z))/4;
+  eval_y[npts * 4] = 3*bf*y*(x*x + y*y - 4*z*z)/2 + bf_y*(3*x*x*x*x + 6*x*x*y*y - 24*x*x*z*z + 3*y*y*y*y - 24*y*y*z*z + 8*z*z*z*z)/8;
+  eval_y[npts * 5] = sqrt_10*x*z*(-6*bf*y - bf_y*(3*x*x + 3*y*y - 4*z*z))/4;
+  eval_y[npts * 6] = sqrt_5*(bf*y*(y*y - 3*z*z) - bf_y*(x*x*x*x - 6*x*x*z*z - y*y*y*y + 6*y*y*z*z)/4);
+  eval_y[npts * 7] = sqrt_70*x*z*(-6*bf*y + bf_y*(x*x - 3*y*y))/4;
+  eval_y[npts * 8] = sqrt_35*(-4*bf*y*(3*x*x - y*y) + bf_y*(x*x*x*x - 6*x*x*y*y + y*y*y*y))/8;
+
+  eval_z[npts * 0] = sqrt_35*bf_z*x*y*(x*x - y*y)/2;
+  eval_z[npts * 1] = sqrt_70*y*(bf + bf_z*z)*(3*x*x - y*y)/4;
+  eval_z[npts * 2] = sqrt_5*x*y*(12*bf*z - bf_z*(x*x + y*y - 6*z*z))/2;
+  eval_z[npts * 3] = sqrt_10*y*(3*bf*(-x*x - y*y + 4*z*z) - bf_z*z*(3*x*x + 3*y*y - 4*z*z))/4;
+  eval_z[npts * 4] = -2*bf*z*(3*x*x + 3*y*y - 2*z*z) + bf_z*(3*x*x*x*x + 6*x*x*y*y - 24*x*x*z*z + 3*y*y*y*y - 24*y*y*z*z + 8*z*z*z*z)/8;
+  eval_z[npts * 5] = sqrt_10*x*(3*bf*(-x*x - y*y + 4*z*z) - bf_z*z*(3*x*x + 3*y*y - 4*z*z))/4;
+  eval_z[npts * 6] = sqrt_5*(12*bf*z*(x*x - y*y) - bf_z*(x*x*x*x - 6*x*x*z*z - y*y*y*y + 6*y*y*z*z))/4;
+  eval_z[npts * 7] = sqrt_70*x*(bf + bf_z*z)*(x*x - 3*y*y)/4;
+  eval_z[npts * 8] = sqrt_35*bf_z*(x*x*x*x - 6*x*x*y*y + y*y*y*y)/8;
 
 }
 
@@ -242,6 +312,10 @@ GPGAUEVAL_INLINE __device__ void collocation_spherical_unnorm_angular(
       } else if( l == 3 ) {
   
         collocation_spherical_unnorm_angular_3( npts, bf, x, y, z, eval );
+
+      } else if( l == 4 ) {
+  
+        collocation_spherical_unnorm_angular_4( npts, bf, x, y, z, eval );
 
     } else {
       assert( false && "L < L_MAX" );
@@ -287,6 +361,11 @@ GPGAUEVAL_INLINE __device__ void collocation_spherical_unnorm_angular_deriv1(
   
         collocation_spherical_unnorm_angular_3( npts, bf, x, y, z, eval );
         collocation_spherical_unnorm_angular_3_deriv1( npts, bf, bf_x, bf_y, bf_z, x, y, z, eval_x, eval_y, eval_z );
+
+      } else if( l == 4 ) {
+  
+        collocation_spherical_unnorm_angular_4( npts, bf, x, y, z, eval );
+        collocation_spherical_unnorm_angular_4_deriv1( npts, bf, bf_x, bf_y, bf_z, x, y, z, eval_x, eval_y, eval_z );
 
     } else {
       assert( false && "L < L_MAX" );

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/collocation/collocation_device_constants.hpp
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/collocation/collocation_device_constants.hpp
@@ -11,11 +11,15 @@
  */
 #pragma once
 
-namespace GauXC {
+namespace GauXC      {
 
-  constexpr double sqrt_15 = 3.872983346207417;
   constexpr double sqrt_3 = 1.7320508075688772;
-  constexpr double sqrt_6 = 2.449489742783178;
+  constexpr double sqrt_5 = 2.23606797749979;
+  constexpr double sqrt_15 = 3.872983346207417;
   constexpr double sqrt_10 = 3.1622776601683795;
+  constexpr double sqrt_6 = 2.449489742783178;
+  constexpr double sqrt_35 = 5.916079783099616;
+  constexpr double sqrt_70 = 8.366600265340756;
 
 } // namespace GauXC
+#include "hip/hip_runtime.h"

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/collocation_device.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/collocation_device.hip
@@ -18,9 +18,11 @@
 #include "device/common/collocation_device.hpp"
 #include "device/hip/kernels/collocation_masked_kernels.hpp"
 #include "device/hip/kernels/collocation_masked_combined_kernels.hpp"
-//#include "device/hip/kernels/collocation_shell_to_task_kernels.hpp"
+#include "device/hip/kernels/collocation_shell_to_task_kernels.hpp"
 
 #include "device_specific/hip_device_constants.hpp"
+
+#define GAUXC_HIP_MAX_L 4
 
 namespace GauXC {
 
@@ -38,7 +40,7 @@ void eval_collocation_masked(
   device_queue queue
 ) {
 
-  hipStream_t stream = queue.queue_as<util::hip_stream>();
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
 
   auto nmax_threads = util::hip_kernel_max_threads_per_block( 
     collocation_device_masked_kernel<T>
@@ -49,7 +51,9 @@ void eval_collocation_masked(
   dim3 blocks( util::div_ceil( npts,    threads.x ),
                util::div_ceil( nshells, threads.y ) );
 
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(collocation_device_masked_kernel<T>), dim3(blocks), dim3(threads), 0, stream,  nshells, nbf, npts, shells_device, mask_device,
+  collocation_device_masked_kernel<T>
+    <<<blocks, threads, 0, stream>>>
+    ( nshells, nbf, npts, shells_device, mask_device,
       offs_device, pts_device, eval_device );
 
 }
@@ -80,7 +84,7 @@ void eval_collocation_masked_combined(
   device_queue queue
 ) {
 
-  hipStream_t stream = queue.queue_as<util::hip_stream>();
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
 
   auto nmax_threads = util::hip_kernel_max_threads_per_block( 
     collocation_device_masked_combined_kernel<T>
@@ -92,7 +96,9 @@ void eval_collocation_masked_combined(
                util::div_ceil( nshells_max, threads.y ),
                ntasks );
 
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(collocation_device_masked_combined_kernel<T>), dim3(blocks), dim3(threads), 0, stream,  ntasks, shells_device, device_tasks );
+  collocation_device_masked_combined_kernel<T>
+    <<<blocks, threads, 0, stream>>>
+    ( ntasks, shells_device, device_tasks );
      
 }
 
@@ -132,7 +138,7 @@ void eval_collocation_masked_deriv1(
   device_queue queue
 ) {
 
-  hipStream_t stream = queue.queue_as<util::hip_stream>();
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
 
   auto nmax_threads = util::hip_kernel_max_threads_per_block( 
     collocation_device_masked_combined_kernel<T>
@@ -143,7 +149,9 @@ void eval_collocation_masked_deriv1(
   dim3 blocks( util::div_ceil( npts,    threads.x ),
                util::div_ceil( nshells, threads.y ) );
 
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(collocation_device_masked_kernel_deriv1<T>), dim3(blocks), dim3(threads), 0, stream,  nshells, nbf, npts, shells_device, mask_device, offs_device,
+  collocation_device_masked_kernel_deriv1<T>
+    <<<blocks, threads, 0, stream>>>
+    ( nshells, nbf, npts, shells_device, mask_device, offs_device,
       pts_device, eval_device, deval_device_x, deval_device_y,
       deval_device_z );
 
@@ -190,7 +198,7 @@ void eval_collocation_masked_combined_deriv1(
   device_queue queue
 ) {
 
-  hipStream_t stream = queue.queue_as<util::hip_stream>();
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
 
   auto nmax_threads = util::hip_kernel_max_threads_per_block( 
     collocation_device_masked_combined_kernel_deriv1<T>
@@ -201,7 +209,9 @@ void eval_collocation_masked_combined_deriv1(
                util::div_ceil( nshells_max, threads.y ),
                ntasks );
 
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(collocation_device_masked_combined_kernel_deriv1<T>), dim3(blocks), dim3(threads), 0, stream,  ntasks, shells_device, device_tasks );
+  collocation_device_masked_combined_kernel_deriv1<T>
+    <<<blocks, threads, 0, stream>>>
+    ( ntasks, shells_device, device_tasks );
      
 }
 
@@ -214,5 +224,542 @@ void eval_collocation_masked_combined_deriv1(
   XCDeviceTask* device_tasks,
   device_queue queue
 );
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+uint32_t max_threads_shell_to_task_collocation( int32_t l, bool pure ) {
+  if( pure ) {
+    switch(l) {
+      case 0: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_0 );      
+      case 1: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_1 );      
+      case 2: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_2 );      
+      case 3: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_3 );      
+      case 4: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_4 );      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  } else {
+    switch(l) {
+      
+      case 0: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_0 );      
+      case 1: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_1 );      
+      case 2: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_2 );      
+      case 3: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_3 );      
+      case 4: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_4 );      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  }
+  return 0;
+}
+
+template <typename... Args>
+void dispatch_shell_to_task_collocation( hipStream_t stream, int32_t l, 
+  bool pure, int32_t ntask_average, int32_t nshells, Args&&... args ) {
+
+  dim3 threads = max_threads_shell_to_task_collocation(l,pure);
+  int nwarp_per_block = threads.x / hip::warp_size;
+  int n_task_blocks = util::div_ceil( ntask_average, nwarp_per_block );
+  dim3 block(n_task_blocks, 1, nshells);
+
+  if( pure ) {
+    switch(l) {
+      case 0:
+        collocation_device_shell_to_task_kernel_cartesian_0<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 1:
+        collocation_device_shell_to_task_kernel_spherical_1<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 2:
+        collocation_device_shell_to_task_kernel_spherical_2<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 3:
+        collocation_device_shell_to_task_kernel_spherical_3<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 4:
+        collocation_device_shell_to_task_kernel_spherical_4<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  } else {
+    switch(l) {      
+      case 0:
+        collocation_device_shell_to_task_kernel_cartesian_0<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 1:
+        collocation_device_shell_to_task_kernel_cartesian_1<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 2:
+        collocation_device_shell_to_task_kernel_cartesian_2<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 3:
+        collocation_device_shell_to_task_kernel_cartesian_3<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 4:
+        collocation_device_shell_to_task_kernel_cartesian_4<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  }
+}
+
+
+void eval_collocation_shell_to_task(
+  uint32_t                    max_l,
+  AngularMomentumShellToTaskBatch* l_batched_shell_to_task,
+  XCDeviceTask*               device_tasks,
+  device_queue           queue 
+) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
+
+  for( auto l = 0u; l <= max_l; ++l ) {
+    auto pure = l_batched_shell_to_task[l].pure;
+    auto shell_to_task_device = l_batched_shell_to_task[l].shell_to_task_device;
+    auto nshells = l_batched_shell_to_task[l].nshells_in_batch;
+    auto ntask_average = std::max(1ul, l_batched_shell_to_task[l].ntask_average);
+    dispatch_shell_to_task_collocation( stream, l, pure, ntask_average, nshells, 
+      shell_to_task_device, device_tasks );
+  }
+
+
+}
+
+
+uint32_t max_threads_shell_to_task_collocation_gradient( int32_t l, bool pure ) {
+  if( pure ) {
+    switch(l) {
+      case 0: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_gradient_0 );      
+      case 1: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_gradient_1 );      
+      case 2: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_gradient_2 );      
+      case 3: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_gradient_3 );      
+      case 4: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_gradient_4 );      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  } else {
+    switch(l) {      
+      case 0: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_gradient_0 );      
+      case 1: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_gradient_1 );      
+      case 2: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_gradient_2 );      
+      case 3: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_gradient_3 );      
+      case 4: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_gradient_4 );      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  }
+  return 0;
+}
+
+template <typename... Args>
+void dispatch_shell_to_task_collocation_gradient( hipStream_t stream, int32_t l, 
+  bool pure, uint32_t ntask_average, uint32_t nshells, Args&&... args ) {
+
+  dim3 threads = max_threads_shell_to_task_collocation_gradient(l,pure);
+  int nwarp_per_block = threads.x / hip::warp_size;
+  int n_task_blocks = util::div_ceil( ntask_average, nwarp_per_block );
+  dim3 block(n_task_blocks, 1, nshells);
+
+  if( pure ) {
+    switch(l) {
+      case 0:
+        collocation_device_shell_to_task_kernel_cartesian_gradient_0<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 1:
+        collocation_device_shell_to_task_kernel_spherical_gradient_1<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 2:
+        collocation_device_shell_to_task_kernel_spherical_gradient_2<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 3:
+        collocation_device_shell_to_task_kernel_spherical_gradient_3<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 4:
+        collocation_device_shell_to_task_kernel_spherical_gradient_4<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  } else {
+    switch(l) {      
+      case 0:
+        collocation_device_shell_to_task_kernel_cartesian_gradient_0<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 1:
+        collocation_device_shell_to_task_kernel_cartesian_gradient_1<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 2:
+        collocation_device_shell_to_task_kernel_cartesian_gradient_2<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 3:
+        collocation_device_shell_to_task_kernel_cartesian_gradient_3<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 4:
+        collocation_device_shell_to_task_kernel_cartesian_gradient_4<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  }
+
+}
+
+
+void eval_collocation_shell_to_task_gradient(
+  uint32_t                    max_l,
+  AngularMomentumShellToTaskBatch* l_batched_shell_to_task,
+  XCDeviceTask*               device_tasks,
+  device_queue           queue 
+) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
+
+  for( auto l = 0u; l <= max_l; ++l ) {
+    auto pure = l_batched_shell_to_task[l].pure;
+    auto shell_to_task_device = l_batched_shell_to_task[l].shell_to_task_device;
+    auto nshells = l_batched_shell_to_task[l].nshells_in_batch;
+    auto ntask_average = std::max(1ul, l_batched_shell_to_task[l].ntask_average);
+    dispatch_shell_to_task_collocation_gradient( stream, l, pure, 
+      ntask_average, nshells, shell_to_task_device, device_tasks );
+  }
+
+
+}
+
+
+uint32_t max_threads_shell_to_task_collocation_hessian( int32_t l, bool pure ) {
+  if( pure ) {
+    switch(l) {
+      case 0: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_hessian_0 );      
+      case 1: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_hessian_1 );      
+      case 2: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_hessian_2 );      
+      case 3: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_hessian_3 );      
+      case 4: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_hessian_4 );      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  } else {
+    switch(l) {      
+      case 0: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_hessian_0 );      
+      case 1: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_hessian_1 );      
+      case 2: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_hessian_2 );      
+      case 3: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_hessian_3 );      
+      case 4: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_hessian_4 );      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  }
+  return 0;
+}
+
+template <typename... Args>
+void dispatch_shell_to_task_collocation_hessian( hipStream_t stream, int32_t l, 
+  bool pure, uint32_t ntask_average, uint32_t nshells, Args&&... args ) {
+
+  dim3 threads = max_threads_shell_to_task_collocation_hessian(l,pure);
+  int nwarp_per_block = threads.x / hip::warp_size;
+  int n_task_blocks = util::div_ceil( ntask_average, nwarp_per_block );
+  dim3 block(n_task_blocks, 1, nshells);
+
+  if( pure ) {
+    switch(l) {
+      case 0:
+        collocation_device_shell_to_task_kernel_cartesian_hessian_0<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 1:
+        collocation_device_shell_to_task_kernel_spherical_hessian_1<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 2:
+        collocation_device_shell_to_task_kernel_spherical_hessian_2<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 3:
+        collocation_device_shell_to_task_kernel_spherical_hessian_3<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 4:
+        collocation_device_shell_to_task_kernel_spherical_hessian_4<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  } else {
+    switch(l) {      
+      case 0:
+        collocation_device_shell_to_task_kernel_cartesian_hessian_0<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 1:
+        collocation_device_shell_to_task_kernel_cartesian_hessian_1<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 2:
+        collocation_device_shell_to_task_kernel_cartesian_hessian_2<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 3:
+        collocation_device_shell_to_task_kernel_cartesian_hessian_3<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 4:
+        collocation_device_shell_to_task_kernel_cartesian_hessian_4<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  }
+
+}
+
+
+void eval_collocation_shell_to_task_hessian(
+  uint32_t                    max_l,
+  AngularMomentumShellToTaskBatch* l_batched_shell_to_task,
+  XCDeviceTask*               device_tasks,
+  device_queue           queue 
+) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
+
+  for( auto l = 0u; l <= max_l; ++l ) {
+    auto pure = l_batched_shell_to_task[l].pure;
+    auto shell_to_task_device = l_batched_shell_to_task[l].shell_to_task_device;
+    auto nshells = l_batched_shell_to_task[l].nshells_in_batch;
+    auto ntask_average = std::max(1ul, l_batched_shell_to_task[l].ntask_average);
+    dispatch_shell_to_task_collocation_hessian( stream, l, pure, 
+      ntask_average, nshells, shell_to_task_device, device_tasks );
+  }
+
+
+}
+
+
+uint32_t max_threads_shell_to_task_collocation_laplacian( int32_t l, bool pure ) {
+  if( pure ) {
+    switch(l) {
+      case 0: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_laplacian_0 );      
+      case 1: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_laplacian_1 );
+      
+      case 2: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_laplacian_2 );
+      
+      case 3: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_laplacian_3 );
+      
+      case 4: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_laplacian_4 );
+      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  } else {
+    switch(l) {      
+      case 0: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_laplacian_0 );      
+      case 1: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_laplacian_1 );      
+      case 2: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_laplacian_2 );      
+      case 3: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_laplacian_3 );      
+      case 4: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_laplacian_4 );      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  }
+  return 0;
+}
+
+
+
+
+
+template <typename... Args>
+void dispatch_shell_to_task_collocation_laplacian( hipStream_t stream, int32_t l,
+  bool pure, uint32_t ntask_average, uint32_t nshells, Args&&... args ) {
+
+  dim3 threads = max_threads_shell_to_task_collocation_laplacian(l,pure);
+  int nwarp_per_block = threads.x / hip::warp_size;
+  int n_task_blocks = util::div_ceil( ntask_average, nwarp_per_block );
+  dim3 block(n_task_blocks, 1, nshells);
+
+  if( pure ) {
+    switch(l) {
+      case 0:
+        collocation_device_shell_to_task_kernel_cartesian_laplacian_0<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;
+      
+      case 1:
+        collocation_device_shell_to_task_kernel_spherical_laplacian_1<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 2:
+        collocation_device_shell_to_task_kernel_spherical_laplacian_2<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 3:
+        collocation_device_shell_to_task_kernel_spherical_laplacian_3<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 4:
+        collocation_device_shell_to_task_kernel_spherical_laplacian_4<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  } else {
+    switch(l) {      
+      case 0:
+        collocation_device_shell_to_task_kernel_cartesian_laplacian_0<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 1:
+        collocation_device_shell_to_task_kernel_cartesian_laplacian_1<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 2:
+        collocation_device_shell_to_task_kernel_cartesian_laplacian_2<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 3:
+        collocation_device_shell_to_task_kernel_cartesian_laplacian_3<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 4:
+        collocation_device_shell_to_task_kernel_cartesian_laplacian_4<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  }
+
+}
+
+
+
+void eval_collocation_shell_to_task_laplacian(
+  uint32_t                    max_l,
+  AngularMomentumShellToTaskBatch* l_batched_shell_to_task,
+  XCDeviceTask*               device_tasks,
+  device_queue           queue
+) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
+
+  for( auto l = 0u; l <= max_l; ++l ) {
+    auto pure = l_batched_shell_to_task[l].pure;
+    auto shell_to_task_device = l_batched_shell_to_task[l].shell_to_task_device;
+    auto nshells = l_batched_shell_to_task[l].nshells_in_batch;
+    auto ntask_average = std::max(1ul, l_batched_shell_to_task[l].ntask_average);
+    dispatch_shell_to_task_collocation_laplacian( stream, l, pure,
+      ntask_average, nshells, shell_to_task_device, device_tasks );
+    auto stat = cudaGetLastError();
+    GAUXC_HIP_ERROR("LAP", stat);
+  }
+
+
+}
+
+uint32_t max_threads_shell_to_task_collocation_lapgrad( int32_t l, bool pure ) {
+  if( pure ) {
+    switch(l) {
+      case 0: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_lapgrad_0 );      
+      case 1: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_lapgrad_1 );
+      
+      case 2: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_lapgrad_2 );
+      
+      case 3: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_lapgrad_3 );
+      
+      case 4: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_spherical_lapgrad_4 );
+      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  } else {
+    switch(l) {      
+      case 0: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_lapgrad_0 );      
+      case 1: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_lapgrad_1 );      
+      case 2: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_lapgrad_2 );      
+      case 3: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_lapgrad_3 );      
+      case 4: return util::hip_kernel_max_threads_per_block( collocation_device_shell_to_task_kernel_cartesian_lapgrad_4 );      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  }
+  return 0;
+}
+
+
+
+
+
+template <typename... Args>
+void dispatch_shell_to_task_collocation_lapgrad( hipStream_t stream, int32_t l,
+  bool pure, uint32_t ntask_average, uint32_t nshells, Args&&... args ) {
+
+  dim3 threads = max_threads_shell_to_task_collocation_lapgrad(l,pure);
+  int nwarp_per_block = threads.x / hip::warp_size;
+  int n_task_blocks = util::div_ceil( ntask_average, nwarp_per_block );
+  dim3 block(n_task_blocks, 1, nshells);
+
+  if( pure ) {
+    switch(l) {
+      case 0:
+        collocation_device_shell_to_task_kernel_cartesian_lapgrad_0<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;
+      
+      case 1:
+        collocation_device_shell_to_task_kernel_spherical_lapgrad_1<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 2:
+        collocation_device_shell_to_task_kernel_spherical_lapgrad_2<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 3:
+        collocation_device_shell_to_task_kernel_spherical_lapgrad_3<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 4:
+        collocation_device_shell_to_task_kernel_spherical_lapgrad_4<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  } else {
+    switch(l) {      
+      case 0:
+        collocation_device_shell_to_task_kernel_cartesian_lapgrad_0<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 1:
+        collocation_device_shell_to_task_kernel_cartesian_lapgrad_1<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 2:
+        collocation_device_shell_to_task_kernel_cartesian_lapgrad_2<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 3:
+        collocation_device_shell_to_task_kernel_cartesian_lapgrad_3<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      case 4:
+        collocation_device_shell_to_task_kernel_cartesian_lapgrad_4<<<block,threads,0,stream>>>( nshells, std::forward<Args>(args)... );
+        break;      
+      default: GAUXC_GENERIC_EXCEPTION("CUDA L_MAX = 4");
+    }
+  }
+
+}
+
+
+
+void eval_collocation_shell_to_task_lapgrad(
+  uint32_t                    max_l,
+  AngularMomentumShellToTaskBatch* l_batched_shell_to_task,
+  XCDeviceTask*               device_tasks,
+  device_queue           queue
+) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
+
+  for( auto l = 0u; l <= max_l; ++l ) {
+    auto pure = l_batched_shell_to_task[l].pure;
+    auto shell_to_task_device = l_batched_shell_to_task[l].shell_to_task_device;
+    auto nshells = l_batched_shell_to_task[l].nshells_in_batch;
+    auto ntask_average = std::max(1ul, l_batched_shell_to_task[l].ntask_average);
+    dispatch_shell_to_task_collocation_lapgrad( stream, l, pure,
+      ntask_average, nshells, shell_to_task_device, device_tasks );
+    auto stat = cudaGetLastError();
+    GAUXC_HIP_ERROR("LAPGRAD", stat);
+  }
+
+
+}
+
+
 
 } // namespace GauXC

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/collocation_masked_combined_kernels.hpp
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/collocation_masked_combined_kernels.hpp
@@ -17,7 +17,7 @@
 
 #include "device/hip/kernels/collocation/collocation_angular_cartesian.hpp"
 #include "device/hip/kernels/collocation/collocation_angular_spherical_unnorm.hpp"
-//#include "device/hip/kernels/hip_alg_variant_control.hpp"
+//#include "device/hip/kernels/cuda_alg_variant_control.hpp"
 #include "device/xc_device_task.hpp"
 
 namespace GauXC {
@@ -39,7 +39,7 @@ void collocation_device_masked_combined_kernel(
     auto& task = device_tasks[ blockIdx.z ];
   
     const auto               nshells     = task.bfn_screening.nshells;
-    const auto               nbf         = task.bfn_screening.nbe;
+    //const auto               nbf         = task.bfn_screening.nbe;
     const auto               npts        = task.npts;
     //const auto* __restrict__ pts_device  = task.points;
     const auto* __restrict__ pts_x_device  = task.points_x;
@@ -123,7 +123,7 @@ void collocation_device_masked_combined_kernel_deriv1(
     auto& task = device_tasks[ blockIdx.z ];
   
     const auto               nshells     = task.bfn_screening.nshells;
-    const auto               nbf         = task.bfn_screening.nbe;
+    //const auto               nbf         = task.bfn_screening.nbe;
     const auto               npts        = task.npts;
     //const auto* __restrict__ pts_device  = task.points;
     const auto* __restrict__ pts_x_device  = task.points_x;

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/collocation_shell_to_task_kernels.hpp
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/collocation_shell_to_task_kernels.hpp
@@ -1,0 +1,83 @@
+/**
+ * GauXC Copyright (c) 2020-2024, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of
+ * any required approvals from the U.S. Dept. of Energy).
+ *
+ * (c) 2024-2025, Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * See LICENSE.txt for details
+ */
+#pragma once
+
+
+#include "hip/hip_runtime.h"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l0.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l1.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l2.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l3.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l4.hpp"
+
+
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l0_gradient.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l1_gradient.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l2_gradient.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l3_gradient.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l4_gradient.hpp"
+
+
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l0_hessian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l1_hessian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l2_hessian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l3_hessian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l4_hessian.hpp"
+
+
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l0_laplacian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l1_laplacian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l2_laplacian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l3_laplacian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l4_laplacian.hpp"
+
+
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l0_lapgrad.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l1_lapgrad.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l2_lapgrad.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l3_lapgrad.hpp"
+#include "collocation/collocation_shell_to_task_kernels_cartesian_l4_lapgrad.hpp"
+
+
+#include "collocation/collocation_shell_to_task_kernels_spherical_l0.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l1.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l2.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l3.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l4.hpp"
+
+
+#include "collocation/collocation_shell_to_task_kernels_spherical_l0_gradient.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l1_gradient.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l2_gradient.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l3_gradient.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l4_gradient.hpp"
+
+
+#include "collocation/collocation_shell_to_task_kernels_spherical_l0_hessian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l1_hessian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l2_hessian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l3_hessian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l4_hessian.hpp"
+
+
+#include "collocation/collocation_shell_to_task_kernels_spherical_l0_laplacian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l1_laplacian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l2_laplacian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l3_laplacian.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l4_laplacian.hpp"
+
+
+#include "collocation/collocation_shell_to_task_kernels_spherical_l0_lapgrad.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l1_lapgrad.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l2_lapgrad.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l3_lapgrad.hpp"
+#include "collocation/collocation_shell_to_task_kernels_spherical_l4_lapgrad.hpp"

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/exx_ek_screening_bfn_stats.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/exx_ek_screening_bfn_stats.hip
@@ -1,0 +1,742 @@
+/**
+ * GauXC Copyright (c) 2020-2024, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of
+ * any required approvals from the U.S. Dept. of Energy).
+ *
+ * (c) 2024-2025, Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * See LICENSE.txt for details
+ */
+#include "hip/hip_runtime.h"
+#include "device/common/exx_ek_screening.hpp"
+#include <gauxc/util/div_ceil.hpp>
+#include <gauxc/shell.hpp>
+#include "device_specific/hip_util.hpp"
+#include "hip_extensions.hpp"
+#include "device_specific/hip_device_constants.hpp"
+#include <cub/device/device_scan.cuh>
+#include "buffer_adaptor.hpp"
+#include "device/common/device_blas.hpp"
+//#include <mpi.h>
+#include <chrono>
+//#include <fstream>
+#include "exceptions/hip_exception.hpp"
+
+namespace GauXC {
+
+__global__ void exx_ek_screening_bfn_stats_kernel( size_t ntasks, 
+                                                   double      * max_bfn_sum_device,
+                                                   double      * bfn_max_device,
+                                                   size_t        LDBFM,
+                                                   XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.x;
+  if( batch_idx >= ntasks ) return;
+  
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+  auto* basis_eval_device = task.bf;
+  const auto* weights_device    = task.weights;
+  //double* bfn_max_device  = task.bfn_max;
+
+  const int warp_lane = threadIdx.x % hip::warp_size;
+  const int warp_id   = threadIdx.x / hip::warp_size;
+  const int nwarp  = blockDim.x  / hip::warp_size;
+
+
+
+  // First scale the basis functions by the weights
+  for(int ipt = warp_lane; ipt < npts; ipt += hip::warp_size) {
+    const auto w = std::sqrt(weights_device[ipt]);
+    for(int ibf = warp_id; ibf < nbf; ibf += nwarp) {
+      const auto val = basis_eval_device[ ipt + ibf*npts ];
+      basis_eval_device[ ipt + ibf*npts ] = w * std::abs(val);
+    }
+  }
+  __syncthreads();
+
+
+
+
+  __shared__ double bf_shared[32][32 + 1];
+  __shared__ double bfn_sum_shared[32];
+  bfn_sum_shared[warp_lane] = 0.0;
+  __syncthreads();
+
+  const int npts_chunks = GauXC::util::div_ceil(npts, hip::warp_size);
+  const int  nbf_chunks = GauXC::util::div_ceil(nbf,  nwarp);
+  for(int ipts_chunk = 0; ipts_chunk < npts_chunks; ++ipts_chunk) {
+    double tmp_bfn_sum = 0.0;
+    const int ipt = ipts_chunk * hip::warp_size + warp_lane;
+  for(int  ibf_chunk = 0;  ibf_chunk <  nbf_chunks; ++ ibf_chunk) {
+    const int ibf =  ibf_chunk * nwarp + warp_id;
+
+    bf_shared[warp_id][warp_lane] = 0.0;
+
+    // Load in a block of basis functions
+    // Warp lane is the point index and warp ID is the bfn idx
+    if(ipt < npts and ibf < nbf) 
+      bf_shared[warp_id][warp_lane]  = basis_eval_device[ipt + ibf*npts];
+    __syncthreads();
+
+    // Do transpose
+    // Warp lane is the bfn index and warp ID is the point idx
+    auto tmp = bf_shared[warp_lane][warp_id];
+    __syncthreads();
+ 
+    // Do a sum reduce over basis functions for the chunk
+    // Now every warp has the local bfn chunk sum in lane 0
+    // corresponding to the point represented by the warp Id
+    tmp_bfn_sum += hip::warp_reduce_sum<hip::warp_size>(tmp);
+    
+  }
+    // At this point, every warp contains the total bfn sum
+    // for the point corresponding to its warp id. Update the 
+    // local value accordingly
+    if(warp_lane == 0) {
+      double val = bfn_sum_shared[warp_id];
+      bfn_sum_shared[warp_id] = fmax( val, tmp_bfn_sum );
+    }
+    __syncthreads();
+
+  }
+
+  // Get global maximum
+  double max_bfn_sum;
+  if(warp_id == 0) {
+    auto tmp = bfn_sum_shared[warp_lane];
+    max_bfn_sum = hip::warp_reduce_max<hip::warp_size>(tmp);
+  }
+
+  if(threadIdx.x == 0) {
+    //task.max_bfn_sum = max_bfn_sum;
+    max_bfn_sum_device[batch_idx] =  max_bfn_sum;
+    //printf("[GPU] ITASK = %d MAX_SUM = %.6e PTR = %x\n", batch_idx, max_bfn_sum, task.bfn_shell_indirection);
+    //printf("[GPU] ITASK = %d NBE = %lu NPTS = %lu \n", batch_idx, nbf, npts);
+  }
+
+
+  __syncthreads();
+  for(int ibf = warp_id; ibf < nbf; ibf += nwarp) {
+    double max_bf = 0;
+    for(int ipt = warp_lane; ipt < npts; ipt += hip::warp_size) {
+      const auto val = basis_eval_device[ipt + ibf*npts];
+      max_bf = fmax( max_bf, val );
+    }
+
+    // Warp reduce bf max
+    max_bf = hip::warp_reduce_max<hip::warp_size>(max_bf);
+    if(warp_lane == 0) {
+      //printf("[GPU] ITASK = %d MAX_BFN(0) = %.6e\n", batch_idx, max_bf);
+      bfn_max_device[batch_idx + task.bfn_shell_indirection[ibf]*LDBFM] =
+        max_bf; 
+    }
+  }
+
+}
+
+
+__global__ void exx_ek_collapse_fmax_to_shells_kernel(
+  int                  ntask,
+  int                  nshells,
+  const Shell<double>* shells_device,
+  const int32_t*       shell_to_bf,
+  const double*        fmax_bfn_device,
+  size_t               LDF_bfn,
+  double*              fmax_shell_device,
+  size_t               LDF_shell
+) {
+
+  const int total_nwarp_x   = (blockDim.x * gridDim.x) / hip::warp_size;
+  const int tid_x           = threadIdx.x + blockIdx.x*blockDim.x;
+  const int warp_lane       = tid_x % hip::warp_size;
+  const int warp_id_x       = tid_x / hip::warp_size;
+
+
+  //double sh_buffer[10];
+  double sh_buffer;
+
+  // Each warp gets a shell
+  for(int ish = warp_id_x; ish < nshells; ish += total_nwarp_x) {
+
+    const int sh_sz = shells_device[ish].size();
+    const int sh_st = shell_to_bf[ish];
+
+    // Read in tasks in warp-sized chunks
+    for(int i_task = warp_lane; i_task < ntask; i_task += hip::warp_size) {
+
+      // Get shell max
+      double sh_max = 0.0;
+      for(int ii = 0; ii < sh_sz; ++ii) {
+        sh_max = fmax(sh_max, fabs(fmax_bfn_device[i_task + (ii + sh_st)*LDF_bfn]));
+      }
+      
+      // Write to main memory
+      fmax_shell_device[i_task + ish*LDF_shell] = sh_max;
+      
+    }
+
+  }
+}
+
+
+__global__ void exx_ek_shellpair_collision_shared_kernel(
+  int32_t       ntasks,
+  int32_t       nshell_pairs,
+  int32_t       nshells,
+  int32_t       shell_buffer_length,
+  const double* V_max_sparse_device,
+  const size_t* sp_row_ind_device,
+  const size_t* sp_col_ind_device,
+  const double* F_max_shl_device,
+  size_t        LDF,
+  const double* max_bf_sum_device,
+  double        eps_E,
+  double        eps_K,
+  uint32_t*     collisions,
+  int           LD_coll,
+  uint32_t*     rc_collisions,
+  int           LD_rc,
+  uint32_t*     counts,
+  uint32_t*     rc_counts
+) {
+
+  extern __shared__ uint32_t s_rc_collisions[];
+
+  const int tid_x = threadIdx.y + blockIdx.x * blockDim.y;
+  const int nt_x  = blockDim.y * gridDim.x;
+
+  for(int i_task = tid_x; i_task < ntasks; i_task += nt_x) {
+
+    const auto max_bf_sum = max_bf_sum_device[i_task];
+
+    for (int i = threadIdx.x; i < shell_buffer_length; i+= blockDim.x) {
+      s_rc_collisions[i] = 0;
+    }
+    __syncthreads();
+
+    for(int ij_shell = threadIdx.x; ij_shell < nshell_pairs;  ij_shell+=blockDim.x) {
+
+      const auto i_shell = sp_row_ind_device[ij_shell]; 
+      const auto j_shell = sp_col_ind_device[ij_shell]; 
+
+      const auto V_ij = V_max_sparse_device[ij_shell];
+      const auto F_i  = F_max_shl_device[i_task + i_shell * LDF];
+      const auto F_j  = F_max_shl_device[i_task + j_shell * LDF];
+
+      const double eps_E_compare = F_i * F_j * V_ij;
+      const double eps_K_compare = fmax(F_i, F_j) * V_ij * max_bf_sum;
+      const bool comp = (eps_K_compare > eps_K or eps_E_compare > eps_E);
+
+      const int ij = ij_shell;
+      const int ij_block = ij / 32;
+      const int ij_local = ij % 32;
+      atomicOr(&(collisions[i_task * LD_coll + ij_block]), (comp ? (1u << ij_local) : 0));
+
+      const int i_block = i_shell / 32;
+      const int i_local = i_shell % 32;
+      atomicOr(&(s_rc_collisions[i_block]), (comp ? (1u << i_local) : 0));
+
+      const int j_block = j_shell / 32;
+      const int j_local = j_shell % 32;
+      atomicOr(&(s_rc_collisions[j_block]), (comp ? (1u << j_local) : 0));
+    }
+    __syncthreads();
+
+    // Write from shared to global memory
+    for (int i = threadIdx.x; i < shell_buffer_length; i+= blockDim.x) {
+      rc_collisions[i_task * LD_rc + i] = s_rc_collisions[i];
+    }
+    __syncthreads();
+
+
+    // TODO use thread block level reduction before writing to global memory
+    uint32_t count = 0;
+    for(int ij = threadIdx.x; ij < LD_coll; ij+=blockDim.x)  count += __popc(collisions[i_task * LD_coll + ij]);
+    atomicAdd(&(counts[i_task]), count);
+
+    count = 0;
+    for(int ij = threadIdx.x; ij < LD_rc; ij+=blockDim.x)  count += __popc(rc_collisions[i_task * LD_rc + ij]);
+    atomicAdd(&(rc_counts[i_task]), count);
+    __syncthreads();
+  }
+
+}
+
+
+__global__ void print_coll(size_t ntasks, size_t nshells, uint32_t* collisions,
+  size_t LD_coll) {
+
+
+  for(auto i_task = 0 ; i_task < ntasks; ++i_task) {
+
+    printf("[GPU] ITASK %d: ", i_task);
+    int count = 0;
+    for(int i_shell = 0, ij = 0; i_shell < nshells;  ++i_shell      )
+    for(int j_shell = 0;         j_shell <= i_shell; ++j_shell, ij++) {
+
+      const int ij_block = ij / 32;
+      const int ij_local = ij % 32;
+      if( collisions[i_task * LD_coll + ij_block] & (1u << ij_local) ) {
+        //printf("(%d, %d) ", i_shell, j_shell);
+        count++;
+      }
+    }
+    printf("%d\n", count);
+
+  }
+}
+
+__global__ void print_counts(size_t ntasks, uint32_t* counts) {
+
+
+  for(auto i_task = 0 ; i_task < ntasks; ++i_task) {
+
+    printf("[GPU] ITASK %d: %d\n", i_task,counts[i_task]);
+
+  }
+}
+
+
+
+
+template <int32_t buffer_size, typename buffer_type = uint32_t>
+__global__ void bitvector_to_position_list_shellpair(
+  size_t ntasks,
+  size_t nsp,
+  size_t LD_bit,
+  const uint32_t* collisions,
+  const uint32_t* counts,
+  uint32_t*       position_list
+) {
+
+  constexpr auto warp_size = hip::warp_size;
+  constexpr auto element_size = CHAR_BIT * sizeof(buffer_type);
+  constexpr auto buffer_size_bits = element_size * buffer_size;
+  __shared__ buffer_type collisions_buffer[warp_size][warp_size][buffer_size];
+
+  // We are converting a large number of small bitvectors into position lists. For this reason, I am assigning a single thread to each bitvector
+  // This avoids having to do popcounts and warp wide reductions, but hurts the memory access pattern
+
+  // All threads in a warp must be active to do shared memory loads, so we seperate out the threadId.x
+  for (int i_base = threadIdx.y * blockDim.x + blockIdx.x * blockDim.x * blockDim.y; i_base < ntasks; i_base += blockDim.x * blockDim.y * gridDim.x) {
+    const int i = i_base + threadIdx.x;
+    auto* out = position_list;
+    if (i != 0 && i < ntasks) {
+      out += counts[i-1];
+    } 
+
+    int current = 0;
+    size_t nsp_blocks = (nsp + buffer_size_bits - 1) / buffer_size_bits;
+    for (int j_block = 0; j_block < nsp_blocks; j_block++) {
+      // Each thread has a buffer of length BUFFER_SIZE. All the threads in the warp work to 
+      // load this data in a coalesced way (at least as much as possible)
+      for (int buffer_loop = 0; buffer_loop < warp_size; buffer_loop += warp_size/buffer_size) {
+        const int t_id_x        = threadIdx.x % buffer_size;
+        const int buffer_thread = threadIdx.x / buffer_size;
+        const int buffer_idx    = buffer_thread + buffer_loop;
+        if (j_block * buffer_size_bits + t_id_x * element_size < nsp && i_base + buffer_idx < ntasks) {
+          collisions_buffer[threadIdx.y][buffer_idx][t_id_x] = collisions[(i_base + buffer_idx) * LD_bit + j_block * buffer_size + t_id_x];
+        }
+      }
+
+      // __syncwarp();  // lockstep wavefronts on AMD
+      if (i < ntasks) {  // Once the data has been loaded, we exclude the threads not corresponding to a bitvector
+        // We have loaded in BUFFER_SIZE_BITS elements to be processed by each warp
+        for (int j_inner = 0; j_inner < buffer_size_bits && j_block * buffer_size_bits + j_inner < nsp; j_inner++) {
+          const int j = buffer_size_bits * j_block + j_inner;
+          const int j_int = j_inner / element_size;
+          const int j_bit = j_inner % element_size;
+          if( collisions_buffer[threadIdx.y][threadIdx.x][j_int] & (1 << (j_bit)) ) {
+            out[current++] = j;
+          }
+        }
+      }
+      // __syncwarp();  // lockstep wavefronts on AMD
+    }
+  }
+
+}
+
+
+
+
+
+template <int32_t buffer_size, typename buffer_type = uint32_t>
+__global__ void bitvector_to_position_list_shells( 
+           size_t  ntasks, 
+           size_t  nshells, 
+           size_t  LD_bit,
+    const uint32_t* collisions, 
+    const uint32_t* counts, 
+    const int32_t* shell_size,
+          uint32_t* position_list, 
+           size_t* nbe_list
+) {
+  constexpr auto warp_size = hip::warp_size;
+  constexpr auto element_size = CHAR_BIT * sizeof(buffer_type);
+  constexpr auto buffer_size_bits = element_size * buffer_size;
+  __shared__ buffer_type collisions_buffer[warp_size][warp_size][buffer_size];
+
+  // We are converting a large number of small bitvectors into position lists. For this reason, I am assigning a single thread to each bitvector
+  // This avoids having to do popcounts and warp wide reductions, but hurts the memory access pattern
+
+  // All threads in a warp must be active to do shared memory loads, so we seperate out the threadId.x
+  for (int i_base = threadIdx.y * blockDim.x + blockIdx.x * blockDim.x * blockDim.y; i_base < ntasks; i_base += blockDim.x * blockDim.y * gridDim.x) {
+    const int i = i_base + threadIdx.x;
+    auto* out = position_list;
+    if (i != 0 && i < ntasks) {
+      out += counts[i-1];
+    } 
+
+    int current = 0;
+    size_t nbe = 0;
+    size_t nsphere_blocks = (nshells + buffer_size_bits - 1) / buffer_size_bits;
+    for (int j_block = 0; j_block < nsphere_blocks; j_block++) {
+      // Each thread has a buffer of length BUFFER_SIZE. All the threads in the warp work to 
+      // load this data in a coalesced way (at least as much as possible)
+      for (int buffer_loop = 0; buffer_loop < warp_size; buffer_loop += warp_size/buffer_size) {
+        const int t_id_x        = threadIdx.x % buffer_size;
+        const int buffer_thread = threadIdx.x / buffer_size;
+        const int buffer_idx    = buffer_thread + buffer_loop;
+        if (j_block * buffer_size_bits + t_id_x * element_size < nshells && i_base + buffer_idx < ntasks) {
+          collisions_buffer[threadIdx.y][buffer_idx][t_id_x] = collisions[(i_base + buffer_idx) * LD_bit + j_block * buffer_size + t_id_x];
+        }
+      }
+
+      // __syncwarp();  // lockstep wavefronts on AMD
+      if (i < ntasks) {  // Once the data has been loaded, we exclude the threads not corresponding to a bitvector
+        // We have loaded in BUFFER_SIZE_BITS elements to be processed by each warp
+        for (int j_inner = 0; j_inner < buffer_size_bits && j_block * buffer_size_bits + j_inner < nshells; j_inner++) {
+          const int j = buffer_size_bits * j_block + j_inner;
+          const int j_int = j_inner / element_size;
+          const int j_bit = j_inner % element_size;
+          if( collisions_buffer[threadIdx.y][threadIdx.x][j_int] & (1 << (j_bit)) ) {
+            out[current++] = j;
+            nbe += shell_size[j];
+          }
+        }
+      }
+      // __syncwarp();  // lockstep wavefronts on AMD
+    }
+    if (i < ntasks) {
+      nbe_list[i] = nbe;
+    }
+  }
+}
+
+
+
+
+
+
+void exx_ek_screening_bfn_stats( size_t        ntasks,
+                                 XCDeviceTask* tasks_device,
+                                 double      * max_bfn_sum_device,
+                                 double      * bfn_max_device,
+                                 size_t        LDBFM,
+                                 device_queue queue ) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
+  dim3 threads = 1024;//hip::max_threads_per_thread_block;
+  dim3 blocks  = ntasks;
+  exx_ek_screening_bfn_stats_kernel<<<blocks, threads, 0, stream >>>(
+    ntasks, max_bfn_sum_device, bfn_max_device, LDBFM, tasks_device );
+
+}
+
+
+void exx_ek_collapse_fmax_to_shells(
+  int                  ntask,
+  int                  nshells,
+  const Shell<double>* shells_device,
+  const int32_t*       shell_to_bf,
+  const double*        fmax_bfn_device,
+  size_t               LDF_bfn,
+  double*              fmax_shell_device,
+  size_t               LDF_shell,
+  device_queue         queue
+) {
+
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
+  dim3 threads = 1024;//hip::max_threads_per_thread_block;
+  dim3 blocks  = std::max(ntask / hip::warp_size,1u);
+  exx_ek_collapse_fmax_to_shells_kernel<<<blocks, threads, 0, stream >>>(
+    ntask, nshells, shells_device, shell_to_bf, fmax_bfn_device, LDF_bfn,
+    fmax_shell_device, LDF_shell );
+
+}
+
+void exx_ek_shellpair_collision(
+  int32_t       ntasks,
+  int32_t       nshells,
+  int32_t       nbf,
+  const double* abs_dmat_device,
+  size_t        LDP,
+  const double* V_max_sparse_device,
+  const size_t* sp_row_ind_device,
+  const size_t* sp_col_ind_device,
+  const double* max_bf_sum_device,
+  const double* bfn_max_device,
+  size_t        LDBM,
+  const Shell<double>* shells_device,
+  const int32_t* shell_to_bf_device,
+  const int32_t* shell_sizes_device,
+  double        eps_E,
+  double        eps_K,
+  void*         dyn_stack,
+  size_t        dyn_size,
+  host_task_iterator tb,
+  host_task_iterator te,
+  const ShellPairCollection<double>& shpairs,
+  device_queue  queue,
+  device_blas_handle handle
+) {
+
+  using hrt_t = std::chrono::high_resolution_clock;
+  using dur_t = std::chrono::duration<double,std::milli>;
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>();
+  std::vector<uint32_t> counts_host    (ntasks);
+  std::vector<uint32_t> rc_counts_host (ntasks);
+
+  const size_t nshell_pairs = shpairs.npairs();
+  const size_t LD_coll   = util::div_ceil(nshell_pairs, 32);
+  const size_t LD_rc     = util::div_ceil(nshells     , 32);
+
+  // We need 1 bit per shell 
+  // This is the number of shells divided by 8
+  const int requiredSharedMemoryInBytes = LD_rc * sizeof(uint32_t);
+
+  // By default the maximum amount of shared memory per block is 48KiB, but
+  // newer archs can go higher with an opt-in setting
+  int dev_id = 0;
+  int maxSharedMemoryPerBlock, maxSharedMemoryPerBlockOptin;
+  hipDeviceGetAttribute(&maxSharedMemoryPerBlock,
+    hipDeviceAttributeMaxSharedMemoryPerBlock, dev_id);
+
+  hipDeviceGetAttribute(&maxSharedMemoryPerBlockOptin,
+    hipDeviceAttributeMaxSharedMemoryPerBlock, dev_id);
+
+  if (requiredSharedMemoryInBytes > maxSharedMemoryPerBlock) {
+    hipError_t res = hipFuncSetAttribute(&exx_ek_shellpair_collision_shared_kernel,
+      hipFuncAttributeMaxDynamicSharedMemorySize, maxSharedMemoryPerBlockOptin);
+
+    if (requiredSharedMemoryInBytes > maxSharedMemoryPerBlockOptin) {
+      throw hip_exception(__FILE__, __LINE__, "Number of shell pairs exceeds device shared memory", res);
+    }
+  }
+
+  buffer_adaptor full_stack(dyn_stack, dyn_size);
+
+  auto collisions    = full_stack.aligned_alloc<uint32_t>(ntasks * LD_coll);
+  auto counts        = full_stack.aligned_alloc<uint32_t>(ntasks);
+  auto rc_collisions = full_stack.aligned_alloc<uint32_t>(ntasks * LD_rc);
+  auto rc_counts     = full_stack.aligned_alloc<uint32_t>(ntasks);
+
+  auto sp_check_st = hrt_t::now();
+  util::hip_set_zero_async( ntasks * LD_coll,collisions.ptr,    stream, "Zero Coll");
+  util::hip_set_zero_async( ntasks * LD_rc,  rc_collisions.ptr, stream, "Zero RC");
+  util::hip_set_zero_async( ntasks,  counts.ptr, stream, "Zero counts");
+  util::hip_set_zero_async( ntasks,  rc_counts.ptr, stream, "Zero rc counts");
+
+  // Compute approximate FMAX and screen
+  {
+    buffer_adaptor sub_stack( full_stack.stack(), full_stack.nleft() );
+    double* fmax_shl_device = nullptr;
+    double* fmax_bfn_device = nullptr;
+    fmax_bfn_device = sub_stack.aligned_alloc<double>(ntasks * nbf);
+    fmax_shl_device = sub_stack.aligned_alloc<double>(ntasks * nshells);
+    
+    gemm(handle, DeviceBlasOp::NoTrans, DeviceBlasOp::NoTrans,
+      ntasks, nbf, nbf,
+      1.0, bfn_max_device,  LDBM, abs_dmat_device, nbf,
+      0.0, fmax_bfn_device, ntasks
+    );
+
+    exx_ek_collapse_fmax_to_shells( ntasks, nshells, shells_device,
+      shell_to_bf_device, fmax_bfn_device, ntasks, fmax_shl_device,
+      ntasks, queue );
+
+    //#if 1
+    //{
+    //std::vector<double> fmax_host(ntasks * nshells);
+    //util::hip_copy(ntasks * nshells,fmax_host.data(), fmax_shl_device);
+    //std::ofstream ofile("gpu_fmax." + std::to_string(world_rank) + ".txt");
+    //for(auto i = 0; i < ntasks; ++i) 
+    //for(auto j = 0; j < nshells; ++j) {
+    //  ofile << i << " " << fmax_host[i + j*ntasks] << std::endl;
+    //}
+    //}
+    //#else
+    //{
+    //std::vector<double> fmax_host(ntasks * nbf);
+    //util::hip_copy(ntasks * nbf,fmax_host.data(), fmax_bfn_device);
+    //std::ofstream ofile("gpu_fmax." + std::to_string(world_rank) + ".txt");
+    //for(auto i = 0; i < ntasks; ++i) 
+    //for(auto j = 0; j < nbf; ++j) {
+    //  ofile << i << " " << fmax_host[i + j*ntasks] << std::endl;
+    //}
+    //}
+    //#endif
+    
+    dim3 threads = dim3(512, 1);//hip::max_threads_per_thread_block;
+    dim3 blocks  = GauXC::util::div_ceil(ntasks,threads.y);
+    exx_ek_shellpair_collision_shared_kernel<<<blocks, threads,
+      requiredSharedMemoryInBytes, stream>>>(
+      ntasks, nshell_pairs, nshells, LD_rc, V_max_sparse_device, sp_row_ind_device,
+      sp_col_ind_device, fmax_shl_device, ntasks, 
+      max_bf_sum_device, eps_E, eps_K, collisions, LD_coll, 
+      rc_collisions, LD_rc, counts, rc_counts);
+  }
+  auto sp_check_en = hrt_t::now();
+  //util::hip_copy(ntasks, counts_host.data(), counts.ptr);
+  //util::hip_copy(ntasks, rc_counts_host.data(), rc_counts.ptr);
+  //{
+  //std::vector<double> max_bfn_host(ntasks);
+  //util::hip_copy(ntasks,max_bfn_host.data(), max_bf_sum_device);
+  //std::ofstream ofile("gpu_max_bfn." + std::to_string(world_rank) + ".txt");
+  //for(auto i = 0; i < ntasks; ++i) {
+  //  ofile << i << " " << max_bfn_host[i] << std::endl;
+  //}
+  //}
+  //{
+  //std::ofstream ofile("gpu_counts." + std::to_string(world_rank) + ".txt");
+  //for(auto i = 0; i < ntasks; ++i) {
+  //  ofile << i << " " << counts_host[i] << std::endl;
+  //}
+  //}
+  //{
+  //std::ofstream ofile("gpu_rc_counts." + std::to_string(world_rank) + ".txt");
+  //for(auto i = 0; i < ntasks; ++i) {
+  //  ofile << i << " " << rc_counts_host[i] << std::endl;
+  //}
+  //}
+
+  dur_t sp_check_dur = sp_check_en - sp_check_st;
+
+  hipError_t stat;
+
+  size_t prefix_sum_bytes = 0;
+  stat = hipcub::DeviceScan::InclusiveSum( NULL, prefix_sum_bytes,
+    counts.ptr, counts.ptr, ntasks, stream );
+
+
+  void* prefix_sum_storage = full_stack.aligned_alloc<char>(prefix_sum_bytes, 16);
+  
+  auto scan_st = hrt_t::now();
+
+  // Get inclusive sums
+  stat = hipcub::DeviceScan::InclusiveSum( prefix_sum_storage, prefix_sum_bytes,
+    counts.ptr, counts.ptr, ntasks, stream );
+  stat = hipcub::DeviceScan::InclusiveSum( prefix_sum_storage, prefix_sum_bytes,
+    rc_counts.ptr, rc_counts.ptr, ntasks, stream );
+
+  // Get counts after prefix sum
+  util::hip_copy(ntasks, counts_host.data(), counts.ptr);
+  util::hip_copy(ntasks, rc_counts_host.data(), rc_counts.ptr);
+  auto scan_en = hrt_t::now();
+  dur_t scan_dur = scan_en - scan_st;
+
+  uint32_t total_sp_count = counts_host[ntasks-1];
+  uint32_t total_s_count = rc_counts_host[ntasks-1];
+
+  //size_t global_sp_count = total_sp_count;
+  //MPI_Allreduce(MPI_IN_PLACE, &global_sp_count, 1, MPI_UINT64_T, MPI_SUM,
+  //  MPI_COMM_WORLD);
+  //if(!world_rank) {
+  //  printf("*****TOTAL_SP %lu\n", global_sp_count);
+  //}
+
+  auto bv_st = hrt_t::now();
+
+  auto position_sp_list_device = full_stack.aligned_alloc<uint32_t>(total_sp_count);
+  auto position_s_list_device  = full_stack.aligned_alloc<uint32_t>(total_s_count);
+  auto nbe_list                = full_stack.aligned_alloc<size_t>(ntasks);
+  {
+  dim3 threads(32,32);
+  dim3 blocks( util::div_ceil(ntasks, 1024) );
+  bitvector_to_position_list_shellpair<8><<<blocks, threads, 0, stream>>>(
+    ntasks, nshell_pairs, LD_coll, collisions, counts, position_sp_list_device
+  );
+  bitvector_to_position_list_shells<8><<<blocks, threads, 0, stream>>>(
+    ntasks, nshells, LD_rc, rc_collisions.ptr, rc_counts.ptr, shell_sizes_device,
+    position_s_list_device.ptr, nbe_list.ptr
+  );
+  }
+
+  std::vector<uint32_t> position_sp_list(total_sp_count);
+  util::hip_copy(total_sp_count, position_sp_list.data(), position_sp_list_device.ptr, "Position List ShellPair");
+
+  auto bv_en = hrt_t::now();
+  dur_t bv_dur = bv_en - bv_st;
+
+
+  auto d2h_st = hrt_t::now();
+  std::vector<uint32_t> position_s_list(total_s_count);
+  std::vector<size_t> nbe_list_host(ntasks);
+  util::hip_copy(total_s_count, position_s_list.data(), position_s_list_device.ptr, "Position List Shell");
+  util::hip_copy(ntasks, nbe_list_host.data(), nbe_list.ptr, "NBE List");
+  auto d2h_en = hrt_t::now();
+  dur_t d2h_dur = d2h_en - d2h_st;
+
+
+  auto gen_trip_st = hrt_t::now();
+  const auto& shpair_row_ptr = shpairs.row_ptr();
+  const auto& shpair_col_ind = shpairs.col_ind();
+  std::vector<size_t> shpair_row_ind(nshell_pairs);
+  for( auto i = 0; i < nshells; ++i ) {
+    const auto j_st = shpair_row_ptr[i];
+    const auto j_en = shpair_row_ptr[i+1];
+    for( auto _j = j_st; _j < j_en; ++_j ) {
+      shpair_row_ind[_j] = i;
+    }
+  }
+  auto gen_trip_en = hrt_t::now();
+  dur_t gen_trip_dur = gen_trip_en - gen_trip_st;
+
+  auto finalize_st = hrt_t::now();
+  for( auto it = tb; it != te; ++it ) {
+    {
+    size_t begin = (it == tb) ? 0 : counts_host[std::distance(tb,it)-1];
+    size_t end   = counts_host[std::distance(tb,it)];
+
+    it->cou_screening.shell_pair_list.resize(end - begin);
+    it->cou_screening.shell_pair_idx_list.resize(end - begin);
+    for( auto ij = begin, idx = 0ul; ij < end; ++ij, ++idx) {
+      const auto global_ij =  position_sp_list[ij];
+      it->cou_screening.shell_pair_idx_list[idx] = global_ij;
+      it->cou_screening.shell_pair_list[idx] = std::make_pair(
+        shpair_row_ind[global_ij], shpair_col_ind[global_ij]
+      );
+    }
+    }
+
+    {
+    size_t begin = (it == tb) ? 0 : rc_counts_host[std::distance(tb,it)-1];
+    size_t end   = rc_counts_host[std::distance(tb,it)];
+
+    it->cou_screening.shell_list.resize(end - begin);
+    it->cou_screening.nbe = nbe_list_host[std::distance(tb,it)];
+    for( auto ij = begin, idx = 0ul; ij < end; ++ij, ++idx) {
+      it->cou_screening.shell_list[idx] = position_s_list[ij]; 
+    }
+    }
+    
+  }
+
+  auto finalize_en = hrt_t::now();
+  dur_t finalize_dur = finalize_en - finalize_st;
+  
+
+  //printf("SPC = %.3f SCAN = %.3f BV = %.3f D2H = %.3f GT = %.3f FIN = %.3f\n", 
+  //  sp_check_dur.count(), scan_dur.count(), bv_dur.count(),
+  //  d2h_dur.count(), gen_trip_dur.count(), finalize_dur.count());
+  
+}
+
+}

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/grid_to_center.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/grid_to_center.hip
@@ -13,14 +13,14 @@
 #include <gauxc/util/div_ceil.hpp>
 #include "grid_to_center.hpp"
 #include "device_specific/hip_device_constants.hpp"
-#include "exceptions/hip_exception.hpp"
 
 namespace GauXC {
 
 __global__ void compute_grid_to_center_dist(
-        int32_t npts,
-        int32_t natoms,
+        size_t npts,
+        size_t natoms,
   const double* coords,
+  //const double* points,
   const double* points_x,
   const double* points_y,
   const double* points_z,
@@ -28,37 +28,61 @@ __global__ void compute_grid_to_center_dist(
         size_t lddist
 ) {
 
-  const auto tid_x = threadIdx.x + blockIdx.x*blockDim.x;
-  const auto tid_y = threadIdx.y + blockIdx.y*blockDim.y;
+  __shared__ double3 point_buffer[hip::warp_size];
+  register double3 coord_reg;
 
-  if( tid_x < natoms && tid_y < npts ) {
-    const double3* coords_vec = (double3*) coords;
-    const auto RA = coords_vec[tid_x];
+  const int natoms_block = (natoms + hip::warp_size-1) / hip::warp_size;
+  const int coords_block = (npts + hip::warp_size-1) / hip::warp_size;
 
-    const double rix = points_x[tid_y];
-    const double riy = points_y[tid_y];
-    const double riz = points_z[tid_y];
+  const double3* coords_vec = (double3*) coords;
+  //const double3* points_vec = (double3*) points;
 
-    const auto rx = RA.x - rix;
-    const auto ry = RA.y - riy;
-    const auto rz = RA.z - riz;
+  for (int j = blockIdx.x; j < natoms_block; j += gridDim.x) {
+    const int iAtom = j * hip::warp_size + threadIdx.x;
+    // Load blocks into registers/shared memory
+    if (iAtom < natoms) {
+      coord_reg = coords_vec[iAtom];
+    }
+    for (int i = blockIdx.y; i < coords_block; i += gridDim.y) {
+      const int iPt_load = i * hip::warp_size + threadIdx.x;
+      if (iPt_load < npts) {
+        //point_buffer[threadIdx.x] = points_vec[iPt_load];
+        point_buffer[threadIdx.x].x = points_x[iPt_load];
+        point_buffer[threadIdx.x].y = points_y[iPt_load];
+        point_buffer[threadIdx.x].z = points_z[iPt_load];
+      }
+      __syncthreads();
 
-    dist[ tid_x + tid_y * lddist ] = std::sqrt(rx*rx + ry*ry + rz*rz);
+      // do the computation
+      #pragma unroll 2
+      for (int k = threadIdx.y; k < hip::warp_size; k+=hip::warp_size/2) {
+        const int iPt_sm = k;
+        const int iPt = i * hip::warp_size + iPt_sm;
+        const double rx = point_buffer[iPt_sm].x - coord_reg.x;
+        const double ry = point_buffer[iPt_sm].y - coord_reg.y;
+        const double rz = point_buffer[iPt_sm].z - coord_reg.z;
+
+        if (iAtom < natoms and iPt < npts) {
+          dist[ iAtom + iPt * lddist ] = std::sqrt( rx*rx + ry*ry + rz*rz );
+        }
+      }
+      __syncthreads();
+    }
   }
-
 }
 
 void compute_grid_to_center_dist( int32_t npts, int32_t natoms,
-  const double* coords, const double* points_x,  const double* points_y, 
+  const double* coords, const double* points_x, const double* points_y, 
   const double* points_z, double* dist, int32_t lddist, hipStream_t stream ) {
 
+    const int distance_thread_y = hip::max_warps_per_thread_block / 2;
+    dim3 threads( hip::warp_size, distance_thread_y );
+    dim3 blocks( util::div_ceil( natoms,   threads.x), 
+                 util::div_ceil( npts, threads.y * distance_thread_y) );
 
-  dim3 threads( hip::warp_size, hip::max_warps_per_thread_block );
-  dim3 blocks( util::div_ceil( natoms, threads.x ),
-               util::div_ceil( npts, threads.y ) );
-
-  hipLaunchKernelGGL( compute_grid_to_center_dist, blocks, threads, 0, stream,
-    npts, natoms, coords, points_x, points_y, points_z, dist, lddist );
+    compute_grid_to_center_dist<<< blocks, threads, 0, stream>>>(
+      npts, natoms, coords, points_x, points_y, points_z, dist, lddist
+    );
 
 }
 

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/grid_to_center.hpp
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/grid_to_center.hpp
@@ -18,3 +18,4 @@ void compute_grid_to_center_dist( int32_t npts, int32_t natoms,
   const double* points_z, double* dist, int32_t lddist, hipStream_t stream );
 
 }
+#include "hip/hip_runtime.h"

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/hip_extensions.hpp
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/hip_extensions.hpp
@@ -11,41 +11,36 @@
  */
 #pragma once
 #include "hip/hip_runtime.h"
-#include <hipcub/hipcub.hpp>
-#include "device_specific/hip_device_constants.hpp"
+#include <cuda.h>
 
 namespace GauXC {
-namespace hip   {
+namespace cuda  {
 
 template <size_t warp_sz, typename T>
-__device__ T warp_reduce_sum( T val ) { 
+__device__ T warp_reduce_sum(T val) {
 
-  using warp_reducer = hipcub::WarpReduce<double>;
-  static __shared__ typename warp_reducer::TempStorage 
-    temp_storage[hip::max_warps_per_thread_block];
-  int tid = 
-    threadIdx.x + threadIdx.y * blockDim.x + threadIdx.z * blockDim.x * blockDim.y;
+  for(int i=(warp_sz/2); i>=1; i/=2)
+    val += __shfl_xor(val, i, warp_sz);
 
-  int warp_lane = tid / warp_size;
-
-  return warp_reducer( temp_storage[warp_lane] ).Sum( val );
-
+  return val;
 }
 
 template <size_t warp_sz, typename T>
-__device__ T warp_reduce_prod( T val ) { 
+__device__ T warp_reduce_prod(T val) {
 
-  using warp_reducer = hipcub::WarpReduce<double>;
-  static __shared__ typename warp_reducer::TempStorage 
-    temp_storage[hip::max_warps_per_thread_block];
-  int tid = 
-    threadIdx.x + threadIdx.y * blockDim.x + threadIdx.z * blockDim.x * blockDim.y;
+  for(int i=(warp_sz/2); i>=1; i/=2)
+    val *= __shfl_xor(val, i, warp_sz);
 
-  int warp_lane = tid / warp_size;
+  return val;
+}
 
-  return warp_reducer( temp_storage[warp_lane] ).Reduce( val,
-    [](const T& a, const T& b){ return a * b; } );
+template <size_t warp_sz, typename T>
+__device__ T warp_reduce_max(T val) {
 
+  for(int i=(warp_sz/2); i>=1; i/=2)
+    val = fmax( val, __shfl_xor(val, i, warp_sz) );
+
+  return val;
 }
 
 }

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/hip_inc_potential.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/hip_inc_potential.hip
@@ -9,77 +9,216 @@
  *
  * See LICENSE.txt for details
  */
-#include "device_specific/hip_device_constants.hpp"
+#include "hip/hip_runtime.h"
 #include "device/common/inc_potential.hpp"
+#include "device_specific/hip_device_constants.hpp"
 #include <gauxc/util/div_ceil.hpp>
 #include "device_specific/hip_util.hpp"
 
 
 namespace GauXC {
 
-template <typename T>
-__global__ void inc_by_submat_combined_kernel( size_t           ntasks,
-                                               XCDeviceTask* device_tasks,
-                                               T*               A,
-                                               size_t           LDA ) {
+
+#define WARP_X 16
+#define WARP_Y 1
+#define UNROLL_FACTOR 4
+#define EFF_UNROLL 4
+#define CUT_X 8
+#define CUT_Y 8
+
+
+__global__ __launch_bounds__(1024, 1)
+void sym_inc_by_submat_combined_kernel( size_t        ntasks,
+                                    XCDeviceTask* device_tasks,
+                                    double*       A,
+                                    size_t        LDA, 
+				    const int block_y,
+				    const int block_x ) {
 
   const int batch_id = blockIdx.z;
-
-  if( batch_id < ntasks ) {
-
   auto& task = device_tasks[ batch_id ];
 
-  const auto  ncut              = task.bfn_screening.ncut;
   const auto* submat_cut_device = task.bfn_screening.submat_cut;
+  const auto* submat_block_device = task.bfn_screening.submat_block;
   const auto  LDAS              = task.bfn_screening.nbe;
         auto* ASmall_device     = task.nbe_scr;
 
   //if( LDAS == LDAB ) return;
+  const int tid_xx = threadIdx.x % WARP_X;
+  const int tid_xy = threadIdx.x / WARP_X;
 
+  const int tid_yx = threadIdx.y % CUT_X;
+  const int tid_yy = threadIdx.y / CUT_X;
 
-  const int tid_x = blockDim.x * blockIdx.x + threadIdx.x;
-  const int tid_y = blockDim.y * blockIdx.y + threadIdx.y;
+  const int start_cut_y = submat_block_device[block_y];
+  const int end_cut_y   = submat_block_device[block_y+1];
+  const int start_cut_x = submat_block_device[block_x];
+  const int end_cut_x   = submat_block_device[block_x+1];
 
-  int64_t i(0);
-  for( size_t i_cut = 0; i_cut < ncut; ++i_cut ) {
-    const int64_t i_cut_first  = submat_cut_device[ 3*i_cut ];
-    const int64_t delta_i      = submat_cut_device[ 3*i_cut + 1 ];
+  for( int i_cut = tid_yy + start_cut_y; i_cut < end_cut_y; i_cut += CUT_Y ) {
+    const int3 i_data = *((int3*)(submat_cut_device + 3*i_cut));
+    const int i_cut_first  = i_data.x;
+    const int delta_i      = i_data.y;
+    const int i_cut_small  = i_data.z;
 
-    int64_t j(0);
-  for( size_t j_cut = 0; j_cut < ncut; ++j_cut ) {
-    const int64_t j_cut_first  = submat_cut_device[ 3*j_cut ];
-    const int64_t delta_j      = submat_cut_device[ 3*j_cut + 1 ];
+  for( int j_cut = tid_yx + start_cut_x; j_cut < end_cut_x; j_cut += CUT_X ) {
+    const int3 j_data = *((int3*)(submat_cut_device + 3*j_cut));
+    const int j_cut_first  = j_data.x; 
+    const int delta_j      = j_data.y;
+    const int j_cut_small  = j_data.z;
 
-    auto* ASmall_begin = ASmall_device + i           + j          *LDAS;
-    auto* ABig_begin   = A             + i_cut_first + j_cut_first*LDA ;
+    auto* ASmall_begin = ASmall_device + i_cut_small + j_cut_small*LDAS;
+    auto* ABig_begin   = A   + i_cut_first + j_cut_first*LDA;
 
-    for( size_t J = tid_y; J < delta_j; J += blockDim.y )      
-    for( size_t I = tid_x; I < delta_i; I += blockDim.x )
-      //ABig_begin[I + J*LDA] += ASmall_begin[I + J*LDAS];
-      atomicAdd( ABig_begin + I + J*LDA, ASmall_begin[I+J*LDAS] );
+    int J;
+    for( J = tid_xy; J < (delta_j / EFF_UNROLL) * EFF_UNROLL; J += EFF_UNROLL ) {
+      for( int I = tid_xx; I < delta_i; I += WARP_X ) {
 
-    j += delta_j;
+        double val[UNROLL_FACTOR];
+        double* address[UNROLL_FACTOR];
+#pragma unroll
+        for (int k = 0; k < UNROLL_FACTOR; k++) {
+          val[k] = ASmall_begin[I + (J+k*WARP_Y)*LDAS];
+          address[k] = ABig_begin + I + (J+k*WARP_Y)*LDA;
+        }
+#pragma unroll
+        for (int k = 0; k < UNROLL_FACTOR; k++) {
+          atomicAdd(address[k], val[k] );
+        }
+      }
+    }
+
+    for ( ; J < delta_j; J += WARP_Y) {
+      for( int I = tid_xx; I < delta_i; I += WARP_X ) {
+        atomicAdd(ABig_begin + I + J*LDA, ASmall_begin[I + J*LDAS] );
+      }
+    }
+
   }
-    i += delta_i;
   }
-
-  } // batch_id check
 }
+
 
 void sym_task_inc_potential( size_t        ntasks,
                          XCDeviceTask* device_tasks,
                          double*       V_device,
                          size_t        LDV,
                          size_t        submat_block_size,
-                         device_queue queue ) {
-
+                         device_queue  queue ) {
 
   hipStream_t stream = queue.queue_as<util::hip_stream>();
-  dim3 threads(hip::warp_size,hip::max_warps_per_thread_block,1), 
-       blocks(1,1,ntasks);
-  hipLaunchKernelGGL(inc_by_submat_combined_kernel, blocks, threads, 0, stream , 
-    ntasks, device_tasks, V_device, LDV
-  );
+
+  dim3 threads( hip::warp_size/2, hip::max_warps_per_thread_block * 2, 1 );
+  dim3 blocks( 1,1, ntasks );
+
+  auto n_launch = util::div_ceil( LDV, submat_block_size );
+  for (int i = 0; i < n_launch; i++) 
+  for (int j = 0; j < n_launch; j++) {
+    sym_inc_by_submat_combined_kernel<<< blocks, threads, 0, stream >>>(
+      ntasks, device_tasks, V_device, LDV, i, j
+    );
+  }
+
+}
+
+
+
+
+
+__global__ __launch_bounds__(1024, 1)
+void asym_inc_by_submat_combined_kernel( size_t        ntasks,
+                                    XCDeviceTask* device_tasks,
+                                    double*       A,
+                                    size_t        LDA, 
+				    const int block_y,
+				    const int block_x ) {
+
+  const int batch_id = blockIdx.z;
+  auto& task = device_tasks[ batch_id ];
+
+  const auto* row_submat_cut_device = task.bfn_screening.submat_cut;
+  const auto* row_submat_block_device = task.bfn_screening.submat_block;
+  const auto* col_submat_cut_device = task.cou_screening.submat_cut;
+  const auto* col_submat_block_device = task.cou_screening.submat_block;
+
+  const auto  LDAS              = task.bfn_screening.nbe;
+        auto* ASmall_device     = task.nbe_scr;
+
+  //if( LDAS == LDAB ) return;
+  const int tid_xx = threadIdx.x % WARP_X;
+  const int tid_xy = threadIdx.x / WARP_X;
+
+  const int tid_yx = threadIdx.y % CUT_X;
+  const int tid_yy = threadIdx.y / CUT_X;
+
+  const int start_cut_y = row_submat_block_device[block_y];
+  const int end_cut_y   = row_submat_block_device[block_y+1];
+  const int start_cut_x = col_submat_block_device[block_x];
+  const int end_cut_x   = col_submat_block_device[block_x+1];
+
+  for( int i_cut = tid_yy + start_cut_y; i_cut < end_cut_y; i_cut += CUT_Y ) {
+    const int3 i_data = *((int3*)(row_submat_cut_device + 3*i_cut));
+    const int i_cut_first  = i_data.x;
+    const int delta_i      = i_data.y;
+    const int i_cut_small  = i_data.z;
+
+  for( int j_cut = tid_yx + start_cut_x; j_cut < end_cut_x; j_cut += CUT_X ) {
+    const int3 j_data = *((int3*)(col_submat_cut_device + 3*j_cut));
+    const int j_cut_first  = j_data.x; 
+    const int delta_j      = j_data.y;
+    const int j_cut_small  = j_data.z;
+
+    auto* ASmall_begin = ASmall_device + i_cut_small + j_cut_small*LDAS;
+    auto* ABig_begin   = A   + i_cut_first + j_cut_first*LDA;
+
+    int J;
+    for( J = tid_xy; J < (delta_j / EFF_UNROLL) * EFF_UNROLL; J += EFF_UNROLL ) {
+      for( int I = tid_xx; I < delta_i; I += WARP_X ) {
+
+        double val[UNROLL_FACTOR];
+        double* address[UNROLL_FACTOR];
+#pragma unroll
+        for (int k = 0; k < UNROLL_FACTOR; k++) {
+          val[k] = ASmall_begin[I + (J+k*WARP_Y)*LDAS];
+          address[k] = ABig_begin + I + (J+k*WARP_Y)*LDA;
+        }
+#pragma unroll
+        for (int k = 0; k < UNROLL_FACTOR; k++) {
+          atomicAdd(address[k], val[k] );
+        }
+      }
+    }
+
+    for ( ; J < delta_j; J += WARP_Y) {
+      for( int I = tid_xx; I < delta_i; I += WARP_X ) {
+        atomicAdd(ABig_begin + I + J*LDA, ASmall_begin[I + J*LDAS] );
+      }
+    }
+
+  }
+  }
+}
+
+
+void asym_task_inc_potential( size_t        ntasks,
+                         XCDeviceTask* device_tasks,
+                         double*       V_device,
+                         size_t        LDV,
+                         size_t        submat_block_size,
+                         device_queue  queue ) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>();
+
+  dim3 threads( hip::warp_size/2, hip::max_warps_per_thread_block * 2, 1 );
+  dim3 blocks( 1,1, ntasks );
+
+  auto n_launch = util::div_ceil( LDV, submat_block_size );
+  for (int i = 0; i < n_launch; i++) 
+  for (int j = 0; j < n_launch; j++) {
+    asym_inc_by_submat_combined_kernel<<< blocks, threads, 0, stream >>>(
+      ntasks, device_tasks, V_device, LDV, i, j
+    );
+  }
 
 }
 

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/hip_ssf_1d.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/hip_ssf_1d.hip
@@ -10,13 +10,11 @@
  * See LICENSE.txt for details
  */
 #include "hip/hip_runtime.h"
-#include "hip_ssf_1d.hpp"
+#include "cuda_ssf_1d.hpp"
 #include "device_specific/hip_device_constants.hpp"
 #include "common/integrator_constants.hpp"
 #include <gauxc/util/div_ceil.hpp>
 #include <numeric>
-#include <iostream>
-#include "exceptions/hip_exception.hpp"
 
 static constexpr auto eps_d = std::numeric_limits<double>::epsilon();
 
@@ -28,10 +26,10 @@ __global__ void modify_weights_ssf_kernel_1d(
         size_t                            npts,
         size_t                            natoms,
   const double*                           RAB,
-        size_t                            ldRAB,
+        int32_t                           ldRAB,
   const double*                           coords,
   const double*                           dist_scratch,
-        size_t                            lddist,
+        int32_t                           lddist,
   const int32_t*                          iparent_device,
   const double*                           dist_nearest_device,
         double*                           weights_device
@@ -40,22 +38,23 @@ __global__ void modify_weights_ssf_kernel_1d(
   // Frisch partition functions
   auto gFrisch = [](double x) {
 
-    const double s_x  = x / integrator::magic_ssf_factor<>;
+    const double s_x  = x  * 1.5625; // / integrator::magic_ssf_factor<>;
     const double s_x2 = s_x  * s_x;
     const double s_x3 = s_x  * s_x2;
     const double s_x5 = s_x3 * s_x2;
     const double s_x7 = s_x5 * s_x2;
 
-    return (35.*(s_x - s_x3) + 21.*s_x5 - 5.*s_x7) / 16.;
+    //return (35.*(s_x - s_x3) + 21.*s_x5 - 5.*s_x7) / 16.;
+    return ((35.)*(s_x - s_x3) + (21.)*s_x5 - (5.)*s_x7);
   };
   
   auto sFrisch = [&] (double x) {
-    if( fabs(x) < integrator::magic_ssf_factor<> ) return 0.5 * (1. - gFrisch(x));
+    if( fabs(x) < integrator::magic_ssf_factor<> ) return (0.5 - (0.5/16.) * gFrisch(x));
     else if( x >= integrator::magic_ssf_factor<> ) return 0.;
     else                               return 1.;
   };
 
-  constexpr double weight_tol = 1e-10;
+  constexpr double weight_tol = integrator::ssf_weight_tol;
 
   const int tid_x = threadIdx.x + blockIdx.x * blockDim.x;
   const int nt_x  = blockDim.x  * gridDim.x;
@@ -107,7 +106,7 @@ __global__ void modify_weights_ssf_kernel_1d(
 
       const double ri = local_dist_scratch[ iCenter ];
 
-      const double* const local_rab = RAB + iCenter * natoms;
+      const double* const local_rab = RAB + iCenter * ldRAB;
 
       double ps = 1.;
       for( int jCenter = 0; jCenter < natoms; jCenter++ ) 
@@ -129,6 +128,7 @@ __global__ void modify_weights_ssf_kernel_1d(
     weights_device[ipt] *= parent_weight / sum;
   }
 
+
 }
 
 void partition_weights_ssf_1d( int32_t npts, int32_t natoms, const double* RAB,
@@ -138,10 +138,233 @@ void partition_weights_ssf_1d( int32_t npts, int32_t natoms, const double* RAB,
 
   dim3 threads( hip::max_threads_per_thread_block );
   dim3 blocks ( util::div_ceil( npts, threads.x ) );
-  hipLaunchKernelGGL(modify_weights_ssf_kernel_1d, dim3(blocks), dim3(threads), 0, stream, 
+  modify_weights_ssf_kernel_1d<<<blocks, threads, 0, stream>>>(
     npts, natoms, RAB, ldRAB, coords, dist, lddist, iparent, dist_nearest, weights
   );
 
 }
+
+__global__ void eval_weight_1st_deriv_contracted_ssf_kernel_1d(
+        size_t                            npts,
+        size_t                            natoms,
+  const double*                           RAB,
+        int32_t                           ldRAB,
+  const double*                           coords,
+  const double*                           points_x,
+  const double*                           points_y,
+  const double*                           points_z,
+  const double*                           dist_scratch,
+        int32_t                           lddist,
+  const int32_t*                          iparent_device,
+  const double*                           dist_nearest_device,
+  const double*       __restrict__        w_times_f_device,
+        double*       __restrict__        exc_grad_w_device
+) {
+
+  // Frisch partition functions
+  auto gFrisch = [](double x) {
+
+    const double s_x  = x  * 1.5625; // / integrator::magic_ssf_factor<>;
+    const double s_x2 = s_x  * s_x;
+    const double s_x3 = s_x  * s_x2;
+    const double s_x5 = s_x3 * s_x2;
+    const double s_x7 = s_x5 * s_x2;
+
+    return ((35.)*(s_x - s_x3) + (21.)*s_x5 - (5.)*s_x7);
+  };
+  
+  auto sFrisch = [&] (double x) {
+    if( fabs(x) < integrator::magic_ssf_factor<> ) return (0.5 - (0.5/16.) * gFrisch(x));
+    else if( x >= integrator::magic_ssf_factor<> ) return 0.;
+    else                               return 1.;
+  };
+  
+  auto tFrisch = [&](double x) {
+    const double s_x  = x * 1.5625; // / integrator::magic_ssf_factor<>;
+    const double s_x2 = s_x  * s_x;
+    const double s_x3 = s_x  * s_x2;
+    const double numerator = (35.) * (s_x3 + (3.) * s_x2 + (3.) * s_x + (1.));
+    const double denominator = (x - integrator::magic_ssf_factor<>) * ((5.)*s_x3 + (20.)*s_x2 + (29.)*s_x + (16.));
+    return numerator / denominator ;
+  };
+
+  constexpr double safe_magic_ssf_bound = integrator::magic_ssf_factor<> - 1e-4;
+  constexpr double weight_tol = integrator::ssf_weight_tol;
+  constexpr double w_times_f_thresh = 1.e-12;
+
+  const int tid_x = threadIdx.x + blockIdx.x * blockDim.x;
+  const int nt_x  = blockDim.x  * gridDim.x;
+
+  for( int ipt = tid_x; ipt < npts; ipt += nt_x ) {
+
+    const auto w_times_f_i = w_times_f_device[ipt];
+    if (fabs(w_times_f_i) < w_times_f_thresh) continue; // weight derivative = 0 when p_A = 0
+    const auto iParent = iparent_device[ipt];
+
+    double sum = 0.; 
+    double parent_weight = 0.;
+
+    const double* const local_dist_scratch = dist_scratch + ipt * lddist;
+    const double dist_cutoff = 0.18 * dist_nearest_device[ipt]; // 0.5 * (1-integrator::magic_ssf_factor<>) * task.dist_nearest
+    if( local_dist_scratch[iParent] < dist_cutoff ) continue; //weight derivative = 0 when p_A = 1
+
+    // Do iParent First
+    {
+      const double ri = local_dist_scratch[ iParent ];
+      const double* const local_rab = RAB + iParent * ldRAB;
+
+      parent_weight = 1.;
+      for( int jCenter = 0; jCenter < natoms; jCenter++ ) 
+      if( parent_weight > weight_tol ) {
+      if( iParent != jCenter ) {
+      
+        const double rj = local_dist_scratch[ jCenter ];
+
+        const double mu = (ri - rj) * local_rab[ jCenter ]; // XXX: RAB is symmetric
+        parent_weight *= sFrisch( mu );
+
+      }
+      } else break;
+
+      sum += parent_weight;
+    }
+
+    // caculate sum
+    for( int iCenter = 0; iCenter < natoms; iCenter++ ) 
+    if ( iParent != iCenter ) {
+      const double ri = local_dist_scratch[ iCenter ];
+      const double* const local_rab = RAB + iCenter * ldRAB;
+      double ps = 1.;
+      for( int jCenter = 0; jCenter < natoms; jCenter++ ) 
+      if( ps > weight_tol ) {
+        if( iCenter != jCenter ) {
+        
+          const double rj = local_dist_scratch[ jCenter ];
+          const double mu = (ri - rj) * local_rab[ jCenter ]; // XXX: RAB is symmetric
+          ps *= sFrisch( mu );
+        }
+      } else break;
+
+      sum += ps;
+
+    }
+
+    double sum_inv = 1. / sum;
+
+    const double point_x = points_x[ipt];
+    const double point_y = points_y[ipt];
+    const double point_z = points_z[ipt];
+
+    // Now do derivative
+    for( int iB = 0; iB < natoms; iB++ ) 
+    if( iParent != iB ) 
+    {
+      double exc_grad_w_iBx = 0.0, exc_grad_w_iBy = 0.0, exc_grad_w_iBz = 0.0;
+
+      const double* const local_Rinv_B = RAB + iB * ldRAB;
+      const double rB = local_dist_scratch[ iB ];
+      const double coords_B_x = coords[3*iB + 0];
+      const double coords_B_y = coords[3*iB + 1];
+      const double coords_B_z = coords[3*iB + 2];
+
+      // first term
+      const double rA = local_dist_scratch[ iParent ];
+      const double rAB_inv = local_Rinv_B[ iParent ];
+      const double mu_AB = (rA - rB) * rAB_inv; 
+      if( fabs(mu_AB) < safe_magic_ssf_bound) {
+        // first term is tFrisch(mu_AB) * (PA-Z)/Z * w_times_f_i * nabla_B mu_BA 
+        double coef1 = tFrisch(mu_AB) * rAB_inv * (parent_weight - sum) * sum_inv * w_times_f_i / rB;
+        exc_grad_w_iBx = coef1 * (coords_B_x - point_x + mu_AB * ( coords_B_x - coords[3*iParent + 0]) * rAB_inv * rB);
+        exc_grad_w_iBy = coef1 * (coords_B_y - point_y + mu_AB * ( coords_B_y - coords[3*iParent + 1]) * rAB_inv * rB);
+        exc_grad_w_iBz = coef1 * (coords_B_z - point_z + mu_AB * ( coords_B_z - coords[3*iParent + 2]) * rAB_inv * rB);
+      }
+
+      // second term and third term
+      // first need to calculate PB
+      double PB = 1.;
+      for( int jCenter = 0; jCenter < natoms; jCenter++ )
+      if( PB > weight_tol ) {
+        if( iB != jCenter ) {
+          const double rj = local_dist_scratch[ jCenter ];
+          const double mu = (rB - rj) * local_Rinv_B[ jCenter ]; 
+          PB *= sFrisch( mu );
+        }
+      } else break;
+
+      if( PB >  weight_tol ) 
+        for( int iC = 0; iC < natoms; iC++ ) {
+          if (iB == iC) continue;
+          const double rBC_inv = local_Rinv_B[iC];
+          const double rC = local_dist_scratch[iC];
+          const double mu_BC = (rB - rC) * rBC_inv;
+          
+          if(fabs(mu_BC) < safe_magic_ssf_bound){
+            const double t_BC = tFrisch(mu_BC);
+            const double coef = PB * t_BC * rBC_inv * sum_inv * w_times_f_i;
+
+            const double coords_C_x = coords[3*iC + 0];
+            const double coords_C_y = coords[3*iC + 1];
+            const double coords_C_z = coords[3*iC + 2];
+
+            // second term
+            {
+              const double rB_inv = 1. / rB;
+              exc_grad_w_iBx -= coef * ((coords_B_x - point_x) * rB_inv - mu_BC * (coords_B_x - coords_C_x) * rBC_inv);
+              exc_grad_w_iBy -= coef * ((coords_B_y - point_y) * rB_inv - mu_BC * (coords_B_y - coords_C_y) * rBC_inv);
+              exc_grad_w_iBz -= coef * ((coords_B_z - point_z) * rB_inv - mu_BC * (coords_B_z - coords_C_z) * rBC_inv);
+            }
+
+            if(iC != iParent) {
+              // third term
+              const double rC_inv = 1. / rC;
+              const double C_x = coef * ((coords_C_x - point_x) * rC_inv + mu_BC * (coords_C_x - coords_B_x) * rBC_inv);
+              const double C_y = coef * ((coords_C_y - point_y) * rC_inv + mu_BC * (coords_C_y - coords_B_y) * rBC_inv);
+              const double C_z = coef * ((coords_C_z - point_z) * rC_inv + mu_BC * (coords_C_z - coords_B_z) * rBC_inv);
+              
+              atomicAdd(exc_grad_w_device + 3*iC + 0, C_x);
+              atomicAdd(exc_grad_w_device + 3*iC + 1, C_y);
+              atomicAdd(exc_grad_w_device + 3*iC + 2, C_z);
+
+              // Update parent atom
+              atomicAdd(exc_grad_w_device + 3*iParent + 0, -C_x);
+              atomicAdd(exc_grad_w_device + 3*iParent + 1, -C_y);
+              atomicAdd(exc_grad_w_device + 3*iParent + 2, -C_z);
+            }
+          }
+        }
+
+        atomicAdd(exc_grad_w_device + 3*iB + 0, exc_grad_w_iBx);
+        atomicAdd(exc_grad_w_device + 3*iB + 1, exc_grad_w_iBy);
+        atomicAdd(exc_grad_w_device + 3*iB + 2, exc_grad_w_iBz);
+
+        // Update parent atom
+        atomicAdd(exc_grad_w_device + 3*iParent + 0, -exc_grad_w_iBx);
+        atomicAdd(exc_grad_w_device + 3*iParent + 1, -exc_grad_w_iBy);
+        atomicAdd(exc_grad_w_device + 3*iParent + 2, -exc_grad_w_iBz);
+
+    }
+
+  }
+
+}
+
+
+
+void eval_weight_1st_deriv_contracted_ssf_1d( int32_t npts, int32_t natoms, const double* RAB,
+  int32_t ldRAB, const double* coords, 
+  const double* points_x, const double* points_y, const double* points_z,
+  const double* dist, int32_t lddist,
+  const int32_t* iparent, const double* dist_nearest, const double* w_times_f,
+  double* exc_grad_w, hipStream_t stream){
+
+  dim3 threads( hip::max_threads_per_thread_block/4 );
+  dim3 blocks ( util::div_ceil( npts, threads.x ) );
+  eval_weight_1st_deriv_contracted_ssf_kernel_1d<<<blocks, threads, 0, stream>>>(
+    npts, natoms, RAB, ldRAB, coords, points_x, points_y, points_z, dist, lddist, iparent, dist_nearest,
+    w_times_f, exc_grad_w
+  );
+
+}
+
 
 }

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/hip_ssf_1d.hpp
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/hip_ssf_1d.hpp
@@ -17,4 +17,12 @@ void partition_weights_ssf_1d( int32_t npts, int32_t natoms, const double* RAB,
   const int32_t* iparent, const double* dist_nearest, double* weights,
   hipStream_t stream);
 
+void eval_weight_1st_deriv_contracted_ssf_1d( int32_t npts, int32_t natoms, const double* RAB,
+  int32_t ldRAB, const double* coords, 
+  const double* points_x, const double* points_y, const double* points_z,
+  const double* dist, int32_t lddist,
+  const int32_t* iparent, const double* dist_nearest, const double* w_times_f,
+  double* exc_grad_w, hipStream_t stream);
+
 }
+#include "hip/hip_runtime.h"

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/hipblas_extensions.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/hipblas_extensions.hip
@@ -19,7 +19,7 @@
 
 namespace GauXC {
 
-hipblasOperation_t device_op_to_hipblas( DeviceBlasOp op ) {
+hipblasOperation_t device_op_to_cublas( DeviceBlasOp op ) {
   switch( op ) {
     case DeviceBlasOp::NoTrans: return HIPBLAS_OP_N;
     case DeviceBlasOp::Trans:   return HIPBLAS_OP_T;
@@ -29,7 +29,7 @@ hipblasOperation_t device_op_to_hipblas( DeviceBlasOp op ) {
   }
 }
 
-hipblasFillMode_t device_uplo_to_hipblas( DeviceBlasUplo uplo ) {
+hipblasFillMode_t device_uplo_to_cublas( DeviceBlasUplo uplo ) {
   switch(uplo) {
     case DeviceBlasUplo::Upper: return HIPBLAS_FILL_MODE_UPPER;
     case DeviceBlasUplo::Lower: return HIPBLAS_FILL_MODE_LOWER;
@@ -47,8 +47,26 @@ __global__ void increment_kernel( const T* X, T* Y ) {
 
 template <typename T>
 void increment( const T* X, T* Y, hipStream_t stream ) {
-  hipLaunchKernelGGL(increment_kernel, dim3(1), dim3(1), 0, stream, X,Y);
+  increment_kernel<<<1,1,0,stream>>>(X,Y);
 }
+
+template <typename T>
+__global__ void increment_vec_kernel( const T* X, T* Y, int N ) {
+  const auto tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if( tid < N ) Y[tid] += X[tid];
+}
+
+template <typename T>
+void increment( device_blas_handle generic_handle, const T* X, T* Y, int N) {
+  const int threads = hip::warp_size * hip::max_warps_per_thread_block;
+  const int blocks = util::div_ceil( N, threads );
+  hipblasHandle_t handle = generic_handle.blas_handle_as<util::hipblas_handle>();
+  auto stream = util::get_stream(handle);
+  increment_vec_kernel<<<blocks, threads, 0, stream>>>(X,Y,N);
+}
+
+template
+  void increment( device_blas_handle generic_handle, const double* X, double* Y, int N );
 
 template <>
 void dot( device_blas_handle generic_handle,
@@ -62,7 +80,7 @@ void dot( device_blas_handle generic_handle,
   hipblasHandle_t handle = generic_handle.blas_handle_as<util::hipblas_handle>();
 
   auto stat = hipblasDdot( handle, N, X, INCX, Y, INCY, RES );
-  GAUXC_HIPBLAS_ERROR("HIPBLAS DDOT FAILED", stat );
+  GAUXC_CUBLAS_ERROR("CUBLAS DDOT FAILED", stat );
 
 }
 
@@ -138,7 +156,7 @@ void hadamard_product( device_blas_handle generic_handle,
   dim3 blocks( util::div_ceil( M, threads.x ),
                util::div_ceil( N, threads.y ) );
 
-  hipLaunchKernelGGL(hadamard_product_kernel, dim3(blocks), dim3(threads), 0, stream ,  M, N, A, LDA, B, LDB );
+  hadamard_product_kernel<<< blocks, threads, 0, stream >>>( M, N, A, LDA, B, LDB );
 
 }
  
@@ -163,10 +181,10 @@ void gemm( device_blas_handle generic_handle,
 
 
   hipblasHandle_t handle = generic_handle.blas_handle_as<util::hipblas_handle>();
-  auto stat = hipblasDgemm( handle, device_op_to_hipblas(TA), 
-    device_op_to_hipblas(TB), M, N, K, &ALPHA, A, LDA,
+  auto stat = hipblasDgemm( handle, device_op_to_cublas(TA), 
+    device_op_to_cublas(TB), M, N, K, &ALPHA, A, LDA,
     B, LDB, &BETA, C, LDC );
-  GAUXC_HIPBLAS_ERROR("HIPBLAS DGEMM FAILED", stat);
+  GAUXC_CUBLAS_ERROR("CUBLAS DGEMM FAILED", stat);
 
 }
 
@@ -179,12 +197,13 @@ void syr2k( device_blas_handle generic_handle,
             double BETA, double* C, int LDC ) {
 
   hipblasHandle_t handle = generic_handle.blas_handle_as<util::hipblas_handle>();
-  auto stat = hipblasDsyr2k( handle, device_uplo_to_hipblas(UPLO), 
-    device_op_to_hipblas(Trans), M, K, &ALPHA, A, LDA, B, LDB,
+  auto stat = hipblasDsyr2k( handle, device_uplo_to_cublas(UPLO), 
+    device_op_to_cublas(Trans), M, K, &ALPHA, A, LDA, B, LDB,
     &BETA, C, LDC );
-  GAUXC_HIPBLAS_ERROR("HIPBLAS DSYR2K FAILED", stat);
+  GAUXC_CUBLAS_ERROR("CUBLAS DSYR2K FAILED", stat);
 
 }
+
 
 }
 

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/increment_exc_grad.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/increment_exc_grad.hip
@@ -1,0 +1,987 @@
+/**
+ * GauXC Copyright (c) 2020-2024, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of
+ * any required approvals from the U.S. Dept. of Energy).
+ *
+ * (c) 2024-2025, Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * See LICENSE.txt for details
+ */
+#include "hip/hip_runtime.h"
+#include "device/common/increment_exc_grad.hpp"
+#include "hip_extensions.hpp"
+#include "device_specific/hip_device_constants.hpp"
+#include <gauxc/util/div_ceil.hpp>
+#include "device_specific/hip_util.hpp"
+
+namespace GauXC {
+
+template<bool with_weight_derivatives>
+__global__ __launch_bounds__(1024,1) void increment_exc_grad_lda_rks_kernel(
+  uint32_t                        nshell,
+  ShellToTaskDevice* __restrict__ shell_to_task,
+  XCDeviceTask*      __restrict__ device_tasks,
+  double*            __restrict__ EXC_GRAD
+) {
+
+  for( uint32_t ish = blockIdx.z; ish < nshell; ish += gridDim.z ) {
+    const uint32_t ntasks      = shell_to_task[ish].ntask;
+    const auto shell           = shell_to_task[ish].shell_device;
+    const auto task_idx        = shell_to_task[ish].task_idx_device;
+    const auto task_shell_offs = shell_to_task[ish].task_shell_offs_device;
+    const int iCen = shell_to_task[ish].center_idx;
+    const uint32_t shsz   = shell->size();
+
+    const int global_warp_id = 
+      (threadIdx.x + blockIdx.x*blockDim.x) / hip::warp_size;
+    const int nwarp_global   = max((blockDim.x*gridDim.x) / hip::warp_size,1);
+
+    double g_acc_x(0), g_acc_y(0), g_acc_z(0);
+    for( uint32_t itask = global_warp_id; itask < ntasks; itask += nwarp_global ) {
+      
+      const auto*    task   = device_tasks + task_idx[itask];
+      const uint32_t npts   = task->npts;
+      const size_t   shoff  = task_shell_offs[itask] * npts;
+      const int iParent     = task->iParent;
+      if constexpr( with_weight_derivatives ) {
+        if( iCen == iParent ) 
+          continue;
+      }
+      double g_acc_x_task(0), g_acc_y_task(0), g_acc_z_task(0);
+
+      const auto* __restrict__ basis_x_eval = task->dbfx + shoff;
+      const auto* __restrict__ basis_y_eval = task->dbfy + shoff;
+      const auto* __restrict__ basis_z_eval = task->dbfz + shoff;
+
+      const auto* __restrict__  xmat = task->zmat + shoff;
+      const auto* __restrict__  vrho = task->vrho;
+
+      #pragma unroll 1
+      for( uint32_t ipt = threadIdx.x % hip::warp_size; 
+           ipt < npts; 
+           ipt += hip::warp_size ) {
+
+        const double vrho_i = vrho[ipt];
+        for( uint32_t ibf = 0; ibf < shsz; ++ibf ) {
+          const double z_mu_i    = vrho_i * xmat[ipt + ibf*npts];
+          const double dbfx_mu_i = basis_x_eval[ipt + ibf*npts];
+          const double dbfy_mu_i = basis_y_eval[ipt + ibf*npts];
+          const double dbfz_mu_i = basis_z_eval[ipt + ibf*npts];
+
+          g_acc_x_task += z_mu_i * dbfx_mu_i;
+          g_acc_y_task += z_mu_i * dbfy_mu_i;
+          g_acc_z_task += z_mu_i * dbfz_mu_i;
+        } // Loop over bfns within a shell
+
+      } // Loop over points
+
+      g_acc_x += g_acc_x_task;
+      g_acc_y += g_acc_y_task;
+      g_acc_z += g_acc_z_task;
+
+      //write to Parent atom with translational invariance
+      if constexpr( with_weight_derivatives ) {
+        atomicAdd( EXC_GRAD + 3*iParent + 0, 2.0 * g_acc_x_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 1, 2.0 * g_acc_y_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 2, 2.0 * g_acc_z_task );
+      }
+
+    } // Loop over tasks assigned to shell
+
+    constexpr auto warp_size = hip::warp_size;
+    g_acc_x = -2. * hip::warp_reduce_sum<warp_size>( g_acc_x );
+    g_acc_y = -2. * hip::warp_reduce_sum<warp_size>( g_acc_y );
+    g_acc_z = -2. * hip::warp_reduce_sum<warp_size>( g_acc_z );
+
+    if( (threadIdx.x % hip::warp_size) == 0 ) {
+      
+      atomicAdd( EXC_GRAD + 3*iCen + 0, g_acc_x );
+      atomicAdd( EXC_GRAD + 3*iCen + 1, g_acc_y );
+      atomicAdd( EXC_GRAD + 3*iCen + 2, g_acc_z );
+    }
+
+  } // Loop over shells
+
+}
+
+template<bool with_weight_derivatives>
+__global__ __launch_bounds__(1024,1) void increment_exc_grad_lda_uks_kernel(
+  uint32_t                        nshell,
+  ShellToTaskDevice* __restrict__ shell_to_task,
+  XCDeviceTask*      __restrict__ device_tasks,
+  double*            __restrict__ EXC_GRAD
+) {
+
+  for( uint32_t ish = blockIdx.z; ish < nshell; ish += gridDim.z ) {
+    const uint32_t ntasks      = shell_to_task[ish].ntask;
+    const auto shell           = shell_to_task[ish].shell_device;
+    const auto task_idx        = shell_to_task[ish].task_idx_device;
+    const auto task_shell_offs = shell_to_task[ish].task_shell_offs_device;
+    const int  iCen            = shell_to_task[ish].center_idx;
+    const uint32_t shsz   = shell->size();
+
+    const int global_warp_id = 
+      (threadIdx.x + blockIdx.x*blockDim.x) / hip::warp_size;
+    const int nwarp_global   = max((blockDim.x*gridDim.x) / hip::warp_size,1);
+
+    double g_acc_x(0), g_acc_y(0), g_acc_z(0);
+    for( uint32_t itask = global_warp_id; itask < ntasks; itask += nwarp_global ) {
+      
+      const auto*    task   = device_tasks + task_idx[itask];
+      const uint32_t npts   = task->npts;
+      const size_t   shoff  = task_shell_offs[itask] * npts;
+      const int    iParent  = task->iParent;
+      if constexpr( with_weight_derivatives ) {
+        if( iCen == iParent )
+          continue;
+      }
+      double g_acc_x_task(0), g_acc_y_task(0), g_acc_z_task(0);
+
+      const auto* __restrict__ basis_x_eval = task->dbfx + shoff;
+      const auto* __restrict__ basis_y_eval = task->dbfy + shoff;
+      const auto* __restrict__ basis_z_eval = task->dbfz + shoff;
+
+      const auto* __restrict__  xmatS = task->xmatS + shoff;
+      const auto* __restrict__  xmatZ = task->xmatZ + shoff;
+      const auto* __restrict__  vrhop = task->vrho_pos;
+      const auto* __restrict__  vrhom = task->vrho_neg;
+
+      #pragma unroll 1
+      for( uint32_t ipt = threadIdx.x % hip::warp_size; 
+           ipt < npts; 
+           ipt += hip::warp_size ) {
+
+        const double vrhop_i = vrhop[ipt];
+        const double vrhom_i = vrhom[ipt];
+
+        const auto vrhoS_i = 0.5 * (vrhop_i + vrhom_i);
+        const auto vrhoZ_i = 0.5 * (vrhop_i - vrhom_i);
+        for( uint32_t ibf = 0; ibf < shsz; ++ibf ) {
+          const double zS_mu_i    = vrhoS_i * xmatS[ipt + ibf*npts];
+          const double zZ_mu_i    = vrhoZ_i * xmatZ[ipt + ibf*npts];
+          const double dbfx_mu_i = basis_x_eval[ipt + ibf*npts];
+          const double dbfy_mu_i = basis_y_eval[ipt + ibf*npts];
+          const double dbfz_mu_i = basis_z_eval[ipt + ibf*npts];
+
+          g_acc_x_task += zS_mu_i * dbfx_mu_i;
+          g_acc_y_task += zS_mu_i * dbfy_mu_i;
+          g_acc_z_task += zS_mu_i * dbfz_mu_i;
+          g_acc_x_task += zZ_mu_i * dbfx_mu_i;
+          g_acc_y_task += zZ_mu_i * dbfy_mu_i;
+          g_acc_z_task += zZ_mu_i * dbfz_mu_i;
+        } // Loop over bfns within a shell
+
+      } // Loop over points
+
+      g_acc_x += g_acc_x_task;
+      g_acc_y += g_acc_y_task;
+      g_acc_z += g_acc_z_task;
+
+      //write to Parent atom with translational invariance
+      if constexpr( with_weight_derivatives ) {
+        atomicAdd( EXC_GRAD + 3*iParent + 0, 2.0 * g_acc_x_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 1, 2.0 * g_acc_y_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 2, 2.0 * g_acc_z_task );
+      }
+
+    } // Loop over tasks assigned to shell
+
+    constexpr auto warp_size = hip::warp_size;
+    g_acc_x = -2. * hip::warp_reduce_sum<warp_size>( g_acc_x );
+    g_acc_y = -2. * hip::warp_reduce_sum<warp_size>( g_acc_y );
+    g_acc_z = -2. * hip::warp_reduce_sum<warp_size>( g_acc_z );
+
+    if( (threadIdx.x % hip::warp_size) == 0 ) {
+      atomicAdd( EXC_GRAD + 3*iCen + 0, g_acc_x );
+      atomicAdd( EXC_GRAD + 3*iCen + 1, g_acc_y );
+      atomicAdd( EXC_GRAD + 3*iCen + 2, g_acc_z );
+    }
+
+  } // Loop over shells
+
+}
+
+void increment_exc_grad_lda( integrator_ks_scheme ks_scheme, size_t nshell, ShellToTaskDevice* shell_to_task,
+  XCDeviceTask* device_tasks, double* EXC_GRAD, bool with_weight_derivatives, device_queue queue ) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>();
+  #if 0
+  int nthreads_per_block = 1024;
+  int nwarp_per_block    = nthreads_per_block / hip::warp_size;
+  int nblocks            = util::div_ceil( nshell, nwarp_per_block );
+
+  dim3 threads( nthreads_per_block );
+  dim3 blocks( nblocks );
+  #else
+  dim3 threads(1024), blocks(1,1,nshell);
+  #endif
+
+  switch(ks_scheme) {
+    case RKS:
+      if (with_weight_derivatives) {
+        increment_exc_grad_lda_rks_kernel<true><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      } else {
+        increment_exc_grad_lda_rks_kernel<false><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      }
+      break;
+    case UKS:
+      if (with_weight_derivatives) {
+        increment_exc_grad_lda_uks_kernel<true><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      } else {
+        increment_exc_grad_lda_uks_kernel<false><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      }
+      break;
+    default: GAUXC_GENERIC_EXCEPTION("LDA EXC GRAD + GKS NYI");
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+template<bool with_weight_derivatives>
+__global__ __launch_bounds__(512,1) void increment_exc_grad_gga_rks_kernel(
+  uint32_t                        nshell,
+  ShellToTaskDevice* __restrict__ shell_to_task,
+  XCDeviceTask*      __restrict__ device_tasks,
+  double*            __restrict__ EXC_GRAD
+) {
+
+  for( uint32_t ish = blockIdx.z; ish < nshell; ish += gridDim.z ) {
+    const uint32_t ntasks      = shell_to_task[ish].ntask;
+    const auto shell           = shell_to_task[ish].shell_device;
+    const auto task_idx        = shell_to_task[ish].task_idx_device;
+    const auto task_shell_offs = shell_to_task[ish].task_shell_offs_device;
+    const int iCen = shell_to_task[ish].center_idx;
+    const uint32_t shsz   = shell->size();
+
+    const int global_warp_id = 
+      (threadIdx.x + blockIdx.x*blockDim.x) / hip::warp_size;
+    const int nwarp_global   = max((blockDim.x*gridDim.x) / hip::warp_size,1);
+
+    double g_acc_x(0), g_acc_y(0), g_acc_z(0);
+    for( uint32_t itask = global_warp_id; itask < ntasks; itask += nwarp_global ) {
+      
+      const auto*    task   = device_tasks + task_idx[itask];
+      const uint32_t npts   = task->npts;
+      const size_t   shoff  = task_shell_offs[itask] * npts;
+      const int iParent     = task->iParent;
+      if constexpr( with_weight_derivatives ) {
+        if( iCen == iParent ) 
+          continue;
+      }
+      double g_acc_x_task(0), g_acc_y_task(0), g_acc_z_task(0);
+
+      const auto* __restrict__ basis_x_eval = task->dbfx + shoff;
+      const auto* __restrict__ basis_y_eval = task->dbfy + shoff;
+      const auto* __restrict__ basis_z_eval = task->dbfz + shoff;
+
+      const auto* __restrict__ basis_xx_eval = task->d2bfxx + shoff;
+      const auto* __restrict__ basis_xy_eval = task->d2bfxy + shoff;
+      const auto* __restrict__ basis_xz_eval = task->d2bfxz + shoff;
+      const auto* __restrict__ basis_yy_eval = task->d2bfyy + shoff;
+      const auto* __restrict__ basis_yz_eval = task->d2bfyz + shoff;
+      const auto* __restrict__ basis_zz_eval = task->d2bfzz + shoff;
+
+      const auto* __restrict__  xmat = task->zmat + shoff;
+      const auto* __restrict__  xmat_x = task->xmat_x + shoff;
+      const auto* __restrict__  xmat_y = task->xmat_y + shoff;
+      const auto* __restrict__  xmat_z = task->xmat_z + shoff;
+
+      const auto* __restrict__  vrho = task->vrho;
+      const auto* __restrict__  vgamma = task->vgamma;
+
+      const auto* __restrict__ den_x = task->dden_sx;
+      const auto* __restrict__ den_y = task->dden_sy;
+      const auto* __restrict__ den_z = task->dden_sz;
+
+      #pragma unroll 1
+      for( uint32_t ipt = threadIdx.x % hip::warp_size; 
+           ipt < npts; 
+           ipt += hip::warp_size ) {
+
+        const double vrho_i   = vrho[ipt];
+        const double vgamma_i = vgamma[ipt];
+
+        const double denx_i = den_x[ipt];
+        const double deny_i = den_y[ipt];
+        const double denz_i = den_z[ipt];
+        for( uint32_t ibf = 0; ibf < shsz; ++ibf ) {
+          const double z_mu_i    = xmat[ipt + ibf*npts];          
+          const double dbfx_mu_i = basis_x_eval[ipt + ibf*npts];
+          const double dbfy_mu_i = basis_y_eval[ipt + ibf*npts];
+          const double dbfz_mu_i = basis_z_eval[ipt + ibf*npts];
+
+          g_acc_x_task += vrho_i * z_mu_i * dbfx_mu_i;
+          g_acc_y_task += vrho_i * z_mu_i * dbfy_mu_i;
+          g_acc_z_task += vrho_i * z_mu_i * dbfz_mu_i;
+
+          const double zx = xmat_x[ipt + ibf*npts];
+          const double zy = xmat_y[ipt + ibf*npts];
+          const double zz = xmat_z[ipt + ibf*npts];
+
+          const double d11_xmat_term = denx_i * zx + deny_i * zy + denz_i * zz;
+
+          const double d2bfxx = basis_xx_eval[ipt + ibf*npts];
+          const double d2bfxy = basis_xy_eval[ipt + ibf*npts];
+          const double d2bfxz = basis_xz_eval[ipt + ibf*npts];
+          const double d2bfyy = basis_yy_eval[ipt + ibf*npts];
+          const double d2bfyz = basis_yz_eval[ipt + ibf*npts];
+          const double d2bfzz = basis_zz_eval[ipt + ibf*npts];
+
+          const double d2_term_x = d2bfxx*denx_i + d2bfxy*deny_i + d2bfxz*denz_i;
+          const double d2_term_y = d2bfxy*denx_i + d2bfyy*deny_i + d2bfyz*denz_i;
+          const double d2_term_z = d2bfxz*denx_i + d2bfyz*deny_i + d2bfzz*denz_i;
+
+          g_acc_x_task += 2 * vgamma_i * ( z_mu_i * d2_term_x + dbfx_mu_i * d11_xmat_term );
+          g_acc_y_task += 2 * vgamma_i * ( z_mu_i * d2_term_y + dbfy_mu_i * d11_xmat_term );
+          g_acc_z_task += 2 * vgamma_i * ( z_mu_i * d2_term_z + dbfz_mu_i * d11_xmat_term );
+
+        } // Loop over bfns within a shell
+
+      } // Loop over points
+
+      g_acc_x += g_acc_x_task;
+      g_acc_y += g_acc_y_task;
+      g_acc_z += g_acc_z_task;
+
+      //write to Parent atom with translational invariance
+      if constexpr( with_weight_derivatives ) {
+        atomicAdd( EXC_GRAD + 3*iParent + 0, 2.0 * g_acc_x_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 1, 2.0 * g_acc_y_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 2, 2.0 * g_acc_z_task );
+      }
+
+    } // Loop over tasks assigned to shell
+
+    constexpr auto warp_size = hip::warp_size;
+    g_acc_x = -2. * hip::warp_reduce_sum<warp_size>( g_acc_x );
+    g_acc_y = -2. * hip::warp_reduce_sum<warp_size>( g_acc_y );
+    g_acc_z = -2. * hip::warp_reduce_sum<warp_size>( g_acc_z );
+
+    if( (threadIdx.x % hip::warp_size) == 0 ) {
+      atomicAdd( EXC_GRAD + 3*iCen + 0, g_acc_x );
+      atomicAdd( EXC_GRAD + 3*iCen + 1, g_acc_y );
+      atomicAdd( EXC_GRAD + 3*iCen + 2, g_acc_z );
+    }
+
+  } // Loop over shells
+
+}
+
+template<bool with_weight_derivatives>
+__global__ __launch_bounds__(512,1) void increment_exc_grad_gga_uks_kernel(
+  uint32_t                        nshell,
+  ShellToTaskDevice* __restrict__ shell_to_task,
+  XCDeviceTask*      __restrict__ device_tasks,
+  double*            __restrict__ EXC_GRAD
+) {
+
+  for( uint32_t ish = blockIdx.z; ish < nshell; ish += gridDim.z ) {
+    const uint32_t ntasks      = shell_to_task[ish].ntask;
+    const auto shell           = shell_to_task[ish].shell_device;
+    const auto task_idx        = shell_to_task[ish].task_idx_device;
+    const auto task_shell_offs = shell_to_task[ish].task_shell_offs_device;
+    const int iCen = shell_to_task[ish].center_idx;
+    const uint32_t shsz   = shell->size();
+
+    const int global_warp_id = 
+      (threadIdx.x + blockIdx.x*blockDim.x) / hip::warp_size;
+    const int nwarp_global   = max((blockDim.x*gridDim.x) / hip::warp_size,1);
+
+    double g_acc_x(0), g_acc_y(0), g_acc_z(0);
+    for( uint32_t itask = global_warp_id; itask < ntasks; itask += nwarp_global ) {
+      
+      const auto*    task   = device_tasks + task_idx[itask];
+      const uint32_t npts   = task->npts;
+      const size_t   shoff  = task_shell_offs[itask] * npts;
+      const int iParent     = task->iParent;
+      if constexpr( with_weight_derivatives ) {
+        if( iCen == iParent ) 
+          continue;
+      }
+      double g_acc_x_task(0), g_acc_y_task(0), g_acc_z_task(0);
+
+      const auto* __restrict__ basis_x_eval = task->dbfx + shoff;
+      const auto* __restrict__ basis_y_eval = task->dbfy + shoff;
+      const auto* __restrict__ basis_z_eval = task->dbfz + shoff;
+
+      const auto* __restrict__ basis_xx_eval = task->d2bfxx + shoff;
+      const auto* __restrict__ basis_xy_eval = task->d2bfxy + shoff;
+      const auto* __restrict__ basis_xz_eval = task->d2bfxz + shoff;
+      const auto* __restrict__ basis_yy_eval = task->d2bfyy + shoff;
+      const auto* __restrict__ basis_yz_eval = task->d2bfyz + shoff;
+      const auto* __restrict__ basis_zz_eval = task->d2bfzz + shoff;
+
+      const auto* __restrict__  xmatS   = task->xmatS   + shoff;
+      const auto* __restrict__  xmatS_x = task->xmatS_x + shoff;
+      const auto* __restrict__  xmatS_y = task->xmatS_y + shoff;
+      const auto* __restrict__  xmatS_z = task->xmatS_z + shoff;
+
+      const auto* __restrict__  xmatZ   = task->xmatZ   + shoff;
+      const auto* __restrict__  xmatZ_x = task->xmatZ_x + shoff;
+      const auto* __restrict__  xmatZ_y = task->xmatZ_y + shoff;
+      const auto* __restrict__  xmatZ_z = task->xmatZ_z + shoff;
+
+      const auto* __restrict__  vrhop = task->vrho_pos;
+      const auto* __restrict__  vrhom = task->vrho_neg;
+
+      const auto* __restrict__  vgamma_pp = task->vgamma_pp;
+      const auto* __restrict__  vgamma_pm = task->vgamma_pm;
+      const auto* __restrict__  vgamma_mm = task->vgamma_mm;
+
+      const auto* __restrict__ dens_x = task->dden_sx;
+      const auto* __restrict__ dens_y = task->dden_sy;
+      const auto* __restrict__ dens_z = task->dden_sz;
+
+      const auto* __restrict__ denz_x = task->dden_zx;
+      const auto* __restrict__ denz_y = task->dden_zy;
+      const auto* __restrict__ denz_z = task->dden_zz;
+
+      #pragma unroll 1
+      for( uint32_t ipt = threadIdx.x % hip::warp_size; 
+           ipt < npts; 
+           ipt += hip::warp_size ) {
+
+        const double vrhop_i = vrhop[ipt];
+        const double vrhom_i = vrhom[ipt];
+        const double vrhoS_i = 0.5 * (vrhop_i + vrhom_i);
+        const double vrhoZ_i = 0.5 * (vrhop_i - vrhom_i);
+
+        const double vgammapp_i = vgamma_pp[ipt];
+        const double vgammapm_i = vgamma_pm[ipt];
+        const double vgammamm_i = vgamma_mm[ipt];
+
+        const double denSx_i = dens_x[ipt];
+        const double denSy_i = dens_y[ipt];
+        const double denSz_i = dens_z[ipt];
+        const double denZx_i = denz_x[ipt];
+        const double denZy_i = denz_y[ipt];
+        const double denZz_i = denz_z[ipt];
+
+        for( uint32_t ibf = 0; ibf < shsz; ++ibf ) {
+          const double xN    = xmatS[ipt + ibf*npts];
+          const double xZ    = xmatZ[ipt + ibf*npts];
+          const double dbfx_mu_i = basis_x_eval[ipt + ibf*npts];
+          const double dbfy_mu_i = basis_y_eval[ipt + ibf*npts];
+          const double dbfz_mu_i = basis_z_eval[ipt + ibf*npts];
+
+          g_acc_x_task += vrhoS_i * xN * dbfx_mu_i;
+          g_acc_y_task += vrhoS_i * xN * dbfy_mu_i;
+          g_acc_z_task += vrhoS_i * xN * dbfz_mu_i;
+          g_acc_x_task += vrhoZ_i * xZ * dbfx_mu_i;
+          g_acc_y_task += vrhoZ_i * xZ * dbfy_mu_i;
+          g_acc_z_task += vrhoZ_i * xZ * dbfz_mu_i;
+
+          const double xNx = xmatS_x[ipt + ibf*npts];
+          const double xNy = xmatS_y[ipt + ibf*npts];
+          const double xNz = xmatS_z[ipt + ibf*npts];
+          const double xZx = xmatZ_x[ipt + ibf*npts];
+          const double xZy = xmatZ_y[ipt + ibf*npts];
+          const double xZz = xmatZ_z[ipt + ibf*npts];
+
+          const double d11nn_xmat_term = denSx_i * xNx + denSy_i * xNy + denSz_i * xNz;
+          const double d11nz_xmat_term = denSx_i * xZx + denSy_i * xZy + denSz_i * xZz;
+          const double d11zn_xmat_term = denZx_i * xNx + denZy_i * xNy + denZz_i * xNz;
+          const double d11zz_xmat_term = denZx_i * xZx + denZy_i * xZy + denZz_i * xZz;
+
+          const double d2bfxx = basis_xx_eval[ipt + ibf*npts];
+          const double d2bfxy = basis_xy_eval[ipt + ibf*npts];
+          const double d2bfxz = basis_xz_eval[ipt + ibf*npts];
+          const double d2bfyy = basis_yy_eval[ipt + ibf*npts];
+          const double d2bfyz = basis_yz_eval[ipt + ibf*npts];
+          const double d2bfzz = basis_zz_eval[ipt + ibf*npts];
+
+          const double d2n_term_x = d2bfxx*denSx_i + d2bfxy*denSy_i + d2bfxz*denSz_i;
+          const double d2n_term_y = d2bfxy*denSx_i + d2bfyy*denSy_i + d2bfyz*denSz_i;
+          const double d2n_term_z = d2bfxz*denSx_i + d2bfyz*denSy_i + d2bfzz*denSz_i;
+          const double d2z_term_x = d2bfxx*denZx_i + d2bfxy*denZy_i + d2bfxz*denZz_i;
+          const double d2z_term_y = d2bfxy*denZx_i + d2bfyy*denZy_i + d2bfyz*denZz_i;
+          const double d2z_term_z = d2bfxz*denZx_i + d2bfyz*denZy_i + d2bfzz*denZz_i;
+
+          g_acc_x_task += 0.5 * (vgammapp_i + vgammapm_i + vgammamm_i) * (d2n_term_x * xN + d11nn_xmat_term * dbfx_mu_i);
+          g_acc_x_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2z_term_x * xN + d11zn_xmat_term * dbfx_mu_i);
+          g_acc_x_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2n_term_x * xZ + d11nz_xmat_term * dbfx_mu_i);
+          g_acc_x_task += 0.5 * (vgammapp_i - vgammapm_i + vgammamm_i) * (d2z_term_x * xZ + d11zz_xmat_term * dbfx_mu_i);
+
+          g_acc_y_task += 0.5 * (vgammapp_i + vgammapm_i + vgammamm_i) * (d2n_term_y * xN + d11nn_xmat_term * dbfy_mu_i);
+          g_acc_y_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2z_term_y * xN + d11zn_xmat_term * dbfy_mu_i);
+          g_acc_y_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2n_term_y * xZ + d11nz_xmat_term * dbfy_mu_i);
+          g_acc_y_task += 0.5 * (vgammapp_i - vgammapm_i + vgammamm_i) * (d2z_term_y * xZ + d11zz_xmat_term * dbfy_mu_i);
+
+          g_acc_z_task += 0.5 * (vgammapp_i + vgammapm_i + vgammamm_i) * (d2n_term_z * xN + d11nn_xmat_term * dbfz_mu_i);
+          g_acc_z_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2z_term_z * xN + d11zn_xmat_term * dbfz_mu_i);
+          g_acc_z_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2n_term_z * xZ + d11nz_xmat_term * dbfz_mu_i);
+          g_acc_z_task += 0.5 * (vgammapp_i - vgammapm_i + vgammamm_i) * (d2z_term_z * xZ + d11zz_xmat_term * dbfz_mu_i);
+
+        }// Loop over bfns within a shell
+
+      } // Loop over points
+
+      g_acc_x += g_acc_x_task;
+      g_acc_y += g_acc_y_task;
+      g_acc_z += g_acc_z_task;
+
+      //write to Parent atom with translational invariance
+      if constexpr( with_weight_derivatives ) {
+        atomicAdd( EXC_GRAD + 3*iParent + 0, 2.0 * g_acc_x_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 1, 2.0 * g_acc_y_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 2, 2.0 * g_acc_z_task );
+      }
+
+    } // Loop over tasks assigned to shell
+
+    constexpr auto warp_size = hip::warp_size;
+    g_acc_x = -2. * hip::warp_reduce_sum<warp_size>( g_acc_x );
+    g_acc_y = -2. * hip::warp_reduce_sum<warp_size>( g_acc_y );
+    g_acc_z = -2. * hip::warp_reduce_sum<warp_size>( g_acc_z );
+
+    if( (threadIdx.x % hip::warp_size) == 0 ) {
+      atomicAdd( EXC_GRAD + 3*iCen + 0, g_acc_x );
+      atomicAdd( EXC_GRAD + 3*iCen + 1, g_acc_y );
+      atomicAdd( EXC_GRAD + 3*iCen + 2, g_acc_z );
+    }
+
+  } // Loop over shells
+
+}
+
+void increment_exc_grad_gga( integrator_ks_scheme ks_scheme, size_t nshell, ShellToTaskDevice* shell_to_task,
+  XCDeviceTask* device_tasks, double* EXC_GRAD, bool with_weight_derivatives, device_queue queue ) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>();
+  dim3 threads(512), blocks(1,1,nshell);
+
+  switch(ks_scheme) {
+    case RKS:
+      if (with_weight_derivatives) {
+        increment_exc_grad_gga_rks_kernel<true><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      } else {
+        increment_exc_grad_gga_rks_kernel<false><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      }
+      break;
+    case UKS:
+      if (with_weight_derivatives) {
+        increment_exc_grad_gga_uks_kernel<true><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      } else {
+        increment_exc_grad_gga_uks_kernel<false><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      }
+      break;
+    default: GAUXC_GENERIC_EXCEPTION("GGA EXC GRAD + GKS NYI");
+  }
+}
+
+
+
+
+
+
+template<bool with_weight_derivatives>
+__global__ __launch_bounds__(512,1) void increment_exc_grad_mgga_rks_kernel(
+  uint32_t                        nshell,
+  ShellToTaskDevice* __restrict__ shell_to_task,
+  XCDeviceTask*      __restrict__ device_tasks,
+  double*            __restrict__ EXC_GRAD
+) {
+
+  for( uint32_t ish = blockIdx.z; ish < nshell; ish += gridDim.z ) {
+    const uint32_t ntasks      = shell_to_task[ish].ntask;
+    const auto shell           = shell_to_task[ish].shell_device;
+    const auto task_idx        = shell_to_task[ish].task_idx_device;
+    const auto task_shell_offs = shell_to_task[ish].task_shell_offs_device;
+    const int iCen = shell_to_task[ish].center_idx;
+    const uint32_t shsz   = shell->size();
+
+    const int global_warp_id = 
+      (threadIdx.x + blockIdx.x*blockDim.x) / hip::warp_size;
+    const int nwarp_global   = max((blockDim.x*gridDim.x) / hip::warp_size,1);
+
+    double g_acc_x(0), g_acc_y(0), g_acc_z(0);
+    for( uint32_t itask = global_warp_id; itask < ntasks; itask += nwarp_global ) {
+      
+      const auto*    task   = device_tasks + task_idx[itask];
+      const uint32_t npts   = task->npts;
+      const size_t   shoff  = task_shell_offs[itask] * npts;
+      const int iParent     = task->iParent;
+      if constexpr( with_weight_derivatives ) {
+        if( iCen == iParent )
+          continue;
+      }
+      double g_acc_x_task(0), g_acc_y_task(0), g_acc_z_task(0);
+
+      const auto* __restrict__ basis_x_eval = task->dbfx + shoff;
+      const auto* __restrict__ basis_y_eval = task->dbfy + shoff;
+      const auto* __restrict__ basis_z_eval = task->dbfz + shoff;
+
+      const auto* __restrict__ basis_xx_eval = task->d2bfxx + shoff;
+      const auto* __restrict__ basis_xy_eval = task->d2bfxy + shoff;
+      const auto* __restrict__ basis_xz_eval = task->d2bfxz + shoff;
+      const auto* __restrict__ basis_yy_eval = task->d2bfyy + shoff;
+      const auto* __restrict__ basis_yz_eval = task->d2bfyz + shoff;
+      const auto* __restrict__ basis_zz_eval = task->d2bfzz + shoff;
+
+      const auto* __restrict__  xmat   = task->zmat + shoff;
+      const auto* __restrict__  xmat_x = task->xmat_x + shoff;
+      const auto* __restrict__  xmat_y = task->xmat_y + shoff;
+      const auto* __restrict__  xmat_z = task->xmat_z + shoff;
+
+      const auto* __restrict__  vrho   = task->vrho;
+      const auto* __restrict__  vgamma = task->vgamma;
+      const auto* __restrict__  vtau   = task->vtau;
+
+      const auto* __restrict__ den_x = task->dden_sx;
+      const auto* __restrict__ den_y = task->dden_sy;
+      const auto* __restrict__ den_z = task->dden_sz;
+
+      #pragma unroll 1
+      for( uint32_t ipt = threadIdx.x % hip::warp_size; 
+           ipt < npts; 
+           ipt += hip::warp_size ) {
+
+        const double vrho_i   = vrho[ipt];
+        const double vgamma_i = vgamma[ipt];
+        const double vtau_i   = 0.5 * vtau[ipt];
+
+        const double denx_i = den_x[ipt];
+        const double deny_i = den_y[ipt];
+        const double denz_i = den_z[ipt];
+        for( uint32_t ibf = 0; ibf < shsz; ++ibf ) {
+          const double z_mu_i    = xmat[ipt + ibf*npts];
+          const double dbfx_mu_i = basis_x_eval[ipt + ibf*npts];
+          const double dbfy_mu_i = basis_y_eval[ipt + ibf*npts];
+          const double dbfz_mu_i = basis_z_eval[ipt + ibf*npts];
+
+          g_acc_x_task += vrho_i * z_mu_i * dbfx_mu_i;
+          g_acc_y_task += vrho_i * z_mu_i * dbfy_mu_i;
+          g_acc_z_task += vrho_i * z_mu_i * dbfz_mu_i;
+
+          const double zx = xmat_x[ipt + ibf*npts];
+          const double zy = xmat_y[ipt + ibf*npts];
+          const double zz = xmat_z[ipt + ibf*npts];
+
+          const double d11_xmat_term = denx_i * zx + deny_i * zy + denz_i * zz;
+
+          const double d2bfxx = basis_xx_eval[ipt + ibf*npts];
+          const double d2bfxy = basis_xy_eval[ipt + ibf*npts];
+          const double d2bfxz = basis_xz_eval[ipt + ibf*npts];
+          const double d2bfyy = basis_yy_eval[ipt + ibf*npts];
+          const double d2bfyz = basis_yz_eval[ipt + ibf*npts];
+          const double d2bfzz = basis_zz_eval[ipt + ibf*npts];
+
+          {
+          const double d2_term_x = d2bfxx*denx_i + d2bfxy*deny_i + d2bfxz*denz_i;
+          const double d2_term_y = d2bfxy*denx_i + d2bfyy*deny_i + d2bfyz*denz_i;
+          const double d2_term_z = d2bfxz*denx_i + d2bfyz*deny_i + d2bfzz*denz_i;
+
+          g_acc_x_task += 2 * vgamma_i * ( z_mu_i * d2_term_x + dbfx_mu_i * d11_xmat_term );
+          g_acc_y_task += 2 * vgamma_i * ( z_mu_i * d2_term_y + dbfy_mu_i * d11_xmat_term );
+          g_acc_z_task += 2 * vgamma_i * ( z_mu_i * d2_term_z + dbfz_mu_i * d11_xmat_term );
+          }
+
+          {
+          const double d2_term_x = d2bfxx*zx + d2bfxy*zy + d2bfxz*zz;
+          const double d2_term_y = d2bfxy*zx + d2bfyy*zy + d2bfyz*zz;
+          const double d2_term_z = d2bfxz*zx + d2bfyz*zy + d2bfzz*zz;
+
+          g_acc_x_task += vtau_i * d2_term_x;
+          g_acc_y_task += vtau_i * d2_term_y;
+          g_acc_z_task += vtau_i * d2_term_z;
+          }
+
+        } // Loop over bfns within a shell
+
+      } // Loop over points
+
+      g_acc_x += g_acc_x_task;
+      g_acc_y += g_acc_y_task;
+      g_acc_z += g_acc_z_task;
+
+      //write to Parent atom with translational invariance
+      if constexpr( with_weight_derivatives ) {
+        atomicAdd( EXC_GRAD + 3*iParent + 0, 2.0 * g_acc_x_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 1, 2.0 * g_acc_y_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 2, 2.0 * g_acc_z_task );
+      }
+
+    } // Loop over tasks assigned to shell
+
+    constexpr auto warp_size = hip::warp_size;
+    g_acc_x = -2. * hip::warp_reduce_sum<warp_size>( g_acc_x );
+    g_acc_y = -2. * hip::warp_reduce_sum<warp_size>( g_acc_y );
+    g_acc_z = -2. * hip::warp_reduce_sum<warp_size>( g_acc_z );
+
+    if( (threadIdx.x % hip::warp_size) == 0 ) {
+      atomicAdd( EXC_GRAD + 3*iCen + 0, g_acc_x );
+      atomicAdd( EXC_GRAD + 3*iCen + 1, g_acc_y );
+      atomicAdd( EXC_GRAD + 3*iCen + 2, g_acc_z );
+    }
+
+  } // Loop over shells
+
+}
+
+template<bool with_weight_derivatives>
+__global__ __launch_bounds__(512,1) void increment_exc_grad_mgga_uks_kernel(
+  uint32_t                        nshell,
+  ShellToTaskDevice* __restrict__ shell_to_task,
+  XCDeviceTask*      __restrict__ device_tasks,
+  double*            __restrict__ EXC_GRAD
+) {
+  for( uint32_t ish = blockIdx.z; ish < nshell; ish += gridDim.z ) {
+    const uint32_t ntasks      = shell_to_task[ish].ntask;
+    const auto shell           = shell_to_task[ish].shell_device;
+    const auto task_idx        = shell_to_task[ish].task_idx_device;
+    const auto task_shell_offs = shell_to_task[ish].task_shell_offs_device;
+    const int iCen = shell_to_task[ish].center_idx;
+    const uint32_t shsz   = shell->size();
+
+    const int global_warp_id = 
+      (threadIdx.x + blockIdx.x*blockDim.x) / hip::warp_size;
+    const int nwarp_global   = max((blockDim.x*gridDim.x) / hip::warp_size,1);
+
+    double g_acc_x(0), g_acc_y(0), g_acc_z(0);
+    for( uint32_t itask = global_warp_id; itask < ntasks; itask += nwarp_global ) {
+      
+      const auto*    task   = device_tasks + task_idx[itask];
+      const uint32_t npts   = task->npts;
+      const size_t   shoff  = task_shell_offs[itask] * npts;
+      const int iParent     = task->iParent;
+      if constexpr( with_weight_derivatives ) {
+        if( iCen == iParent ) 
+          continue;
+      }
+      double g_acc_x_task(0), g_acc_y_task(0), g_acc_z_task(0);
+
+      const auto* __restrict__ basis_x_eval = task->dbfx + shoff;
+      const auto* __restrict__ basis_y_eval = task->dbfy + shoff;
+      const auto* __restrict__ basis_z_eval = task->dbfz + shoff;
+
+      const auto* __restrict__ basis_xx_eval = task->d2bfxx + shoff;
+      const auto* __restrict__ basis_xy_eval = task->d2bfxy + shoff;
+      const auto* __restrict__ basis_xz_eval = task->d2bfxz + shoff;
+      const auto* __restrict__ basis_yy_eval = task->d2bfyy + shoff;
+      const auto* __restrict__ basis_yz_eval = task->d2bfyz + shoff;
+      const auto* __restrict__ basis_zz_eval = task->d2bfzz + shoff;
+
+      const auto* __restrict__  xmatS   = task->xmatS   + shoff;
+      const auto* __restrict__  xmatS_x = task->xmatS_x + shoff;
+      const auto* __restrict__  xmatS_y = task->xmatS_y + shoff;
+      const auto* __restrict__  xmatS_z = task->xmatS_z + shoff;
+
+      const auto* __restrict__  xmatZ   = task->xmatZ   + shoff;
+      const auto* __restrict__  xmatZ_x = task->xmatZ_x + shoff;
+      const auto* __restrict__  xmatZ_y = task->xmatZ_y + shoff;
+      const auto* __restrict__  xmatZ_z = task->xmatZ_z + shoff;
+
+      const auto* __restrict__  vrhop = task->vrho_pos;
+      const auto* __restrict__  vrhom = task->vrho_neg;
+      const auto* __restrict__  vtaup = task->vtau_pos;
+      const auto* __restrict__  vtaum = task->vtau_neg;
+
+      const auto* __restrict__  vgamma_pp = task->vgamma_pp;
+      const auto* __restrict__  vgamma_pm = task->vgamma_pm;
+      const auto* __restrict__  vgamma_mm = task->vgamma_mm;
+
+      const auto* __restrict__ dens_x = task->dden_sx;
+      const auto* __restrict__ dens_y = task->dden_sy;
+      const auto* __restrict__ dens_z = task->dden_sz;
+
+      const auto* __restrict__ denz_x = task->dden_zx;
+      const auto* __restrict__ denz_y = task->dden_zy;
+      const auto* __restrict__ denz_z = task->dden_zz;
+
+      #pragma unroll 1
+      for( uint32_t ipt = threadIdx.x % hip::warp_size; 
+           ipt < npts; 
+           ipt += hip::warp_size ) {
+
+        const double vrhop_i = vrhop[ipt];
+        const double vrhom_i = vrhom[ipt];
+        const double vrhoS_i = 0.5 * (vrhop_i + vrhom_i);
+        const double vrhoZ_i = 0.5 * (vrhop_i - vrhom_i);        
+
+        const double vtaup_i = 0.5 * vtaup[ipt];
+        const double vtaum_i = 0.5 * vtaum[ipt];
+        const double vtauS_i = 0.5 * (vtaup_i + vtaum_i);
+        const double vtauZ_i = 0.5 * (vtaup_i - vtaum_i);
+
+        const double vgammapp_i = vgamma_pp[ipt];
+        const double vgammapm_i = vgamma_pm[ipt];
+        const double vgammamm_i = vgamma_mm[ipt];
+
+        const double denSx_i = dens_x[ipt];
+        const double denSy_i = dens_y[ipt];
+        const double denSz_i = dens_z[ipt];
+        const double denZx_i = denz_x[ipt];
+        const double denZy_i = denz_y[ipt];
+        const double denZz_i = denz_z[ipt];
+
+        for( uint32_t ibf = 0; ibf < shsz; ++ibf ) {
+          const double xN    = xmatS[ipt + ibf*npts];
+          const double xZ    = xmatZ[ipt + ibf*npts];
+          const double dbfx_mu_i = basis_x_eval[ipt + ibf*npts];
+          const double dbfy_mu_i = basis_y_eval[ipt + ibf*npts];
+          const double dbfz_mu_i = basis_z_eval[ipt + ibf*npts];
+
+          g_acc_x_task += vrhoS_i * xN * dbfx_mu_i;
+          g_acc_y_task += vrhoS_i * xN * dbfy_mu_i;
+          g_acc_z_task += vrhoS_i * xN * dbfz_mu_i;
+          g_acc_x_task += vrhoZ_i * xZ * dbfx_mu_i;
+          g_acc_y_task += vrhoZ_i * xZ * dbfy_mu_i;
+          g_acc_z_task += vrhoZ_i * xZ * dbfz_mu_i;
+
+          const double xNx = xmatS_x[ipt + ibf*npts];
+          const double xNy = xmatS_y[ipt + ibf*npts];
+          const double xNz = xmatS_z[ipt + ibf*npts];
+          const double xZx = xmatZ_x[ipt + ibf*npts];
+          const double xZy = xmatZ_y[ipt + ibf*npts];
+          const double xZz = xmatZ_z[ipt + ibf*npts];
+
+          const double d11nn_xmat_term = denSx_i * xNx + denSy_i * xNy + denSz_i * xNz;
+          const double d11nz_xmat_term = denSx_i * xZx + denSy_i * xZy + denSz_i * xZz;
+          const double d11zn_xmat_term = denZx_i * xNx + denZy_i * xNy + denZz_i * xNz;
+          const double d11zz_xmat_term = denZx_i * xZx + denZy_i * xZy + denZz_i * xZz;
+
+          const double d2bfxx = basis_xx_eval[ipt + ibf*npts];
+          const double d2bfxy = basis_xy_eval[ipt + ibf*npts];
+          const double d2bfxz = basis_xz_eval[ipt + ibf*npts];
+          const double d2bfyy = basis_yy_eval[ipt + ibf*npts];
+          const double d2bfyz = basis_yz_eval[ipt + ibf*npts];
+          const double d2bfzz = basis_zz_eval[ipt + ibf*npts];
+
+          {
+          const double d2n_term_x = d2bfxx*denSx_i + d2bfxy*denSy_i + d2bfxz*denSz_i;
+          const double d2n_term_y = d2bfxy*denSx_i + d2bfyy*denSy_i + d2bfyz*denSz_i;
+          const double d2n_term_z = d2bfxz*denSx_i + d2bfyz*denSy_i + d2bfzz*denSz_i;
+          const double d2z_term_x = d2bfxx*denZx_i + d2bfxy*denZy_i + d2bfxz*denZz_i;
+          const double d2z_term_y = d2bfxy*denZx_i + d2bfyy*denZy_i + d2bfyz*denZz_i;
+          const double d2z_term_z = d2bfxz*denZx_i + d2bfyz*denZy_i + d2bfzz*denZz_i;          
+
+          g_acc_x_task += 0.5 * (vgammapp_i + vgammapm_i + vgammamm_i) * (d2n_term_x * xN + d11nn_xmat_term * dbfx_mu_i);
+          g_acc_x_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2z_term_x * xN + d11zn_xmat_term * dbfx_mu_i);
+          g_acc_x_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2n_term_x * xZ + d11nz_xmat_term * dbfx_mu_i);
+          g_acc_x_task += 0.5 * (vgammapp_i - vgammapm_i + vgammamm_i) * (d2z_term_x * xZ + d11zz_xmat_term * dbfx_mu_i);
+
+          g_acc_y_task += 0.5 * (vgammapp_i + vgammapm_i + vgammamm_i) * (d2n_term_y * xN + d11nn_xmat_term * dbfy_mu_i);
+          g_acc_y_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2z_term_y * xN + d11zn_xmat_term * dbfy_mu_i);
+          g_acc_y_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2n_term_y * xZ + d11nz_xmat_term * dbfy_mu_i);
+          g_acc_y_task += 0.5 * (vgammapp_i - vgammapm_i + vgammamm_i) * (d2z_term_y * xZ + d11zz_xmat_term * dbfy_mu_i);
+
+          g_acc_z_task += 0.5 * (vgammapp_i + vgammapm_i + vgammamm_i) * (d2n_term_z * xN + d11nn_xmat_term * dbfz_mu_i);
+          g_acc_z_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2z_term_z * xN + d11zn_xmat_term * dbfz_mu_i);
+          g_acc_z_task += 0.5 * (vgammapp_i              - vgammamm_i) * (d2n_term_z * xZ + d11nz_xmat_term * dbfz_mu_i);
+          g_acc_z_task += 0.5 * (vgammapp_i - vgammapm_i + vgammamm_i) * (d2z_term_z * xZ + d11zz_xmat_term * dbfz_mu_i);
+          }
+
+          {
+          const double d2n_term_x = d2bfxx*xNx + d2bfxy*xNy + d2bfxz*xNz;
+          const double d2n_term_y = d2bfxy*xNx + d2bfyy*xNy + d2bfyz*xNz;
+          const double d2n_term_z = d2bfxz*xNx + d2bfyz*xNy + d2bfzz*xNz;
+          const double d2z_term_x = d2bfxx*xZx + d2bfxy*xZy + d2bfxz*xZz;
+          const double d2z_term_y = d2bfxy*xZx + d2bfyy*xZy + d2bfyz*xZz;
+          const double d2z_term_z = d2bfxz*xZx + d2bfyz*xZy + d2bfzz*xZz;
+          g_acc_x_task += vtauS_i * d2n_term_x;
+          g_acc_y_task += vtauS_i * d2n_term_y;
+          g_acc_z_task += vtauS_i * d2n_term_z;
+
+          g_acc_x_task += vtauZ_i * d2z_term_x;
+          g_acc_y_task += vtauZ_i * d2z_term_y;
+          g_acc_z_task += vtauZ_i * d2z_term_z;
+          }
+        }// Loop over bfns within a shell
+
+      } // Loop over points
+
+      g_acc_x += g_acc_x_task;
+      g_acc_y += g_acc_y_task;
+      g_acc_z += g_acc_z_task;
+
+      //write to Parent atom with translational invariance
+      if constexpr( with_weight_derivatives ) {
+        atomicAdd( EXC_GRAD + 3*iParent + 0, 2.0 * g_acc_x_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 1, 2.0 * g_acc_y_task );
+        atomicAdd( EXC_GRAD + 3*iParent + 2, 2.0 * g_acc_z_task );
+      }
+
+    } // Loop over tasks assigned to shell
+
+    constexpr auto warp_size = hip::warp_size;
+    g_acc_x = -2. * hip::warp_reduce_sum<warp_size>( g_acc_x );
+    g_acc_y = -2. * hip::warp_reduce_sum<warp_size>( g_acc_y );
+    g_acc_z = -2. * hip::warp_reduce_sum<warp_size>( g_acc_z );
+
+    if( (threadIdx.x % hip::warp_size) == 0 ) {
+      atomicAdd( EXC_GRAD + 3*iCen + 0, g_acc_x );
+      atomicAdd( EXC_GRAD + 3*iCen + 1, g_acc_y );
+      atomicAdd( EXC_GRAD + 3*iCen + 2, g_acc_z );
+    }
+
+  } // Loop over shells
+
+}
+
+void increment_exc_grad_mgga( integrator_ks_scheme ks_scheme, size_t nshell, bool need_lapl, 
+  ShellToTaskDevice* shell_to_task, XCDeviceTask* device_tasks, 
+  double* EXC_GRAD, bool with_weight_derivatives, device_queue queue ) {
+ 
+  if(need_lapl) GAUXC_GENERIC_EXCEPTION("CUDA + MGGA/LAPL EXC GRAD NYI");
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>();
+  dim3 threads(512), blocks(1,1,nshell);
+
+  switch(ks_scheme) {
+    case RKS:
+      if (with_weight_derivatives) {
+        increment_exc_grad_mgga_rks_kernel<true><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      } else {
+        increment_exc_grad_mgga_rks_kernel<false><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      }
+      break;
+    case UKS:
+      if (with_weight_derivatives) {
+        increment_exc_grad_mgga_uks_kernel<true><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      } else {
+        increment_exc_grad_mgga_uks_kernel<false><<<blocks, threads, 0 , stream>>>(
+          nshell, shell_to_task, device_tasks, EXC_GRAD 
+        );
+      }
+      break;
+    default: GAUXC_GENERIC_EXCEPTION("GGA EXC GRAD + GKS NYI");
+  }
+}
+
+}

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/pack_submat.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/pack_submat.hip
@@ -9,76 +9,231 @@
  *
  * See LICENSE.txt for details
  */
-#include "device_specific/hip_device_constants.hpp"
+#include "hip/hip_runtime.h"
 #include "device/common/pack_submat.hpp"
+#include "device_specific/hip_device_constants.hpp"
 #include <gauxc/util/div_ceil.hpp>
 #include "device_specific/hip_util.hpp"
 
 namespace GauXC {
 
+#define WARP_X 16
+#define WARP_Y 1
+#define UNROLL_FACTOR 4
+#define EFF_UNROLL 4
+#define CUT_X 8
+#define CUT_Y 8
 
 template <typename T, bool skip_single_cut = true>
-__global__ __launch_bounds__(1024,1) 
-void submat_set_combined_kernel( size_t           ntasks,
+__global__ __launch_bounds__(1024, 1)
+void sym_submat_set_combined_kernel( size_t        ntasks,
                                  XCDeviceTask* device_tasks,
-                                 T*               A,
-                                 size_t           LDA ) {
+                                 T*            A,
+                                 size_t        LDA,
+				 const int block_y,
+				 const int block_x) {
+
 
   const int batch_id = blockIdx.z;
-
-  if( batch_id < ntasks ) {
-
   auto& task = device_tasks[ batch_id ];
 
   if constexpr (skip_single_cut ) {
     if( task.bfn_screening.ncut == 1 ) return;
   }
 
-  const auto  ncut              = task.bfn_screening.ncut;
   const auto* submat_cut_device = task.bfn_screening.submat_cut;
+  const auto* submat_block_device = task.bfn_screening.submat_block;
   const auto  LDAS              = task.bfn_screening.nbe;
         auto* ASmall_device     = task.nbe_scr;
 
   //if( LDAS == LDAB ) return;
 
+  const int tid_xx = threadIdx.x % WARP_X;
+  const int tid_xy = threadIdx.x / WARP_X;
 
-  const int tid_x = blockDim.x * blockIdx.x + threadIdx.x;
-  const int tid_y = blockDim.y * blockIdx.y + threadIdx.y;
+  const int tid_yx = threadIdx.y % CUT_X;
+  const int tid_yy = threadIdx.y / CUT_X;
 
-  int64_t i(0);
-  for( size_t i_cut = 0; i_cut < ncut; ++i_cut ) {
-    const int64_t i_cut_first  = submat_cut_device[ 3*i_cut ];
-    const int64_t delta_i      = submat_cut_device[ 3*i_cut + 1 ];
+  const int start_cut_y = submat_block_device[block_y];
+  const int end_cut_y   = submat_block_device[block_y+1];
+  const int start_cut_x = submat_block_device[block_x];
+  const int end_cut_x   = submat_block_device[block_x+1];
 
-    int64_t j(0);
-  for( size_t j_cut = 0; j_cut < ncut; ++j_cut ) {
-    const int64_t j_cut_first  = submat_cut_device[ 3*j_cut ];
-    const int64_t delta_j      = submat_cut_device[ 3*j_cut + 1 ];
+  for( int i_cut = tid_yy + start_cut_y; i_cut < end_cut_y; i_cut += CUT_Y ) {
+    const int3 i_data = *((int3*)(submat_cut_device + 3*i_cut));
+    const int i_cut_first  = i_data.x;
+    const int delta_i      = i_data.y;
+    const int i_cut_small  = i_data.z;
 
-    auto* ASmall_begin = ASmall_device + i           + j          *LDAS;
-    auto* ABig_begin   = A             + i_cut_first + j_cut_first*LDA ;
+  for( int j_cut = tid_yx + start_cut_x; j_cut < end_cut_x; j_cut += CUT_X ) {
+    const int3 j_data = *((int3*)(submat_cut_device + 3*j_cut));
+    const int j_cut_first  = j_data.x; 
+    const int delta_j      = j_data.y;
+    const int j_cut_small  = j_data.z;
 
-    for( size_t J = tid_y; J < delta_j; J += blockDim.y )      
-    for( size_t I = tid_x; I < delta_i; I += blockDim.x )
-      ASmall_begin[I + J*LDAS] = ABig_begin[I + J*LDA];
+    auto* ASmall_begin = ASmall_device + i_cut_small + j_cut_small*LDAS;
+    auto* ABig_begin   = A   + i_cut_first + j_cut_first*LDA;
 
-    j += delta_j;
+    int J;
+    for( J = tid_xy; J < (delta_j / EFF_UNROLL) * EFF_UNROLL; J += EFF_UNROLL ) {
+      for( int I = tid_xx; I < delta_i; I += WARP_X ) {
+
+        double val[UNROLL_FACTOR];
+        double* address[UNROLL_FACTOR];
+#pragma unroll
+        for (int k = 0; k < UNROLL_FACTOR; k++) {
+          val[k] = ABig_begin[I + (J + k*WARP_Y)*LDA];
+          address[k] = ASmall_begin + I + (J + k*WARP_Y) * LDAS;
+        }
+#pragma unroll
+        for (int k = 0; k < UNROLL_FACTOR; k++) {
+	  // Suggest that the result be evicted first.
+	  *(address[k]) = val[k];
+        }
+      }
+    }
+
+    for ( ; J < delta_j; J += WARP_Y) {
+      for( int I = tid_xx; I < delta_i; I += WARP_X ) {
+        ASmall_begin[I + J*LDAS] = ABig_begin[I + J*LDA];
+      }
+    }
   }
-    i += delta_i;
   }
-
-  } // batch_id check
 }
+
+
+
+
 
 
 void sym_pack_submat( size_t ntasks, XCDeviceTask* device_tasks, const double* A,
   int32_t LDA, int32_t submat_block_size, device_queue queue ) {
 
   hipStream_t stream = queue.queue_as<util::hip_stream>();
-  dim3 threads(hip::warp_size,hip::max_warps_per_thread_block,1), blocks(1,1,ntasks);
-  hipLaunchKernelGGL(submat_set_combined_kernel, dim3(blocks), dim3(threads), 0, stream , 
-    ntasks, device_tasks, A, LDA
-  );
+
+  dim3 threads( hip::warp_size/2, hip::max_warps_per_thread_block * 2, 1 );
+  dim3 blocks( 1,1, ntasks );
+
+  auto n_launch = util::div_ceil( LDA, submat_block_size );
+  for (int i = 0; i < n_launch; i++) 
+  for (int j = 0; j < n_launch; j++) {
+    sym_submat_set_combined_kernel<<< blocks, threads, 0, stream >>>(
+      ntasks, device_tasks, A, LDA, i, j
+    );
+  }
 }
+
+
+
+
+
+
+
+
+
+template <typename T, bool skip_single_cut = false>
+__global__ __launch_bounds__(1024, 1)
+void asym_submat_set_combined_kernel( size_t        ntasks,
+                                 XCDeviceTask* device_tasks,
+                                 T*            A,
+                                 size_t        LDA,
+				 const int block_y,
+				 const int block_x) {
+
+
+  const int batch_id = blockIdx.z;
+  auto& task = device_tasks[ batch_id ];
+
+  if constexpr (skip_single_cut ) {
+    if( task.bfn_screening.ncut == 1 ) return;
+  }
+
+  const auto* row_submat_cut_device = task.bfn_screening.submat_cut;
+  const auto* row_submat_block_device = task.bfn_screening.submat_block;
+  const auto* col_submat_cut_device = task.cou_screening.submat_cut;
+  const auto* col_submat_block_device = task.cou_screening.submat_block;
+
+  const auto  LDAS              = task.bfn_screening.nbe;
+        auto* ASmall_device     = task.nbe_scr;
+
+  //if( LDAS == LDAB ) return;
+
+  const int tid_xx = threadIdx.x % WARP_X;
+  const int tid_xy = threadIdx.x / WARP_X;
+
+  const int tid_yx = threadIdx.y % CUT_X;
+  const int tid_yy = threadIdx.y / CUT_X;
+
+  const int start_cut_y = row_submat_block_device[block_y];
+  const int end_cut_y   = row_submat_block_device[block_y+1];
+  const int start_cut_x = col_submat_block_device[block_x];
+  const int end_cut_x   = col_submat_block_device[block_x+1];
+
+  for( int i_cut = tid_yy + start_cut_y; i_cut < end_cut_y; i_cut += CUT_Y ) {
+    const int3 i_data = *((int3*)(row_submat_cut_device + 3*i_cut));
+    const int i_cut_first  = i_data.x;
+    const int delta_i      = i_data.y;
+    const int i_cut_small  = i_data.z;
+
+  for( int j_cut = tid_yx + start_cut_x; j_cut < end_cut_x; j_cut += CUT_X ) {
+    const int3 j_data = *((int3*)(col_submat_cut_device + 3*j_cut));
+    const int j_cut_first  = j_data.x; 
+    const int delta_j      = j_data.y;
+    const int j_cut_small  = j_data.z;
+
+    auto* ASmall_begin = ASmall_device + i_cut_small + j_cut_small*LDAS;
+    auto* ABig_begin   = A   + i_cut_first + j_cut_first*LDA;
+
+    int J;
+    for( J = tid_xy; J < (delta_j / EFF_UNROLL) * EFF_UNROLL; J += EFF_UNROLL ) {
+      for( int I = tid_xx; I < delta_i; I += WARP_X ) {
+
+        double val[UNROLL_FACTOR];
+        double* address[UNROLL_FACTOR];
+#pragma unroll
+        for (int k = 0; k < UNROLL_FACTOR; k++) {
+          val[k] = ABig_begin[I + (J + k*WARP_Y)*LDA];
+          address[k] = ASmall_begin + I + (J + k*WARP_Y) * LDAS;
+        }
+#pragma unroll
+        for (int k = 0; k < UNROLL_FACTOR; k++) {
+	  // Suggest that the result be evicted first.
+	  *(address[k]) = val[k];
+        }
+      }
+    }
+
+    for ( ; J < delta_j; J += WARP_Y) {
+      for( int I = tid_xx; I < delta_i; I += WARP_X ) {
+        ASmall_begin[I + J*LDAS] = ABig_begin[I + J*LDA];
+      }
+    }
+  }
+  }
+}
+
+
+
+
+
+
+void asym_pack_submat( size_t ntasks, XCDeviceTask* device_tasks, const double* A,
+  int32_t LDA, int32_t submat_block_size, device_queue queue ) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>();
+
+  dim3 threads( hip::warp_size/2, hip::max_warps_per_thread_block * 2, 1 );
+  dim3 blocks( 1,1, ntasks );
+
+  auto n_launch = util::div_ceil( LDA, submat_block_size );
+  for (int i = 0; i < n_launch; i++) 
+  for (int j = 0; j < n_launch; j++) {
+    asym_submat_set_combined_kernel<<< blocks, threads, 0, stream >>>(
+      ntasks, device_tasks, A, LDA, i, j
+    );
+  }
+}
+
 
 }

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/symmetrize_mat.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/symmetrize_mat.hip
@@ -9,58 +9,105 @@
  *
  * See LICENSE.txt for details
  */
-#include "device/common/symmetrize_mat.hpp"
 #include "hip/hip_runtime.h"
+#include "device/common/symmetrize_mat.hpp"
+#include "device_specific/hip_device_constants.hpp"
 #include "device_specific/hip_util.hpp"
 
 namespace GauXC {
 
+__global__ void symmetrize_matrix_device( size_t N, double* A, size_t LDA ) {
 
-__host__ __device__ inline constexpr int div_ceil( int i, int j ){ return (i/j) + !!(i%j); } 
+  constexpr uint32_t block_size = hip::warp_size;
 
-template <int BLOCK_SIZE>
-__global__ void symmetrize_matrix_kernel( int N, double* A, int LDA ) {
+  __shared__ double buffer[block_size][block_size+1];  // Pad shared memory to resolve shared memory
 
-  __shared__ double shmem[BLOCK_SIZE][BLOCK_SIZE+1];
+  const size_t num_blocks = ((N + block_size - 1) / block_size);
 
-  const auto n_block = div_ceil(N, BLOCK_SIZE);
-  for( int i_block = 0;       i_block < n_block; ++i_block )
-  for( int j_block = i_block; j_block < n_block; ++j_block ) { 
-  
-    const int ij_block = (i_block+1) + (j_block+1)*j_block/2 - 1;
-    if( ij_block % gridDim.x != blockIdx.x ) continue;
+  for (int i = blockIdx.x; i < num_blocks; i += gridDim.x) {
+    // TODO This could be load balanced if need be
+    const int i_coord = i * block_size;
+    for (int j = i; j < num_blocks; j++) {
+      const int j_coord = j * block_size;
 
-    const int i_coord = i_block * BLOCK_SIZE;
-    const int j_coord = j_block * BLOCK_SIZE;
+      // Read in block to buffer
+      // TODO These could be vector reads/writes if this becomes significant
+      if (i_coord + threadIdx.y < N && j_coord + threadIdx.x < N) {
+        buffer[threadIdx.y][threadIdx.x] = A[(i_coord + threadIdx.y) * LDA + j_coord + threadIdx.x];
+      }
+      __syncthreads();
 
-    const int ix = i_coord + threadIdx.x;
-    const int iy = i_coord + threadIdx.y;
-    const int jx = j_coord + threadIdx.x;
-    const int jy = j_coord + threadIdx.y;
-
-    if( iy < N and jx < N )
-      shmem[threadIdx.y][threadIdx.x] = A[iy*LDA + jx];
-    __syncthreads();
-
-    if( jy < N and ix < N )
-    if( i_coord != j_coord or threadIdx.x < threadIdx.y ) // Diagonal block
-      A[jy*LDA + ix] = shmem[threadIdx.x][threadIdx.y];
-    __syncthreads();
-
+      // Write buffer
+      if (j_coord + threadIdx.y < N && i_coord + threadIdx.x < N) {
+        if ((j_coord != i_coord || threadIdx.x < threadIdx.y)) { // handles the diagonal block
+          A[(j_coord + threadIdx.y) * LDA + i_coord + threadIdx.x] = buffer[threadIdx.x][threadIdx.y];
+        }
+      }
+      __syncthreads();
+    }
   }
-
 }
+
+__global__ void symmetrize_matrix_inc_device( size_t N, double* A, size_t LDA ) {
+
+  constexpr uint32_t block_size = hip::warp_size;
+
+  __shared__ double buffer_0[block_size][block_size+1];  // Pad shared memory to resolve shared memory
+  __shared__ double buffer_1[block_size][block_size+1];  // Pad shared memory to resolve shared memory
+
+  const size_t num_blocks = ((N + block_size - 1) / block_size);
+
+  for (int i = blockIdx.x; i < num_blocks; i += gridDim.x) {
+    // TODO This could be load balanced if need be
+    const int i_coord = i * block_size;
+    for (int j = i; j < num_blocks; j++) {
+      const int j_coord = j * block_size;
+
+      // Read in block to buffer
+      // TODO These could be vector reads/writes if this becomes significant
+      if (i_coord + threadIdx.y < N && j_coord + threadIdx.x < N) {
+        buffer_0[threadIdx.y][threadIdx.x] = A[(i_coord + threadIdx.y) * LDA + j_coord + threadIdx.x];
+      }
+      if (j_coord + threadIdx.y < N && i_coord + threadIdx.x < N) {
+        buffer_1[threadIdx.y][threadIdx.x] = A[(j_coord + threadIdx.y) * LDA + i_coord + threadIdx.x];
+      }
+      __syncthreads();
+
+      buffer_0[threadIdx.y][threadIdx.x] += buffer_1[threadIdx.x][threadIdx.y];
+      buffer_0[threadIdx.y][threadIdx.x] *= 0.5;
+      __syncthreads();
+
+      // Write buffer
+      if (j_coord + threadIdx.y < N && i_coord + threadIdx.x < N) {
+        //if ((j_coord != i_coord || threadIdx.x < threadIdx.y)) { // handles the diagonal block
+          A[(j_coord + threadIdx.y) * LDA + i_coord + threadIdx.x] = buffer_0[threadIdx.x][threadIdx.y];
+        //}
+      }
+      if (i_coord + threadIdx.y < N && j_coord + threadIdx.x < N) {
+        //if ((j_coord != i_coord || threadIdx.x > threadIdx.y)) { // handles the diagonal block
+          A[(i_coord + threadIdx.y) * LDA + j_coord + threadIdx.x] = buffer_0[threadIdx.y][threadIdx.x];
+        //}
+      }
+      __syncthreads();
+    }
+  }
+}
+
+
 
 void symmetrize_matrix( int32_t N, double* A, size_t LDA, device_queue queue ) {
-
   hipStream_t stream = queue.queue_as<util::hip_stream>();
-  constexpr int block_size = 32;
-  const int n_rc_blocks = div_ceil( N, block_size );
-  const size_t n_total_blocks = n_rc_blocks * (n_rc_blocks+1) / 2;
-  dim3 threads(block_size,block_size), blocks(std::min(100ul, n_total_blocks));
-  
-  symmetrize_matrix_kernel<32><<<blocks,threads,0,stream>>>( N, A, LDA );
-
+  const size_t num_blocks = ((N + hip::warp_size - 1) / hip::warp_size);
+  // Warp size must equal max_warps_per_thread_block must equal 32
+  dim3 threads(hip::warp_size, hip::max_warps_per_thread_block), blocks(num_blocks);
+  symmetrize_matrix_device<<<blocks, threads, 0, stream>>>(N, A, LDA);
 }
 
+void symmetrize_matrix_inc( int32_t N, double* A, size_t LDA, device_queue queue ) {
+  hipStream_t stream = queue.queue_as<util::hip_stream>();
+  const size_t num_blocks = ((N + hip::warp_size - 1) / hip::warp_size);
+  // Warp size must equal max_warps_per_thread_block must equal 32
+  dim3 threads(hip::warp_size, hip::max_warps_per_thread_block), blocks(num_blocks);
+  symmetrize_matrix_inc_device<<<blocks, threads, 0, stream>>>(N, A, LDA);
+}
 }

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/uvvars.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/uvvars.hip
@@ -9,200 +9,221 @@
  *
  * See LICENSE.txt for details
  */
+#include "hip/hip_runtime.h"
 #include "device/common/uvvars.hpp"
 #include "hip_extensions.hpp"
-#include "device_specific/hip_device_constants.hpp"
 #include <gauxc/util/div_ceil.hpp>
-#include "device_specific/hip_util.hpp"
+
+#include "uvvars_lda.hpp"
+#include "uvvars_gga.hpp"
+#include "uvvars_mgga.hpp"
 
 namespace GauXC {
 
+#define EVAL_UVARS_KERNEL(xc_approx) \
+  hipStream_t stream = queue.queue_as<util::hip_stream>();  \
+  switch ( ks_scheme ) { \
+    case RKS: \
+      eval_uvars_##xc_approx##_rks_kernel<<< blocks, threads, 0, stream >>>( ntasks, device_tasks ); \
+      break; \
+    case UKS: \
+      eval_uvars_##xc_approx##_uks_kernel<<< blocks, threads, 0, stream >>>( ntasks, device_tasks ); \
+      break; \
+    case GKS: \
+      eval_uvars_##xc_approx##_gks_kernel<<< blocks, threads, 0, stream >>>( ntasks, device_tasks ); \
+      break; \
+    default: \
+      GAUXC_GENERIC_EXCEPTION( "Unexpected KS scheme when attempting to evaluate U vars" ); \
+  } 
 
-__global__ void eval_uvars_lda_kernel( size_t           ntasks,
-                                       XCDeviceTask* tasks_device ) {
+  
+#define EVAL_TMAT_KERNEL(xc_approx) \
+  hipStream_t stream = queue.queue_as<util::hip_stream>();  \
+  switch ( ks_scheme ) { \
+    case RKS: \
+      eval_tmat_##xc_approx##_rks_kernel<<< blocks, threads, 0, stream >>>( ntasks, device_tasks); \
+      break; \
+    case UKS: \
+      eval_tmat_##xc_approx##_uks_kernel<<< blocks, threads, 0, stream >>>( ntasks, device_tasks); \
+      break; \
+    case GKS: \
+      GAUXC_GENERIC_EXCEPTION( "GKS + evaluate trial U vars NYI" ); \
+      break; \
+    default: \
+      GAUXC_GENERIC_EXCEPTION( "Unexpected KS scheme when attempting to evaluate U vars" ); \
+  } 
 
-  const int batch_idx = blockIdx.z;
-  if( batch_idx >= ntasks ) return;
 
-  auto& task = tasks_device[ batch_idx ];
-
-  const auto npts            = task.npts;
-  const auto nbf             = task.bfn_screening.nbe;
-
-  auto* den_eval_device   = task.den;
-
-  const auto* basis_eval_device = task.bf;
-
-  const auto* den_basis_prod_device = task.zmat;
-
-  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
-  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
-
-  double den_reg = 0.;
-
-  if( tid_x < nbf and tid_y < npts ) {
-
-    const double* bf_col   = basis_eval_device     + tid_x*npts;
-    const double* db_col   = den_basis_prod_device + tid_x*npts;
-
-    den_reg = bf_col[ tid_y ]   * db_col[ tid_y ];
-
+#define EVAL_VVARS_KERNEL(xc_approx) \
+  hipStream_t stream = queue.queue_as<util::hip_stream>();  \
+  switch ( den_select ) { \
+    case DEN_S: \
+      eval_vvar_##xc_approx##_kern<trial,DEN_S><<< blocks, threads, 0, stream >>>( ntasks, device_tasks ); \
+      break; \
+    case DEN_Z: \
+      eval_vvar_##xc_approx##_kern<trial,DEN_Z><<< blocks, threads, 0, stream >>>( ntasks, device_tasks ); \
+      break; \
+    case DEN_Y: \
+      eval_vvar_##xc_approx##_kern<trial,DEN_Y><<< blocks, threads, 0, stream >>>( ntasks, device_tasks ); \
+      break; \
+    case DEN_X: \
+      eval_vvar_##xc_approx##_kern<trial,DEN_X><<< blocks, threads, 0, stream >>>( ntasks, device_tasks ); \
+      break; \
+    default: \
+      GAUXC_GENERIC_EXCEPTION( "Unexpected KS scheme when attempting to evaluate V vars" ); \
   }
 
-  // Warp blocks are stored col major
-  den_reg = 2 * hip::warp_reduce_sum<hip::warp_size>( den_reg );
-
-
-  if( threadIdx.x == 0 and tid_y < npts ) {
-    atomicAdd( den_eval_device   + tid_y, den_reg );
-  }
-
-
-}
-
-
-void eval_uvvars_lda( size_t ntasks, int32_t nbf_max, int32_t npts_max,
+// Internal implementation with trial parameter
+void eval_tmat_lda( size_t ntasks, int32_t npts_max, integrator_ks_scheme ks_scheme,
   XCDeviceTask* device_tasks, device_queue queue ) {
+  dim3 threads( hip::max_warps_per_thread_block * hip::warp_size, 1, 1 );
+  dim3 blocks( util::div_ceil( npts_max,  threads.x ), 1, ntasks ); 
+  EVAL_TMAT_KERNEL(lda);
+}
 
-  hipStream_t stream = queue.queue_as<util::hip_stream>();
+void eval_uvars_lda( size_t ntasks, int32_t npts_max, integrator_ks_scheme ks_scheme,
+  XCDeviceTask* device_tasks, device_queue queue ) {
+  dim3 threads( hip::max_warps_per_thread_block * hip::warp_size, 1, 1 );
+  dim3 blocks( util::div_ceil( npts_max,  threads.x ), 1, ntasks ); 
+  EVAL_UVARS_KERNEL(lda);
+}
 
-  dim3 threads(hip::warp_size, hip::max_warps_per_thread_block, 1);
-  dim3 blocks( util::div_ceil( nbf_max , threads.x ),
-               util::div_ceil( npts_max , threads.y ),
+// Internal implementation with trial as template parameter
+template<bool trial>
+void eval_vvars_lda_impl( size_t ntasks, int32_t nbf_max, int32_t npts_max, density_id den_select,
+  XCDeviceTask* device_tasks, device_queue queue ) {
+  dim3 threads( hip::warp_size, hip::max_warps_per_thread_block, 1 );
+  dim3 blocks( util::div_ceil( nbf_max,  threads.x ),
+               util::div_ceil( npts_max, threads.y ),
                ntasks );
+  EVAL_VVARS_KERNEL(lda);
+}
+void eval_vvars_lda( size_t ntasks, int32_t nbf_max, int32_t npts_max, density_id den_select,
+  XCDeviceTask* device_tasks, device_queue queue ) {
+  eval_vvars_lda_impl<false>(ntasks, nbf_max, npts_max, den_select, device_tasks, queue);
+}
+void eval_vvars_lda_trial( size_t ntasks, int32_t nbf_max, int32_t npts_max, density_id den_select,
+  XCDeviceTask* device_tasks, device_queue queue ) {
+  eval_vvars_lda_impl<true>(ntasks, nbf_max, npts_max, den_select, device_tasks, queue);
+}
 
-  hipLaunchKernelGGL(eval_uvars_lda_kernel, dim3(blocks), dim3(threads), 0, 
-    stream, ntasks, device_tasks );
-
+// Internal implementation with trial parameter
+void eval_tmat_gga( size_t ntasks, int32_t npts_max, integrator_ks_scheme ks_scheme,
+  XCDeviceTask* device_tasks, device_queue queue ) {
+  dim3 threads( GGA_KERNEL_SM_WARPS * hip::warp_size, 1, 1 );
+  dim3 blocks( util::div_ceil( npts_max,  threads.x ), 1, ntasks ); 
+  EVAL_TMAT_KERNEL(gga);
+}
+void eval_uvars_gga( size_t ntasks, int32_t npts_max, integrator_ks_scheme ks_scheme,
+  XCDeviceTask* device_tasks, device_queue queue ) {
+  dim3 threads( GGA_KERNEL_SM_WARPS * hip::warp_size, 1, 1 );
+  dim3 blocks( util::div_ceil( npts_max,  threads.x ), 1, ntasks ); 
+  EVAL_UVARS_KERNEL(gga);
 }
 
 
+// Internal implementation with trial as template parameter
+template<bool trial>
+void eval_vvars_gga_impl( size_t ntasks, int32_t nbf_max, int32_t npts_max, density_id den_select,
+  XCDeviceTask* device_tasks, device_queue queue ) {
+  dim3 threads( hip::warp_size, hip::max_warps_per_thread_block, 1 );
+  dim3 blocks( util::div_ceil( nbf_max,  threads.x ),
+               util::div_ceil( npts_max, threads.y ),
+               ntasks );
+  EVAL_VVARS_KERNEL(gga);
+}
+void eval_vvars_gga( size_t ntasks, int32_t nbf_max, int32_t npts_max, density_id den_select,
+  XCDeviceTask* device_tasks, device_queue queue ) {
+  eval_vvars_gga_impl<false>(ntasks, nbf_max, npts_max, den_select, device_tasks, queue);
+}
+void eval_vvars_gga_trial( size_t ntasks, int32_t nbf_max, int32_t npts_max, density_id den_select,
+  XCDeviceTask* device_tasks, device_queue queue ) {
+  eval_vvars_gga_impl<true>(ntasks, nbf_max, npts_max, den_select, device_tasks, queue);
+}
 
+// Internal implementation with trial parameter
+void eval_tmat_mgga( size_t ntasks, int32_t npts_max, integrator_ks_scheme ks_scheme,
+  bool need_lapl, XCDeviceTask* device_tasks, device_queue queue ) {
+  hipStream_t stream = queue.queue_as<util::hip_stream>(); 
 
+  dim3 threads( GGA_KERNEL_SM_WARPS * hip::warp_size, 1, 1 );
+  dim3 blocks( util::div_ceil( npts_max,  threads.x ), 1, ntasks ); 
 
+  if(need_lapl) {
+    GAUXC_GENERIC_EXCEPTION("MGGA + LAPL + eval tmat NYI");
+  }
+  if(ks_scheme == RKS) {
+      eval_tmat_mgga_rks_kernel<<<blocks, threads, 0, stream>>>(ntasks, device_tasks);
+  } else if(ks_scheme == UKS) {
+      eval_tmat_mgga_uks_kernel<<<blocks, threads, 0, stream>>>(ntasks, device_tasks);
+  } else {
+    GAUXC_GENERIC_EXCEPTION("GKS + MGGA + DEVICE NYI");
+  }
+}
 
+void eval_uvars_mgga( size_t ntasks, int32_t npts_max, integrator_ks_scheme ks_scheme,
+  bool need_lapl, XCDeviceTask* device_tasks, device_queue queue ) {
 
+  hipStream_t stream = queue.queue_as<util::hip_stream>(); 
 
+  // Evaluate GAMMA
+  eval_uvars_gga(ntasks, npts_max, ks_scheme, device_tasks, queue);
 
-
-
-
-
-__global__ void eval_uvars_gga_kernel( size_t           ntasks,
-                                       XCDeviceTask* tasks_device ) {
-
-  const int batch_idx = blockIdx.z;
-  if( batch_idx >= ntasks ) return;
-
-  auto& task = tasks_device[ batch_idx ];
-
-  const auto npts            = task.npts;
-  const auto nbf             = task.bfn_screening.nbe;
-
-  auto* den_eval_device   = task.den;
-  auto* den_x_eval_device = task.ddenx;
-  auto* den_y_eval_device = task.ddeny;
-  auto* den_z_eval_device = task.ddenz;
-
-  const auto* basis_eval_device = task.bf;
-  const auto* dbasis_x_eval_device = task.dbfx;
-  const auto* dbasis_y_eval_device = task.dbfy;
-  const auto* dbasis_z_eval_device = task.dbfz;
-
-  const auto* den_basis_prod_device = task.zmat;
-
-  // We always launch enough blocks to cover npts, so blocks aren't doing multiple results
-  double den_reg = 0.;
-  double dx_reg = 0.;
-  double dy_reg = 0.;
-  double dz_reg = 0.;
-
-  // Have each thread accumulate its own reduction result into a register.
-  // There's no real _need_ for LDS because the reductions are small and
-  // therefore can be done without sharing.
-  for( int ibf = 0; ibf < nbf; ibf++ ) {
-
-    for( int  ipt = blockIdx.x * blockDim.x + threadIdx.x; ipt < npts; ipt += blockDim.x * gridDim.x ) {
-
-      const double* bf_col   = basis_eval_device     + ibf*npts;
-      const double* bf_x_col = dbasis_x_eval_device  + ibf*npts;
-      const double* bf_y_col = dbasis_y_eval_device  + ibf*npts;
-      const double* bf_z_col = dbasis_z_eval_device  + ibf*npts;
-      const double* db_col   = den_basis_prod_device + ibf*npts;
-
-      den_reg += 2 * bf_col[ ipt ]   * db_col[ ipt ];
-      dx_reg += 4 * bf_x_col[ ipt ] * db_col[ ipt ];
-      dy_reg += 4 * bf_y_col[ ipt ] * db_col[ ipt ];
-      dz_reg += 4 * bf_z_col[ ipt ] * db_col[ ipt ];
+  if(ks_scheme == RKS) {
+    return; // Nothing left to do
+  } else if(ks_scheme == UKS) {
+    dim3 threads( hip::max_warps_per_thread_block * hip::warp_size, 1, 1 );
+    dim3 blocks( util::div_ceil( npts_max,  threads.x ), 1, ntasks ); 
+    if(need_lapl) {
+      eval_uvars_mgga_uks_kernel<true><<<blocks, threads, 0, stream>>>(ntasks, device_tasks);
+    } else {
+      eval_uvars_mgga_uks_kernel<false><<<blocks, threads, 0, stream>>>(ntasks, device_tasks);
     }
-  }
-
-
-  for( int  ipt = blockIdx.x * blockDim.x + threadIdx.x; ipt < npts; ipt += blockDim.x * gridDim.x ) {
-    den_eval_device   [ipt] = den_reg;
-    den_x_eval_device [ipt] = dx_reg ;
-    den_y_eval_device [ipt] = dy_reg ;
-    den_z_eval_device [ipt] = dz_reg ;
+  } else {
+    GAUXC_GENERIC_EXCEPTION("GKS + MGGA + DEVICE NYI");
   }
 
 }
 
+// Internal implementation with trial as template parameter
+template<bool trial>
+void eval_vvars_mgga_impl( size_t ntasks, int32_t nbf_max, int32_t npts_max, density_id den_select,
+  bool need_lapl, XCDeviceTask* device_tasks, device_queue queue ) {
+  // First evaluate GGA variables
+  eval_vvars_gga_impl<trial>(ntasks, nbf_max, npts_max, den_select, device_tasks, queue);
 
-__global__ void eval_vvars_gga_kernel( 
-  size_t        npts,
-  const double* den_x_eval_device,
-  const double* den_y_eval_device,
-  const double* den_z_eval_device,
-        double* gamma_eval_device
-) {
-
-  const int tid = threadIdx.x + blockIdx.x * blockDim.x;
-  if( tid < npts ) {
-
-    const double dx = den_x_eval_device[ tid ];
-    const double dy = den_y_eval_device[ tid ];
-    const double dz = den_z_eval_device[ tid ];
-
-    gamma_eval_device[tid] = dx*dx + dy*dy + dz*dz;
-
-  }
-
-}
-
-
-
-
-void eval_uvvars_gga( size_t ntasks, size_t npts_total, int32_t nbf_max, 
-  int32_t npts_max, XCDeviceTask* device_tasks, const double* denx, 
-  const double* deny, const double* denz, double* gamma, device_queue queue ) {
-
-  hipStream_t stream = queue.queue_as<util::hip_stream>();
-
-  // U Variables
-  {
-  dim3 threads(hip::max_threads_per_thread_block, 1, 1);
-  dim3 blocks( util::div_ceil( npts_max , threads.x ),
-               1,
+  dim3 threads( hip::warp_size, hip::max_warps_per_thread_block, 1 );
+  dim3 blocks( util::div_ceil( nbf_max,  threads.x ),
+               util::div_ceil( npts_max, threads.y ),
                ntasks );
 
-  hipLaunchKernelGGL(eval_uvars_gga_kernel, dim3(blocks), dim3(threads), 0, 
-    stream, ntasks, device_tasks );
+  hipStream_t stream = queue.queue_as<util::hip_stream>();
+  switch ( den_select ) {
+    case DEN_S:
+      if (need_lapl) {
+        eval_vvar_mgga_kern<trial,DEN_S,true><<< blocks, threads, 0, stream >>>( ntasks, device_tasks ); 
+      } else {
+        eval_vvar_mgga_kern<trial,DEN_S,false><<< blocks, threads, 0, stream >>>( ntasks, device_tasks );
+      }
+      break;
+    case DEN_Z:
+      if (need_lapl) {
+        eval_vvar_mgga_kern<trial,DEN_Z,true><<< blocks, threads, 0, stream >>>( ntasks, device_tasks ); 
+      } else {
+        eval_vvar_mgga_kern<trial,DEN_Z,false><<< blocks, threads, 0, stream >>>( ntasks, device_tasks );
+      }
+      break;
+    default:
+      GAUXC_GENERIC_EXCEPTION( "Unexpected KS scheme when attempting to evaluate V vars" );
   }
-
-  // V Variables
-  dim3 threads( hip::max_threads_per_thread_block );
-  dim3 blocks( util::div_ceil( npts_total, threads.x ) );
-  hipLaunchKernelGGL(eval_vvars_gga_kernel, blocks, threads, 0, stream,
-    npts_total, denx, deny, denz, gamma);
-
 }
-
-
-
-
-
-
-
-
+void eval_vvars_mgga( size_t ntasks, int32_t nbf_max, int32_t npts_max, density_id den_select,
+  bool need_lapl, XCDeviceTask* device_tasks, device_queue queue ) {
+  eval_vvars_mgga_impl<false>(ntasks, nbf_max, npts_max, den_select, need_lapl, device_tasks, queue);
+}
+void eval_vvars_mgga_trial( size_t ntasks, int32_t nbf_max, int32_t npts_max, density_id den_select,
+  bool need_lapl, XCDeviceTask* device_tasks, device_queue queue ) {
+  eval_vvars_mgga_impl<true>(ntasks, nbf_max, npts_max, den_select, need_lapl, device_tasks, queue);
+}
 
 }

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/uvvars_gga.hpp
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/uvvars_gga.hpp
@@ -1,0 +1,556 @@
+/**
+ * GauXC Copyright (c) 2020-2024, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of
+ * any required approvals from the U.S. Dept. of Energy).
+ *
+ * (c) 2024-2025, Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * See LICENSE.txt for details
+ */
+#pragma once
+#include "hip/hip_runtime.h"
+#include "device_specific/hip_device_constants.hpp"
+#include "device_specific/hip_util.hpp"
+#include "device/xc_device_data.hpp"
+
+#define VVAR_KERNEL_SM_BLOCK 32
+#define GGA_KERNEL_SM_WARPS 16
+
+namespace GauXC {
+
+template <bool trial, density_id den_select>
+__global__ void eval_vvar_gga_kern( size_t        ntasks,
+                                    XCDeviceTask* tasks_device) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+
+  double* den_eval_device   = nullptr;
+  double* den_x_eval_device = nullptr;
+  double* den_y_eval_device = nullptr;
+  double* den_z_eval_device = nullptr;
+
+  constexpr auto warp_size = hip::warp_size;
+
+  if constexpr (trial){
+    if constexpr (den_select == DEN_S) {
+      den_eval_device   = task.tden_s;
+      den_x_eval_device = task.tdden_sx;
+      den_y_eval_device = task.tdden_sy;
+      den_z_eval_device = task.tdden_sz;
+    }
+    if constexpr (den_select == DEN_Z) {
+      den_eval_device   = task.tden_z;
+      den_x_eval_device = task.tdden_zx;
+      den_y_eval_device = task.tdden_zy;
+      den_z_eval_device = task.tdden_zz;
+    }
+    if constexpr (den_select == DEN_Y) {
+      den_eval_device   = task.tden_y;
+      den_x_eval_device = task.tdden_yx;
+      den_y_eval_device = task.tdden_yy;
+      den_z_eval_device = task.tdden_yz;
+    }
+    if constexpr (den_select == DEN_X) {
+      den_eval_device   = task.tden_x;
+      den_x_eval_device = task.tdden_xx;
+      den_y_eval_device = task.tdden_xy;
+      den_z_eval_device = task.tdden_xz;
+    }
+  }else{
+    if constexpr (den_select == DEN_S) {
+      den_eval_device   = task.den_s;
+      den_x_eval_device = task.dden_sx;
+      den_y_eval_device = task.dden_sy;
+      den_z_eval_device = task.dden_sz;
+    }
+    if constexpr (den_select == DEN_Z) {
+      den_eval_device   = task.den_z;
+      den_x_eval_device = task.dden_zx;
+      den_y_eval_device = task.dden_zy;
+      den_z_eval_device = task.dden_zz;
+    }
+    if constexpr (den_select == DEN_Y) {
+      den_eval_device   = task.den_y;
+      den_x_eval_device = task.dden_yx;
+      den_y_eval_device = task.dden_yy;
+      den_z_eval_device = task.dden_yz;
+    }
+    if constexpr (den_select == DEN_X) {
+      den_eval_device   = task.den_x;
+      den_x_eval_device = task.dden_xx;
+      den_y_eval_device = task.dden_xy;
+      den_z_eval_device = task.dden_xz;
+    }
+  }
+
+  const auto* basis_eval_device = task.bf;
+  const auto* dbasis_x_eval_device = task.dbfx;
+  const auto* dbasis_y_eval_device = task.dbfy;
+  const auto* dbasis_z_eval_device = task.dbfz;
+
+  const auto* den_basis_prod_device = task.zmat;
+  
+  __shared__ double den_shared[4][warp_size][VVAR_KERNEL_SM_BLOCK+1];
+
+  for ( int bid_x = blockIdx.x * blockDim.x; 
+        bid_x < nbf;
+        bid_x += blockDim.x * gridDim.x ) {
+    
+    for ( int bid_y = blockIdx.y * VVAR_KERNEL_SM_BLOCK; 
+          bid_y < npts;
+          bid_y += VVAR_KERNEL_SM_BLOCK * gridDim.y ) {
+        
+      for (int sm_y = threadIdx.y; sm_y < VVAR_KERNEL_SM_BLOCK; sm_y += blockDim.y) {
+        den_shared[0][threadIdx.x][sm_y] = 0.;
+        den_shared[1][threadIdx.x][sm_y] = 0.;
+        den_shared[2][threadIdx.x][sm_y] = 0.;
+        den_shared[3][threadIdx.x][sm_y] = 0.;
+
+        if (bid_y + threadIdx.x < npts and bid_x + sm_y < nbf) { 
+          const double* db_col   = den_basis_prod_device + (bid_x + sm_y)*npts;
+          const double* bf_col   = basis_eval_device     + (bid_x + sm_y)*npts;
+          const double* bf_x_col = dbasis_x_eval_device  + (bid_x + sm_y)*npts;
+          const double* bf_y_col = dbasis_y_eval_device  + (bid_x + sm_y)*npts;
+          const double* bf_z_col = dbasis_z_eval_device  + (bid_x + sm_y)*npts;
+
+          den_shared[0][threadIdx.x][sm_y] = bf_col  [ bid_y + threadIdx.x ] * db_col[ bid_y + threadIdx.x ];
+          den_shared[1][threadIdx.x][sm_y] = bf_x_col[ bid_y + threadIdx.x ] * db_col[ bid_y + threadIdx.x ];
+          den_shared[2][threadIdx.x][sm_y] = bf_y_col[ bid_y + threadIdx.x ] * db_col[ bid_y + threadIdx.x ];
+          den_shared[3][threadIdx.x][sm_y] = bf_z_col[ bid_y + threadIdx.x ] * db_col[ bid_y + threadIdx.x ];
+        }
+      }
+      __syncthreads();
+
+
+      for (int sm_y = threadIdx.y; sm_y < VVAR_KERNEL_SM_BLOCK; sm_y += blockDim.y) {
+        const int tid_y = bid_y + sm_y;
+        register double den_reg = den_shared[0][sm_y][threadIdx.x];
+        register double dx_reg  = den_shared[1][sm_y][threadIdx.x];
+        register double dy_reg  = den_shared[2][sm_y][threadIdx.x];
+        register double dz_reg  = den_shared[3][sm_y][threadIdx.x];
+
+        // Warp blocks are stored col major
+        den_reg =     hip::warp_reduce_sum<warp_size>( den_reg );
+        dx_reg  = 2. * hip::warp_reduce_sum<warp_size>( dx_reg );
+        dy_reg  = 2. * hip::warp_reduce_sum<warp_size>( dy_reg );
+        dz_reg  = 2. * hip::warp_reduce_sum<warp_size>( dz_reg );
+
+
+        if( threadIdx.x == 0 and tid_y < npts ) {
+          atomicAdd( den_eval_device   + tid_y, den_reg );
+          atomicAdd( den_x_eval_device + tid_y, dx_reg  );
+          atomicAdd( den_y_eval_device + tid_y, dy_reg  );
+          atomicAdd( den_z_eval_device + tid_y, dz_reg  );
+        }
+      }
+      __syncthreads();
+    }
+  }
+
+}
+
+__global__ void eval_uvars_gga_rks_kernel( size_t ntasks, XCDeviceTask* tasks_device) {
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+  
+  const auto& task = tasks_device[ batch_idx ];
+  const auto npts  = task.npts;
+  
+  const auto*   dden_sx_eval_device = task.dden_sx;
+  const auto*   dden_sy_eval_device = task.dden_sy;
+  const auto*   dden_sz_eval_device = task.dden_sz;
+  auto*         gamma_eval_device   = task.gamma;
+
+  const int tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if( tid < npts ) {
+    const double dx = dden_sx_eval_device[ tid ];
+    const double dy = dden_sy_eval_device[ tid ];
+    const double dz = dden_sz_eval_device[ tid ];
+
+    gamma_eval_device[ tid ] = dx*dx + dy*dy + dz*dz;
+  }
+
+}
+
+__global__ void eval_tmat_gga_rks_kernel( size_t ntasks, XCDeviceTask* tasks_device) {
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+  
+  const auto& task = tasks_device[ batch_idx ];
+  const auto npts  = task.npts;
+  
+  const auto*   dden_sx_eval_device = task.dden_sx;
+  const auto*   dden_sy_eval_device = task.dden_sy;
+  const auto*   dden_sz_eval_device = task.dden_sz;
+  const auto*   tdden_sx_eval_device = task.tdden_sx;
+  const auto*   tdden_sy_eval_device = task.tdden_sy;
+  const auto*   tdden_sz_eval_device = task.tdden_sz;
+
+  const auto* weight_device  = task.weights;
+  const auto* vgamma_device  = task.vgamma;
+  const auto* v2rho2_device     = task.v2rho2;
+  const auto* v2rhogamma_device = task.v2rhogamma;
+  const auto* v2gamma2_device   = task.v2gamma2;
+  const auto* trho_device       = task.tden_s;
+
+  auto* FXC_A_device   = task.FXC_A_s;
+  auto* FXC_Bx_device   = task.FXC_Bx_s;
+  auto* FXC_By_device   = task.FXC_By_s;
+  auto* FXC_Bz_device   = task.FXC_Bz_s;
+
+  const int tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if( tid < npts ) {
+    const auto dx = dden_sx_eval_device[ tid ];
+    const auto dy = dden_sy_eval_device[ tid ];
+    const auto dz = dden_sz_eval_device[ tid ];
+    const auto tdx = tdden_sx_eval_device[ tid ];
+    const auto tdy = tdden_sy_eval_device[ tid ];
+    const auto tdz = tdden_sz_eval_device[ tid ];
+    const auto tgamma = tdx*dx + tdy*dy + tdz*dz;
+
+    const auto FXC_A = v2rho2_device[ tid ] * trho_device[ tid ] + 2.0 * v2rhogamma_device[tid] * tgamma;
+    const auto B_coef = v2rhogamma_device[tid] * trho_device[tid] + 2.0 * v2gamma2_device[tid] * tgamma;
+    FXC_A_device[ tid ]  = weight_device[ tid ] * FXC_A ;
+    FXC_Bx_device[ tid ] = 2.0 * weight_device[ tid ] * ( B_coef * dx + vgamma_device[ tid ] * tdx );
+    FXC_By_device[ tid ] = 2.0 * weight_device[ tid ] * ( B_coef * dy + vgamma_device[ tid ] * tdy );
+    FXC_Bz_device[ tid ] = 2.0 * weight_device[ tid ] * ( B_coef * dz + vgamma_device[ tid ] * tdz );
+  }
+
+}
+
+__global__ void eval_uvars_gga_uks_kernel( size_t ntasks, XCDeviceTask* tasks_device) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  const auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+
+  auto*           den_pos_eval_device   = task.den_s;
+  const auto*     den_pos_x_eval_device = task.dden_sx;
+  const auto*     den_pos_y_eval_device = task.dden_sy;
+  const auto*     den_pos_z_eval_device = task.dden_sz;
+
+  auto*           den_neg_eval_device   = task.den_z;
+  const auto*     den_neg_x_eval_device = task.dden_zx;
+  const auto*     den_neg_y_eval_device = task.dden_zy;
+  const auto*     den_neg_z_eval_device = task.dden_zz;
+
+  auto*     gamma_pp_eval_device  = task.gamma_pp;
+  auto*     gamma_pm_eval_device  = task.gamma_pm;
+  auto*     gamma_mm_eval_device  = task.gamma_mm;
+
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if( tid < npts ) {
+    const double ps     = den_pos_eval_device[ tid ];
+    const double pz     = den_neg_eval_device[ tid ];
+    const double dndx   = den_pos_x_eval_device[ tid ];
+    const double dndy   = den_pos_y_eval_device[ tid ];
+    const double dndz   = den_pos_z_eval_device[ tid ];
+    const double dMzdx  = den_neg_x_eval_device[ tid ];
+    const double dMzdy  = den_neg_y_eval_device[ tid ];
+    const double dMzdz  = den_neg_z_eval_device[ tid ];
+
+    // (del n).(del n)
+    const auto dn_sq  = dndx*dndx + dndy*dndy + dndz*dndz;
+    // (del Mz).(del Mz)
+    const auto dMz_sq = dMzdx*dMzdx + dMzdy*dMzdy + dMzdz*dMzdz;
+    // (del n).(del Mz)
+    const auto dn_dMz = dndx*dMzdx + dndy*dMzdy + dndz*dMzdz;
+
+    gamma_pp_eval_device[ tid ] = 0.25*(dn_sq + dMz_sq) + 0.5*dn_dMz;
+    gamma_pm_eval_device[ tid ] = 0.25*(dn_sq - dMz_sq);
+    gamma_mm_eval_device[ tid ] = 0.25*(dn_sq + dMz_sq) - 0.5*dn_dMz;
+
+    den_pos_eval_device[ tid ] = 0.5*(ps + pz);
+    den_neg_eval_device[ tid ] = 0.5*(ps - pz);
+  }
+
+}
+
+__global__ void eval_tmat_gga_uks_kernel( size_t ntasks, XCDeviceTask* tasks_device) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  const auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+
+  const auto* tden_s_device   = task.tden_s;
+  const auto* tden_z_device   = task.tden_z;
+  const auto* weight_device   = task.weights;
+
+  const auto*     tden_pos_x_eval_device = task.tdden_sx;
+  const auto*     tden_pos_y_eval_device = task.tdden_sy;
+  const auto*     tden_pos_z_eval_device = task.tdden_sz;
+  const auto*     den_pos_x_eval_device = task.dden_sx;
+  const auto*     den_pos_y_eval_device = task.dden_sy;
+  const auto*     den_pos_z_eval_device = task.dden_sz;
+
+  const auto*     tden_neg_x_eval_device = task.tdden_zx;
+  const auto*     tden_neg_y_eval_device = task.tdden_zy;
+  const auto*     tden_neg_z_eval_device = task.tdden_zz;
+  const auto*     den_neg_x_eval_device = task.dden_zx;
+  const auto*     den_neg_y_eval_device = task.dden_zy;
+  const auto*     den_neg_z_eval_device = task.dden_zz;
+
+  const auto* vgamma_aa_device   = task.vgamma_pp;
+  const auto* vgamma_ab_device   = task.vgamma_pm;
+  const auto* vgamma_bb_device   = task.vgamma_mm;
+  const auto* v2rho2_a_a_device    = task.v2rho2_a_a;
+  const auto* v2rho2_a_b_device    = task.v2rho2_a_b;
+  const auto* v2rho2_b_b_device    = task.v2rho2_b_b;
+  const auto* v2rhogamma_a_aa_device = task.v2rhogamma_a_aa;
+  const auto* v2rhogamma_a_ab_device = task.v2rhogamma_a_ab;
+  const auto* v2rhogamma_a_bb_device = task.v2rhogamma_a_bb;
+  const auto* v2rhogamma_b_aa_device = task.v2rhogamma_b_aa;
+  const auto* v2rhogamma_b_ab_device = task.v2rhogamma_b_ab;
+  const auto* v2rhogamma_b_bb_device = task.v2rhogamma_b_bb;
+  const auto* v2gamma2_aa_aa_device = task.v2gamma2_aa_aa;
+  const auto* v2gamma2_aa_ab_device = task.v2gamma2_aa_ab;
+  const auto* v2gamma2_aa_bb_device = task.v2gamma2_aa_bb;
+  const auto* v2gamma2_ab_ab_device = task.v2gamma2_ab_ab;
+  const auto* v2gamma2_ab_bb_device = task.v2gamma2_ab_bb;
+  const auto* v2gamma2_bb_bb_device = task.v2gamma2_bb_bb;
+
+  auto* FXC_A_s_device        = task.FXC_A_s;
+  auto* FXC_A_z_device        = task.FXC_A_z;
+  auto* FXC_Bx_s_device       = task.FXC_Bx_s;
+  auto* FXC_Bx_z_device       = task.FXC_Bx_z;
+  auto* FXC_By_s_device       = task.FXC_By_s;
+  auto* FXC_By_z_device       = task.FXC_By_z;
+  auto* FXC_Bz_s_device       = task.FXC_Bz_s;
+  auto* FXC_Bz_z_device       = task.FXC_Bz_z;
+
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if( tid < npts ) {
+    const auto ps = tden_s_device[ tid ];
+    const auto pz = tden_z_device[ tid ];
+    const auto trho_a_device = 0.5*(ps + pz);
+    const auto trho_b_device = 0.5*(ps - pz);
+
+    const auto tdndx   = tden_pos_x_eval_device[ tid ];
+    const auto tdndy   = tden_pos_y_eval_device[ tid ];
+    const auto tdndz   = tden_pos_z_eval_device[ tid ];
+    const auto tdMzdx  = tden_neg_x_eval_device[ tid ];
+    const auto tdMzdy  = tden_neg_y_eval_device[ tid ];
+    const auto tdMzdz  = tden_neg_z_eval_device[ tid ];
+    const auto tdden_a_x = 0.5*(tdndx + tdMzdx);
+    const auto tdden_a_y = 0.5*(tdndy + tdMzdy);
+    const auto tdden_a_z = 0.5*(tdndz + tdMzdz);
+    const auto tdden_b_x = 0.5*(tdndx - tdMzdx);
+    const auto tdden_b_y = 0.5*(tdndy - tdMzdy);
+    const auto tdden_b_z = 0.5*(tdndz - tdMzdz);
+
+    const auto dndx   = den_pos_x_eval_device[ tid ];
+    const auto dndy   = den_pos_y_eval_device[ tid ];
+    const auto dndz   = den_pos_z_eval_device[ tid ];
+    const auto dMzdx  = den_neg_x_eval_device[ tid ];
+    const auto dMzdy  = den_neg_y_eval_device[ tid ];
+    const auto dMzdz  = den_neg_z_eval_device[ tid ];
+    const auto dden_a_x = 0.5*(dndx + dMzdx);
+    const auto dden_a_y = 0.5*(dndy + dMzdy);
+    const auto dden_a_z = 0.5*(dndz + dMzdz);
+    const auto dden_b_x = 0.5*(dndx - dMzdx);
+    const auto dden_b_y = 0.5*(dndy - dMzdy);
+    const auto dden_b_z = 0.5*(dndz - dMzdz);
+
+    const auto tgamma_pp = tdden_a_x * dden_a_x + tdden_a_y * dden_a_y + tdden_a_z * dden_a_z;
+    const auto tgamma_pm = tdden_a_x * dden_b_x + tdden_a_y * dden_b_y + tdden_a_z * dden_b_z
+                                 + tdden_b_x * dden_a_x + tdden_b_y * dden_a_y + tdden_b_z * dden_a_z;
+    const auto tgamma_mm = tdden_b_x * dden_b_x + tdden_b_y * dden_b_y + tdden_b_z * dden_b_z;
+
+    
+    const auto A_a = v2rho2_a_a_device[tid] * trho_a_device + 2.0 * v2rhogamma_a_aa_device[tid] * tgamma_pp + 
+          v2rhogamma_a_ab_device[tid] * tgamma_pm + 2.0 * v2rhogamma_a_bb_device[tid] * tgamma_mm + 
+          v2rho2_a_b_device[tid] * trho_b_device;
+    const auto A_b = v2rho2_b_b_device[tid] * trho_b_device + 2.0 * v2rhogamma_b_bb_device[tid] * tgamma_mm + 
+          v2rhogamma_b_ab_device[tid] * tgamma_pm + 2.0 * v2rhogamma_b_aa_device[tid] * tgamma_pp + 
+          v2rho2_a_b_device[tid] * trho_a_device;
+    FXC_A_s_device[ tid ] = 0.5 * weight_device[ tid ] * (A_a + A_b);
+    FXC_A_z_device[ tid ] = 0.5 * weight_device[ tid ] * (A_a - A_b);
+    // Calculate B coefficients for alpha spin
+    const double B_coef1_a = v2rhogamma_a_aa_device[tid] * trho_a_device   + 2.0 * v2gamma2_aa_aa_device[tid] * tgamma_pp + 
+                 v2gamma2_aa_ab_device[tid] * tgamma_pm + 2.0 * v2gamma2_aa_bb_device[tid] * tgamma_mm + 
+                 v2rhogamma_b_aa_device[tid] * trho_b_device;
+
+    const double B_coef2_a = v2rhogamma_a_ab_device[tid] * trho_a_device + 2.0 * v2gamma2_aa_ab_device[tid] * tgamma_pp + 
+          v2gamma2_ab_ab_device[tid] * tgamma_pm + 2.0 * v2gamma2_ab_bb_device[tid] * tgamma_mm +
+          v2rhogamma_b_ab_device[tid] * trho_b_device;
+
+    // Calculate gradient components for alpha spin
+    const double Bx_a = 2.0 * B_coef1_a * dden_a_x + B_coef2_a * dden_b_x + 
+           2.0 * vgamma_aa_device[tid] * tdden_a_x + vgamma_ab_device[tid] * tdden_b_x;
+
+    const double By_a = 2.0 * B_coef1_a * dden_a_y + B_coef2_a * dden_b_y + 
+           2.0 * vgamma_aa_device[tid] * tdden_a_y + vgamma_ab_device[tid] * tdden_b_y;
+
+    const double Bz_a = 2.0 * B_coef1_a * dden_a_z + B_coef2_a * dden_b_z + 
+           2.0 * vgamma_aa_device[tid] * tdden_a_z + vgamma_ab_device[tid] * tdden_b_z;
+
+    // Calculate B coefficients for beta spin
+    const double B_coef1_b = v2rhogamma_b_bb_device[tid] * trho_b_device + 2.0 * v2gamma2_bb_bb_device[tid] * tgamma_mm + 
+          v2gamma2_ab_bb_device[tid] * tgamma_pm + 2.0 * v2gamma2_aa_bb_device[tid] * tgamma_pp + 
+          v2rhogamma_a_bb_device[tid] * trho_a_device;
+
+    const double B_coef2_b = v2rhogamma_b_ab_device[tid] * trho_b_device + 2.0 * v2gamma2_ab_bb_device[tid] * tgamma_mm + 
+          v2gamma2_ab_ab_device[tid] * tgamma_pm + 2.0 * v2gamma2_aa_ab_device[tid] * tgamma_pp + 
+          v2rhogamma_a_ab_device[tid] * trho_a_device;
+
+    const double Bx_b = 2.0 * B_coef1_b * dden_b_x + B_coef2_b * dden_a_x + 
+           2.0 * vgamma_bb_device[tid] * tdden_b_x + vgamma_ab_device[tid] * tdden_a_x;
+
+    const double By_b = 2.0 * B_coef1_b * dden_b_y + B_coef2_b * dden_a_y + 
+           2.0 * vgamma_bb_device[tid] * tdden_b_y + vgamma_ab_device[tid] * tdden_a_y;
+
+    const double Bz_b = 2.0 * B_coef1_b * dden_b_z + B_coef2_b * dden_a_z + 
+           2.0 * vgamma_bb_device[tid] * tdden_b_z + vgamma_ab_device[tid] * tdden_a_z;
+
+    FXC_Bx_s_device[tid] = 0.5 * weight_device[tid] * (Bx_a + Bx_b);
+    FXC_By_s_device[tid] = 0.5 * weight_device[tid] * (By_a + By_b);
+    FXC_Bz_s_device[tid] = 0.5 * weight_device[tid] * (Bz_a + Bz_b);
+    FXC_Bx_z_device[tid] = 0.5 * weight_device[tid] * (Bx_a - Bx_b);
+    FXC_By_z_device[tid] = 0.5 * weight_device[tid] * (By_a - By_b);
+    FXC_Bz_z_device[tid] = 0.5 * weight_device[tid] * (Bz_a - Bz_b);
+
+
+  }
+
+}
+
+__global__ void eval_uvars_gga_gks_kernel( size_t ntasks, XCDeviceTask* tasks_device) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  const auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+
+        auto*     den_s_eval_device   = task.den_s;
+  const auto*     dden_sx_eval_device = task.dden_sx;
+  const auto*     dden_sy_eval_device = task.dden_sy;
+  const auto*     dden_sz_eval_device = task.dden_sz;
+
+        auto*     den_z_eval_device   = task.den_z;
+  const auto*     dden_zx_eval_device = task.dden_zx;
+  const auto*     dden_zy_eval_device = task.dden_zy;
+  const auto*     dden_zz_eval_device = task.dden_zz;
+
+  const auto*     den_y_eval_device   = task.den_y;
+  const auto*     dden_yx_eval_device = task.dden_yx;
+  const auto*     dden_yy_eval_device = task.dden_yy;
+  const auto*     dden_yz_eval_device = task.dden_yz;
+
+  const auto*     den_x_eval_device   = task.den_x;
+  const auto*     dden_xx_eval_device = task.dden_xx;
+  const auto*     dden_xy_eval_device = task.dden_xy;
+  const auto*     dden_xz_eval_device = task.dden_xz;
+
+  auto*     gamma_pp_eval_device  = task.gamma_pp;
+  auto*     gamma_pm_eval_device  = task.gamma_pm;
+  auto*     gamma_mm_eval_device  = task.gamma_mm;
+
+  auto*     H_z_eval_device = task.H_z;
+  auto*     H_y_eval_device = task.H_y;
+  auto*     H_x_eval_device = task.H_x;
+  auto*     K_z_eval_device = task.K_z;
+  auto*     K_y_eval_device = task.K_y;
+  auto*     K_x_eval_device = task.K_x;
+
+  const double dtolsq = 1e-24;  // TODO: make variable
+
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if( tid < npts ) {
+    const double dndz = dden_sz_eval_device[ tid ];
+    const double dndy = dden_sy_eval_device[ tid ];
+    const double dndx = dden_sx_eval_device[ tid ];
+
+    const double dMzdz = dden_zz_eval_device[ tid ];
+    const double dMzdy = dden_zy_eval_device[ tid ];
+    const double dMzdx = dden_zx_eval_device[ tid ];
+
+    const double dMydz = dden_yz_eval_device[ tid ];
+    const double dMydy = dden_yy_eval_device[ tid ];
+    const double dMydx = dden_yx_eval_device[ tid ];
+
+    const double dMxdz = dden_xz_eval_device[ tid ];
+    const double dMxdy = dden_xy_eval_device[ tid ];
+    const double dMxdx = dden_xx_eval_device[ tid ];
+
+    const auto ps = den_s_eval_device[ tid ];
+    const auto pz = den_z_eval_device[ tid ];
+    const auto py = den_y_eval_device[ tid ];
+    const auto px = den_x_eval_device[ tid ];
+
+    const auto mtemp = pz*pz + px*px + py*py;
+    double mnorm = 0.;
+
+    const auto dels_dot_dels = dndx * dndx + dndy * dndy + dndz * dndz;
+    const auto delz_dot_delz = dMzdx * dMzdx + dMzdy * dMzdy + dMzdz * dMzdz;
+    const auto delx_dot_delx = dMxdx * dMxdx + dMxdy * dMxdy + dMxdz * dMxdz;
+    const auto dely_dot_dely = dMydx * dMydx + dMydy * dMydy + dMydz * dMydz;
+
+    const auto dels_dot_delz = dndx * dMzdx + dndy * dMzdy + dndz * dMzdz;
+    const auto dels_dot_delx = dndx * dMxdx + dndy * dMxdy + dndz * dMxdz;
+    const auto dels_dot_dely = dndx * dMydx + dndy * dMydy + dndz * dMydz;
+
+    const auto sum = delz_dot_delz + delx_dot_delx + dely_dot_dely;
+    const auto s_sum =
+               dels_dot_delz * pz + dels_dot_delx * px + dels_dot_dely * py;
+
+    const auto inv_sqsum2 =
+        rsqrt(dels_dot_delz * dels_dot_delz + dels_dot_delx * dels_dot_delx +
+             dels_dot_dely * dels_dot_dely);
+    const auto sqsum2 = 1./inv_sqsum2;
+
+    double sign = 1.;
+    if( signbit(s_sum)) 
+      sign = -1.;
+
+
+    if (mtemp > dtolsq) {
+      const double inv_mnorm = rsqrt(mtemp);
+      mnorm = 1./inv_mnorm;
+      K_z_eval_device[ tid ] = pz * inv_mnorm;
+      K_y_eval_device[ tid ] = py * inv_mnorm;
+      K_x_eval_device[ tid ] = px * inv_mnorm;
+      H_z_eval_device[ tid ] = sign * dels_dot_delz * inv_sqsum2;
+      H_y_eval_device[ tid ] = sign * dels_dot_dely * inv_sqsum2;
+      H_x_eval_device[ tid ] = sign * dels_dot_delx * inv_sqsum2;
+    }
+    else {
+      mnorm = (1. / 3.) * (px + py + pz);
+      K_z_eval_device[ tid ] = 1. / 3.;
+      K_y_eval_device[ tid ] = 1. / 3.;
+      K_x_eval_device[ tid ] = 1. / 3.;
+
+      H_z_eval_device[ tid ] = sign / 3.;
+      H_y_eval_device[ tid ] = sign / 3.;
+      H_x_eval_device[ tid ] = sign / 3.;
+    }
+
+    gamma_pp_eval_device[ tid ] = 0.25*(dels_dot_dels + sum) + 0.5*sign*sqsum2;
+    gamma_pm_eval_device[ tid ] = 0.25*(dels_dot_dels - sum);
+    gamma_mm_eval_device[ tid ] = 0.25*(dels_dot_dels + sum) - 0.5*sign*sqsum2;
+
+    den_s_eval_device[ tid ] = 0.5*(ps + mnorm);
+    den_z_eval_device[ tid ] = 0.5*(ps - mnorm);
+
+  }
+
+}
+
+} // namespace GauXC

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/uvvars_lda.hpp
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/uvvars_lda.hpp
@@ -1,0 +1,209 @@
+/**
+ * GauXC Copyright (c) 2020-2024, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of
+ * any required approvals from the U.S. Dept. of Energy).
+ *
+ * (c) 2024-2025, Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * See LICENSE.txt for details
+ */
+#pragma once
+#include "hip/hip_runtime.h"
+#include "device_specific/hip_device_constants.hpp"
+#include "device_specific/hip_util.hpp"
+#include "device/xc_device_data.hpp"
+
+namespace GauXC {
+
+template <bool trial, density_id den_select>
+__global__ void eval_vvar_lda_kern( size_t        ntasks,
+                                    XCDeviceTask* tasks_device) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+
+  double* den_eval_device   = nullptr;
+  // use the "U" variable (+/- for UKS) even though at this point the density (S/Z) is stored
+  if constexpr (trial){
+    if constexpr (den_select == DEN_S) den_eval_device = task.tden_s;
+    if constexpr (den_select == DEN_Z) den_eval_device = task.tden_z;
+    if constexpr (den_select == DEN_Y) den_eval_device = task.tden_y;
+    if constexpr (den_select == DEN_X) den_eval_device = task.tden_x;
+  }else{
+      if constexpr (den_select == DEN_S) den_eval_device = task.den_s;
+      if constexpr (den_select == DEN_Z) den_eval_device = task.den_z;
+      if constexpr (den_select == DEN_Y) den_eval_device = task.den_y;
+      if constexpr (den_select == DEN_X) den_eval_device = task.den_x;
+  }
+
+  const auto* basis_eval_device = task.bf;
+
+  const auto* den_basis_prod_device = task.zmat;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  register double den_reg = 0.;
+
+  if( tid_x < nbf and tid_y < npts ) {
+
+    const double* bf_col   = basis_eval_device     + tid_x*npts;
+    const double* db_col   = den_basis_prod_device + tid_x*npts;
+
+    den_reg = bf_col[ tid_y ]   * db_col[ tid_y ];
+
+  }
+
+  // Warp blocks are stored col major
+  constexpr auto warp_size = hip::warp_size;
+  //constexpr auto max_warps_per_thread_block = hip::max_warps_per_thread_block;
+  den_reg = hip::warp_reduce_sum<warp_size>( den_reg );
+
+
+  if( threadIdx.x == 0 and tid_y < npts ) {
+    atomicAdd( den_eval_device   + tid_y, den_reg );
+  }
+  
+}
+
+__global__ void eval_uvars_lda_rks_kernel( size_t ntasks, XCDeviceTask* tasks_device) {
+  // eval_vvars populated uvar storage already in the case of LDA+RKS
+  return;
+}
+__global__ void eval_tmat_lda_rks_kernel( size_t ntasks, XCDeviceTask* tasks_device) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  const auto& task = tasks_device[ batch_idx ];
+  const auto npts  = task.npts;
+
+  const auto* v2rho2_device  = task.v2rho2;
+  const auto* weight_device  = task.weights;
+  auto* tden_s_eval_device   = task.tden_s;
+  auto* FXC_A_device   = task.FXC_A_s;
+
+  const int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if( tid < npts ) {
+    FXC_A_device[ tid ] = v2rho2_device[ tid ] * tden_s_eval_device[ tid ] * weight_device[ tid ];
+  }
+
+  return;
+}
+
+
+__global__ void eval_uvars_lda_uks_kernel( size_t        ntasks,
+  XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+
+  const auto npts            = task.npts;
+
+  auto* den_pos_eval_device   = task.den_s;
+  auto* den_neg_eval_device   = task.den_z;
+
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if( tid < npts ) {
+    const auto ps = den_pos_eval_device[ tid ];
+    const auto pz = den_neg_eval_device[ tid ];
+    den_pos_eval_device[ tid ] = 0.5*(ps + pz);
+    den_neg_eval_device[ tid ] = 0.5*(ps - pz);
+  }
+}
+
+__global__ void eval_tmat_lda_uks_kernel( size_t        ntasks,
+  XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+
+  const auto npts            = task.npts;
+
+  auto* tden_s_device   = task.tden_s;
+  auto* tden_z_device   = task.tden_z;
+  auto* FXC_A_s_device        = task.FXC_A_s;
+  auto* FXC_A_z_device        = task.FXC_A_z;
+  const auto* weight_device   = task.weights;
+
+  const auto* v2rho2_a_a_device    = task.v2rho2_a_a;
+  const auto* v2rho2_a_b_device    = task.v2rho2_a_b;
+  const auto* v2rho2_b_b_device    = task.v2rho2_b_b;
+
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if( tid < npts ) {
+    const auto ps = tden_s_device[ tid ];
+    const auto pz = tden_z_device[ tid ];
+    const auto trho_a_device = 0.5*(ps + pz);
+    const auto trho_b_device = 0.5*(ps - pz);
+    const auto A_a = v2rho2_a_a_device[tid] * trho_a_device + v2rho2_a_b_device[tid] * trho_b_device;
+    const auto A_b = v2rho2_b_b_device[tid] * trho_b_device + v2rho2_a_b_device[tid] * trho_a_device;
+    FXC_A_s_device[ tid ] = 0.5 * weight_device[ tid ] * (A_a + A_b);
+    FXC_A_z_device[ tid ] = 0.5 * weight_device[ tid ] * (A_a - A_b);
+  }
+}
+
+__global__ void eval_uvars_lda_gks_kernel( size_t        ntasks,
+                                           XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+
+  const auto npts            = task.npts;
+
+  auto* den_z_eval_device   = task.den_s;
+  auto* den_s_eval_device   = task.den_z;
+  auto* den_y_eval_device   = task.den_y;
+  auto* den_x_eval_device   = task.den_x;
+  auto* K_z_eval_device     = task.K_z;
+  auto* K_y_eval_device     = task.K_y;
+  auto* K_x_eval_device     = task.K_x;
+  const double dtolsq = 1e-24;  // TODO: make variable
+
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+
+  if( tid < npts ) {
+    const auto ps = den_s_eval_device[ tid ];
+    const auto pz = den_z_eval_device[ tid ];
+    const auto py = den_y_eval_device[ tid ];
+    const auto px = den_x_eval_device[ tid ];
+    const auto mtemp = pz*pz + px*px + py*py;
+    double mnorm = 0.;
+  
+    if (mtemp > dtolsq) {
+      const double inv_mnorm = rsqrt(mtemp);
+      mnorm = 1./inv_mnorm;
+      K_z_eval_device[ tid ] = pz * inv_mnorm;
+      K_y_eval_device[ tid ] = py * inv_mnorm;
+      K_x_eval_device[ tid ] = px * inv_mnorm;
+    }
+    else {
+      mnorm = (1. / 3.) * (px + py + pz);
+      K_z_eval_device[ tid ] = 1. / 3.;
+      K_y_eval_device[ tid ] = 1. / 3.;
+      K_x_eval_device[ tid ] = 1. / 3.;
+    }
+
+    den_s_eval_device[ tid ] = 0.5*(ps + mnorm);
+    den_z_eval_device[ tid ] = 0.5*(ps - mnorm);
+
+  }
+}
+
+}

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/uvvars_mgga.hpp
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/uvvars_mgga.hpp
@@ -1,0 +1,456 @@
+/**
+ * GauXC Copyright (c) 2020-2024, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of
+ * any required approvals from the U.S. Dept. of Energy).
+ *
+ * (c) 2024-2025, Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * See LICENSE.txt for details
+ */
+#pragma once
+#include "hip/hip_runtime.h"
+#include "device_specific/hip_device_constants.hpp"
+#include "device_specific/hip_util.hpp"
+#include "device/xc_device_data.hpp"
+
+#define MGGA_KERNEL_SM_BLOCK 32
+
+namespace GauXC {
+
+
+
+template <bool trial, density_id den_select, bool need_lapl>
+__global__ void eval_vvar_mgga_kern( size_t           ntasks,
+                                     XCDeviceTask* tasks_device) {
+
+  constexpr auto warp_size = hip::warp_size;
+  //constexpr auto max_warps_per_thread_block = hip::max_warps_per_thread_block;
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+  double* tau_eval_device  = nullptr;
+  double* lapl_eval_device = nullptr;
+
+  if constexpr (trial){
+    if constexpr (den_select == DEN_S) {
+      tau_eval_device = task.ttau_s;
+      if constexpr (need_lapl) {
+        lapl_eval_device = task.tlapl_s;
+      }
+    }
+    if constexpr (den_select == DEN_Z) {
+      tau_eval_device = task.ttau_z;
+      if constexpr (need_lapl) {
+        lapl_eval_device = task.tlapl_z;
+      }
+    }
+  } else{
+    if constexpr (den_select == DEN_S) {
+      tau_eval_device = task.tau_s;
+      if constexpr (need_lapl) {
+        lapl_eval_device = task.lapl_s;
+      }
+    }
+    if constexpr (den_select == DEN_Z) {
+      tau_eval_device = task.tau_z;
+      if constexpr (need_lapl) {
+        lapl_eval_device = task.lapl_z;
+      }
+    }
+  }
+
+  //const auto* basis_eval_device = task.bf;
+  const auto* dbasis_x_eval_device = task.dbfx;
+  const auto* dbasis_y_eval_device = task.dbfy;
+  const auto* dbasis_z_eval_device = task.dbfz;
+  decltype(dbasis_x_eval_device) basis_lapl_eval_device = nullptr;
+  if constexpr (need_lapl) {
+    basis_lapl_eval_device = task.d2bflapl;
+  }
+
+  //const auto* den_basis_prod_device    = task.zmat;
+  const auto* den_basis_dx_prod_device = task.xmat_x;
+  const auto* den_basis_dy_prod_device = task.xmat_y;
+  const auto* den_basis_dz_prod_device = task.xmat_z;
+  decltype(den_basis_dx_prod_device) den_basis_prod_device = nullptr;
+  if constexpr (need_lapl) {
+    den_basis_prod_device = task.zmat;
+  }
+
+  __shared__ double den_shared[3+!!need_lapl][warp_size][MGGA_KERNEL_SM_BLOCK+1];
+
+  for ( int bid_x = blockIdx.x * blockDim.x; 
+        bid_x < nbf;
+        bid_x += blockDim.x * gridDim.x ) {
+    
+    for ( int bid_y = blockIdx.y * MGGA_KERNEL_SM_BLOCK; 
+          bid_y < npts;
+          bid_y += MGGA_KERNEL_SM_BLOCK * gridDim.y ) {
+        
+      for (int sm_y = threadIdx.y; sm_y < MGGA_KERNEL_SM_BLOCK; sm_y += blockDim.y) {
+        den_shared[0][threadIdx.x][sm_y] = 0.;
+        den_shared[1][threadIdx.x][sm_y] = 0.;
+        den_shared[2][threadIdx.x][sm_y] = 0.;
+        if constexpr (need_lapl)
+          den_shared[3][threadIdx.x][sm_y] = 0.;
+
+        if (bid_y + threadIdx.x < npts and bid_x + sm_y < nbf) { 
+          const double* db_x_col = den_basis_dx_prod_device + (bid_x + sm_y)*npts;
+          const double* db_y_col = den_basis_dy_prod_device + (bid_x + sm_y)*npts;
+          const double* db_z_col = den_basis_dz_prod_device + (bid_x + sm_y)*npts;
+
+          const double* bf_x_col = dbasis_x_eval_device  + (bid_x + sm_y)*npts;
+          const double* bf_y_col = dbasis_y_eval_device  + (bid_x + sm_y)*npts;
+          const double* bf_z_col = dbasis_z_eval_device  + (bid_x + sm_y)*npts;
+
+
+          den_shared[0][threadIdx.x][sm_y] = bf_x_col[ bid_y + threadIdx.x ] * db_x_col[ bid_y + threadIdx.x ];
+          den_shared[1][threadIdx.x][sm_y] = bf_y_col[ bid_y + threadIdx.x ] * db_y_col[ bid_y + threadIdx.x ];
+          den_shared[2][threadIdx.x][sm_y] = bf_z_col[ bid_y + threadIdx.x ] * db_z_col[ bid_y + threadIdx.x ];
+
+
+          if constexpr (need_lapl) {
+            const double* db_col   = den_basis_prod_device  + (bid_x + sm_y)*npts;
+            const double* bf_l_col = basis_lapl_eval_device + (bid_x + sm_y)*npts;
+            den_shared[3][threadIdx.x][sm_y] = bf_l_col[ bid_y + threadIdx.x ] * db_col[ bid_y + threadIdx.x ];
+          }
+        }
+      }
+      __syncthreads();
+
+
+      for (int sm_y = threadIdx.y; sm_y < MGGA_KERNEL_SM_BLOCK; sm_y += blockDim.y) {
+        const int tid_y = bid_y + sm_y;
+
+        register double tx_reg  = den_shared[0][sm_y][threadIdx.x];
+        register double ty_reg  = den_shared[1][sm_y][threadIdx.x];
+        register double tz_reg  = den_shared[2][sm_y][threadIdx.x];
+        // Warp blocks are stored col major
+        register double tau_reg = 0.0;
+        tau_reg  = 0.5 * hip::warp_reduce_sum<warp_size>( tx_reg );
+        tau_reg += 0.5 * hip::warp_reduce_sum<warp_size>( ty_reg );
+        tau_reg += 0.5 * hip::warp_reduce_sum<warp_size>( tz_reg );
+
+        register double lapl_reg = 0.0;
+        if constexpr (need_lapl) {
+          lapl_reg = den_shared[3][sm_y][threadIdx.x];
+          lapl_reg = hip::warp_reduce_sum<warp_size>(lapl_reg);
+          lapl_reg = 2. * lapl_reg + 4. * tau_reg;
+        }
+
+        if( threadIdx.x == 0 and tid_y < npts ) {
+          atomicAdd( tau_eval_device   + tid_y, tau_reg );
+          if constexpr (need_lapl) {
+            atomicAdd( lapl_eval_device   + tid_y, lapl_reg );
+          }
+        }
+      }
+      __syncthreads();
+    }
+  }
+}
+
+
+
+
+template <bool need_lapl>
+__global__ void eval_uvars_mgga_uks_kernel( size_t ntasks, XCDeviceTask* tasks_device) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  const auto& task = tasks_device[ batch_idx ];
+  const auto npts  = task.npts;
+
+  auto* tau_pos_eval_device = task.tau_s;
+  auto* tau_neg_eval_device = task.tau_z;
+
+  double* lapl_pos_eval_device = nullptr;
+  double* lapl_neg_eval_device = nullptr;
+  if constexpr (need_lapl) {
+    lapl_pos_eval_device = task.lapl_s;
+    lapl_neg_eval_device = task.lapl_z;
+  }
+
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if( tid < npts ) {
+    const double ts = tau_pos_eval_device[ tid ];
+    const double tz = tau_neg_eval_device[ tid ];
+    tau_pos_eval_device[ tid ] = 0.5*(ts + tz);
+    tau_neg_eval_device[ tid ] = 0.5*(ts - tz);
+
+    if constexpr (need_lapl) {
+      const double ls = lapl_pos_eval_device[ tid ];
+      const double lz = lapl_neg_eval_device[ tid ];
+      lapl_pos_eval_device[ tid ] = 0.5*(ls + lz);
+      lapl_neg_eval_device[ tid ] = 0.5*(ls - lz);
+    }
+  }
+
+}
+
+
+__global__ void eval_tmat_mgga_rks_kernel( size_t ntasks, XCDeviceTask* tasks_device) {
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+  
+  const auto& task = tasks_device[ batch_idx ];
+  const auto npts  = task.npts;
+  
+  const auto*   dden_sx_eval_device = task.dden_sx;
+  const auto*   dden_sy_eval_device = task.dden_sy;
+  const auto*   dden_sz_eval_device = task.dden_sz;
+  const auto*   tdden_sx_eval_device = task.tdden_sx;
+  const auto*   tdden_sy_eval_device = task.tdden_sy;
+  const auto*   tdden_sz_eval_device = task.tdden_sz;
+
+  const auto* weight_device  = task.weights;
+  const auto* vgamma_device  = task.vgamma;
+  const auto* v2rho2_device     = task.v2rho2;
+  const auto* v2rhogamma_device = task.v2rhogamma;
+  const auto* v2gamma2_device   = task.v2gamma2;
+  const auto* v2rhotau_device  = task.v2rhotau;
+  const auto* v2tau2_device   = task.v2tau2;
+  const auto* v2gammatau_device = task.v2gammatau;
+  const auto* trho_device       = task.tden_s;
+  const auto* ttau_device       = task.ttau_s;
+
+  auto* FXC_A_device   = task.FXC_A_s;
+  auto* FXC_Bx_device   = task.FXC_Bx_s;
+  auto* FXC_By_device   = task.FXC_By_s;
+  auto* FXC_Bz_device   = task.FXC_Bz_s;
+  auto* FXC_C_device   = task.FXC_C_s;
+
+  const int tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if( tid < npts ) {
+    const auto dx = dden_sx_eval_device[ tid ];
+    const auto dy = dden_sy_eval_device[ tid ];
+    const auto dz = dden_sz_eval_device[ tid ];
+    const auto tdx = tdden_sx_eval_device[ tid ];
+    const auto tdy = tdden_sy_eval_device[ tid ];
+    const auto tdz = tdden_sz_eval_device[ tid ];
+    const auto tgamma = tdx*dx + tdy*dy + tdz*dz;
+
+    const auto FXC_A = v2rho2_device[ tid ] * trho_device[ tid ] + 2.0 * v2rhogamma_device[tid] * tgamma + 
+        v2rhotau_device[ tid ] * ttau_device[ tid ];
+    FXC_A_device[ tid ]  = weight_device[ tid ] * FXC_A;
+
+    const auto FXC_C = v2rhotau_device[ tid ] * trho_device[ tid ] + 2.0 * v2gammatau_device[ tid ] * tgamma +
+        v2tau2_device[ tid ] * ttau_device[ tid ];
+    FXC_C_device[ tid ]  = weight_device[ tid ] * FXC_C;
+
+    const auto B_coef = v2rhogamma_device[tid] * trho_device[tid] + 2.0 * v2gamma2_device[tid] * tgamma +
+        v2gammatau_device[ tid ] * ttau_device[ tid ];
+    FXC_Bx_device[ tid ] = 2.0 * weight_device[ tid ] * ( B_coef * dx + vgamma_device[ tid ] * tdx );
+    FXC_By_device[ tid ] = 2.0 * weight_device[ tid ] * ( B_coef * dy + vgamma_device[ tid ] * tdy );
+    FXC_Bz_device[ tid ] = 2.0 * weight_device[ tid ] * ( B_coef * dz + vgamma_device[ tid ] * tdz );
+  }
+
+}
+
+
+
+__global__ void eval_tmat_mgga_uks_kernel( size_t ntasks, XCDeviceTask* tasks_device) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  const auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+
+  const auto* tden_s_device   = task.tden_s;
+  const auto* tden_z_device   = task.tden_z;
+  const auto* ttau_s_device   = task.ttau_s;
+  const auto* ttau_z_device   = task.ttau_z;
+  const auto* weight_device   = task.weights;
+
+  const auto*     tden_pos_x_eval_device = task.tdden_sx;
+  const auto*     tden_pos_y_eval_device = task.tdden_sy;
+  const auto*     tden_pos_z_eval_device = task.tdden_sz;
+  const auto*     den_pos_x_eval_device = task.dden_sx;
+  const auto*     den_pos_y_eval_device = task.dden_sy;
+  const auto*     den_pos_z_eval_device = task.dden_sz;
+
+  const auto*     tden_neg_x_eval_device = task.tdden_zx;
+  const auto*     tden_neg_y_eval_device = task.tdden_zy;
+  const auto*     tden_neg_z_eval_device = task.tdden_zz;
+  const auto*     den_neg_x_eval_device = task.dden_zx;
+  const auto*     den_neg_y_eval_device = task.dden_zy;
+  const auto*     den_neg_z_eval_device = task.dden_zz;
+
+  const double* vgamma_aa_device   = task.vgamma_pp;
+  const double* vgamma_ab_device   = task.vgamma_pm;
+  const double* vgamma_bb_device   = task.vgamma_mm;
+  const double* v2rho2_a_a_device    = task.v2rho2_a_a;
+  const double* v2rho2_a_b_device    = task.v2rho2_a_b;
+  const double* v2rho2_b_b_device    = task.v2rho2_b_b;
+  const double* v2rhogamma_a_aa_device = task.v2rhogamma_a_aa;
+  const double* v2rhogamma_a_ab_device = task.v2rhogamma_a_ab;
+  const double* v2rhogamma_a_bb_device = task.v2rhogamma_a_bb;
+  const double* v2rhogamma_b_aa_device = task.v2rhogamma_b_aa;
+  const double* v2rhogamma_b_ab_device = task.v2rhogamma_b_ab;
+  const double* v2rhogamma_b_bb_device = task.v2rhogamma_b_bb;
+  const double* v2gamma2_aa_aa_device = task.v2gamma2_aa_aa;
+  const double* v2gamma2_aa_ab_device = task.v2gamma2_aa_ab;
+  const double* v2gamma2_aa_bb_device = task.v2gamma2_aa_bb;
+  const double* v2gamma2_ab_ab_device = task.v2gamma2_ab_ab;
+  const double* v2gamma2_ab_bb_device = task.v2gamma2_ab_bb;
+  const double* v2gamma2_bb_bb_device = task.v2gamma2_bb_bb;
+  const double* v2rhotau_a_a_device   = task.v2rhotau_a_a;
+  const double* v2rhotau_a_b_device   = task.v2rhotau_a_b;
+  const double* v2rhotau_b_a_device   = task.v2rhotau_b_a;
+  const double* v2rhotau_b_b_device   = task.v2rhotau_b_b;
+  const double* v2gammatau_aa_a_device= task.v2gammatau_aa_a;
+  const double* v2gammatau_aa_b_device= task.v2gammatau_aa_b;
+  const double* v2gammatau_ab_a_device= task.v2gammatau_ab_a;
+  const double* v2gammatau_ab_b_device= task.v2gammatau_ab_b;
+  const double* v2gammatau_bb_a_device= task.v2gammatau_bb_a;
+  const double* v2gammatau_bb_b_device= task.v2gammatau_bb_b;
+  const double* v2tau2_a_a_device   = task.v2tau2_a_a;
+  const double* v2tau2_a_b_device   = task.v2tau2_a_b;
+  const double* v2tau2_b_b_device   = task.v2tau2_b_b;
+
+  auto* FXC_A_s_device        = task.FXC_A_s;
+  auto* FXC_A_z_device        = task.FXC_A_z;
+  auto* FXC_Bx_s_device       = task.FXC_Bx_s;
+  auto* FXC_Bx_z_device       = task.FXC_Bx_z;
+  auto* FXC_By_s_device       = task.FXC_By_s;
+  auto* FXC_By_z_device       = task.FXC_By_z;
+  auto* FXC_Bz_s_device       = task.FXC_Bz_s;
+  auto* FXC_Bz_z_device       = task.FXC_Bz_z;
+  auto* FXC_C_s_device        = task.FXC_C_s;
+  auto* FXC_C_z_device        = task.FXC_C_z;
+
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if( tid < npts ) {
+    const auto ps = tden_s_device[ tid ];
+    const auto pz = tden_z_device[ tid ];
+    const auto trho_a_device = 0.5*(ps + pz);
+    const auto trho_b_device = 0.5*(ps - pz);
+    const auto ts = ttau_s_device[ tid ];
+    const auto tz = ttau_z_device[ tid ];
+    const auto tau_a = 0.5*(ts + tz);
+    const auto tau_b = 0.5*(ts - tz);
+
+    const auto tdndx   = tden_pos_x_eval_device[ tid ];
+    const auto tdndy   = tden_pos_y_eval_device[ tid ];
+    const auto tdndz   = tden_pos_z_eval_device[ tid ];
+    const auto tdMzdx  = tden_neg_x_eval_device[ tid ];
+    const auto tdMzdy  = tden_neg_y_eval_device[ tid ];
+    const auto tdMzdz  = tden_neg_z_eval_device[ tid ];
+    const auto tdden_a_x = 0.5*(tdndx + tdMzdx);
+    const auto tdden_a_y = 0.5*(tdndy + tdMzdy);
+    const auto tdden_a_z = 0.5*(tdndz + tdMzdz);
+    const auto tdden_b_x = 0.5*(tdndx - tdMzdx);
+    const auto tdden_b_y = 0.5*(tdndy - tdMzdy);
+    const auto tdden_b_z = 0.5*(tdndz - tdMzdz);
+
+    const auto dndx   = den_pos_x_eval_device[ tid ];
+    const auto dndy   = den_pos_y_eval_device[ tid ];
+    const auto dndz   = den_pos_z_eval_device[ tid ];
+    const auto dMzdx  = den_neg_x_eval_device[ tid ];
+    const auto dMzdy  = den_neg_y_eval_device[ tid ];
+    const auto dMzdz  = den_neg_z_eval_device[ tid ];
+    const auto dden_a_x = 0.5*(dndx + dMzdx);
+    const auto dden_a_y = 0.5*(dndy + dMzdy);
+    const auto dden_a_z = 0.5*(dndz + dMzdz);
+    const auto dden_b_x = 0.5*(dndx - dMzdx);
+    const auto dden_b_y = 0.5*(dndy - dMzdy);
+    const auto dden_b_z = 0.5*(dndz - dMzdz);
+
+    const auto tgamma_pp = tdden_a_x * dden_a_x + tdden_a_y * dden_a_y + tdden_a_z * dden_a_z;
+    const auto tgamma_pm = tdden_a_x * dden_b_x + tdden_a_y * dden_b_y + tdden_a_z * dden_b_z
+                                 + tdden_b_x * dden_a_x + tdden_b_y * dden_a_y + tdden_b_z * dden_a_z;
+    const auto tgamma_mm = tdden_b_x * dden_b_x + tdden_b_y * dden_b_y + tdden_b_z * dden_b_z;
+
+    
+    const auto A_a = v2rho2_a_a_device[tid] * trho_a_device + 2.0 * v2rhogamma_a_aa_device[tid] * tgamma_pp + 
+          v2rhogamma_a_ab_device[tid] * tgamma_pm + 2.0 * v2rhogamma_a_bb_device[tid] * tgamma_mm + 
+          v2rho2_a_b_device[tid] * trho_b_device + v2rhotau_a_a_device[tid] * tau_a +
+          v2rhotau_a_b_device[tid] * tau_b;
+    const auto A_b = v2rho2_b_b_device[tid] * trho_b_device + 2.0 * v2rhogamma_b_bb_device[tid] * tgamma_mm + 
+          v2rhogamma_b_ab_device[tid] * tgamma_pm + 2.0 * v2rhogamma_b_aa_device[tid] * tgamma_pp + 
+          v2rho2_a_b_device[tid] * trho_a_device + v2rhotau_b_b_device[tid] * tau_b +
+          v2rhotau_b_a_device[tid] * tau_a;
+    FXC_A_s_device[ tid ] = 0.5 * weight_device[ tid ] * (A_a + A_b);
+    FXC_A_z_device[ tid ] = 0.5 * weight_device[ tid ] * (A_a - A_b);
+
+    // Compute C coefficients for alpha and beta spin
+    const auto C_a = v2rhotau_a_a_device[tid] * trho_a_device + v2rhotau_b_a_device[tid] * trho_b_device
+             + 2.0 * v2gammatau_aa_a_device[tid] * tgamma_pp  + v2gammatau_ab_a_device[tid] * tgamma_pm
+             + 2.0 * v2gammatau_bb_a_device[tid] * tgamma_mm
+             + v2tau2_a_a_device[tid] * tau_a + v2tau2_a_b_device[tid] * tau_b;
+
+    const auto C_b = v2rhotau_a_b_device[tid] * trho_a_device + v2rhotau_b_b_device[tid] * trho_b_device
+             + 2.0 * v2gammatau_aa_b_device[tid] * tgamma_pp + v2gammatau_ab_b_device[tid] * tgamma_pm
+             + 2.0 * v2gammatau_bb_b_device[tid] * tgamma_mm
+             + v2tau2_a_b_device[tid] * tau_a + v2tau2_b_b_device[tid] * tau_b;
+
+    FXC_C_s_device[tid] = 0.5 * weight_device[tid] * (C_a + C_b);
+    FXC_C_z_device[tid] = 0.5 * weight_device[tid] * (C_a - C_b);
+
+    // Calculate B coefficients for alpha spin
+    const double B_coef1_a = v2rhogamma_a_aa_device[tid] * trho_a_device   + 2.0 * v2gamma2_aa_aa_device[tid] * tgamma_pp + 
+                 v2gamma2_aa_ab_device[tid] * tgamma_pm + 2.0 * v2gamma2_aa_bb_device[tid] * tgamma_mm + 
+                 v2rhogamma_b_aa_device[tid] * trho_b_device + v2gammatau_aa_a_device[tid] * tau_a +
+                 v2gammatau_aa_b_device[tid] * tau_b;
+
+    const double B_coef2_a = v2rhogamma_a_ab_device[tid] * trho_a_device + 2.0 * v2gamma2_aa_ab_device[tid] * tgamma_pp + 
+          v2gamma2_ab_ab_device[tid] * tgamma_pm + 2.0 * v2gamma2_ab_bb_device[tid] * tgamma_mm +
+          v2rhogamma_b_ab_device[tid] * trho_b_device + v2gammatau_ab_a_device[tid] * tau_a +
+          v2gammatau_ab_b_device[tid] * tau_b;
+
+    // Calculate gradient components for alpha spin
+    const double Bx_a = 2.0 * B_coef1_a * dden_a_x + B_coef2_a * dden_b_x + 
+           2.0 * vgamma_aa_device[tid] * tdden_a_x + vgamma_ab_device[tid] * tdden_b_x;
+
+    const double By_a = 2.0 * B_coef1_a * dden_a_y + B_coef2_a * dden_b_y + 
+           2.0 * vgamma_aa_device[tid] * tdden_a_y + vgamma_ab_device[tid] * tdden_b_y;
+
+    const double Bz_a = 2.0 * B_coef1_a * dden_a_z + B_coef2_a * dden_b_z + 
+           2.0 * vgamma_aa_device[tid] * tdden_a_z + vgamma_ab_device[tid] * tdden_b_z;
+
+    // Calculate B coefficients for beta spin
+    const double B_coef1_b = v2rhogamma_b_bb_device[tid] * trho_b_device + 2.0 * v2gamma2_bb_bb_device[tid] * tgamma_mm + 
+          v2gamma2_ab_bb_device[tid] * tgamma_pm + 2.0 * v2gamma2_aa_bb_device[tid] * tgamma_pp + 
+          v2rhogamma_a_bb_device[tid] * trho_a_device + v2gammatau_bb_b_device[tid] * tau_b +
+          v2gammatau_bb_a_device[tid] * tau_a;
+
+    const double B_coef2_b = v2rhogamma_b_ab_device[tid] * trho_b_device + 2.0 * v2gamma2_ab_bb_device[tid] * tgamma_mm + 
+          v2gamma2_ab_ab_device[tid] * tgamma_pm + 2.0 * v2gamma2_aa_ab_device[tid] * tgamma_pp + 
+          v2rhogamma_a_ab_device[tid] * trho_a_device + v2gammatau_ab_b_device[tid] * tau_b +
+          v2gammatau_ab_a_device[tid] * tau_a;
+
+    const double Bx_b = 2.0 * B_coef1_b * dden_b_x + B_coef2_b * dden_a_x + 
+           2.0 * vgamma_bb_device[tid] * tdden_b_x + vgamma_ab_device[tid] * tdden_a_x;
+
+    const double By_b = 2.0 * B_coef1_b * dden_b_y + B_coef2_b * dden_a_y + 
+           2.0 * vgamma_bb_device[tid] * tdden_b_y + vgamma_ab_device[tid] * tdden_a_y;
+
+    const double Bz_b = 2.0 * B_coef1_b * dden_b_z + B_coef2_b * dden_a_z + 
+           2.0 * vgamma_bb_device[tid] * tdden_b_z + vgamma_ab_device[tid] * tdden_a_z;
+
+    // Store weighted values in output arrays
+    FXC_Bx_s_device[tid] = 0.5 * weight_device[tid] * (Bx_a + Bx_b);
+    FXC_By_s_device[tid] = 0.5 * weight_device[tid] * (By_a + By_b);
+    FXC_Bz_s_device[tid] = 0.5 * weight_device[tid] * (Bz_a + Bz_b);
+    FXC_Bx_z_device[tid] = 0.5 * weight_device[tid] * (Bx_a - Bx_b);
+    FXC_By_z_device[tid] = 0.5 * weight_device[tid] * (By_a - By_b);
+    FXC_Bz_z_device[tid] = 0.5 * weight_device[tid] * (Bz_a - Bz_b);
+
+  }
+
+}
+
+
+}

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/zmat_fxc.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/zmat_fxc.hip
@@ -1,0 +1,239 @@
+/**
+ * GauXC Copyright (c) 2020-2024, The Regents of the University of California,
+ * through Lawrence Berkeley National Laboratory (subject to receipt of
+ * any required approvals from the U.S. Dept. of Energy).
+ *
+ * (c) 2024-2025, Microsoft Corporation
+ *
+ * All rights reserved.
+ *
+ * See LICENSE.txt for details
+ */
+#include "hip/hip_runtime.h"
+#include "device/common/zmat_fxc.hpp"
+#include <gauxc/util/div_ceil.hpp>
+#include "device_specific/hip_util.hpp"
+#include "device_specific/hip_device_constants.hpp"
+
+namespace GauXC {
+
+
+template<density_id den_selector>
+__global__ void zmat_lda_fxc_kernel( size_t        ntasks,
+                                     XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+  const auto* FXC_A_device = task.FXC_A_s;
+  if constexpr ( den_selector == DEN_Z ) FXC_A_device = task.FXC_A_z;
+
+  const auto* basis_eval_device = task.bf;
+  auto* z_matrix_device = task.zmat;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if( tid_x < npts and tid_y < nbf ) {
+
+    const size_t ibfoff = tid_y * npts + tid_x;
+    const double fact = 0.5 * FXC_A_device[tid_x];
+
+    z_matrix_device[ ibfoff ] = fact * basis_eval_device[ ibfoff ];
+  }
+
+}
+
+
+
+
+
+template<density_id den_selector>
+__global__ void zmat_gga_fxc_kernel( size_t        ntasks,
+                                     XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+
+  const auto* basis_eval_device = task.bf;
+  const auto* dbasis_x_eval_device = task.dbfx;
+  const auto* dbasis_y_eval_device = task.dbfy;
+  const auto* dbasis_z_eval_device = task.dbfz;
+  const auto* FXC_A_device   = task.FXC_A_s;
+  const auto* FXC_Bx_device  = task.FXC_Bx_s;
+  const auto* FXC_By_device  = task.FXC_By_s;
+  const auto* FXC_Bz_device  = task.FXC_Bz_s;
+  if constexpr ( den_selector == DEN_Z ) {
+    FXC_A_device   = task.FXC_A_z;
+    FXC_Bx_device  = task.FXC_Bx_z;
+    FXC_By_device  = task.FXC_By_z;
+    FXC_Bz_device  = task.FXC_Bz_z;
+  }
+
+  auto* z_matrix_device = task.zmat;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if( tid_x < npts and tid_y < nbf ) {
+
+    const size_t ibfoff = tid_y * npts + tid_x;
+
+    const double dx = FXC_Bx_device[tid_x] * dbasis_x_eval_device[ ibfoff ];
+    const double dy = FXC_By_device[tid_x] * dbasis_y_eval_device[ ibfoff ];
+    const double dz = FXC_Bz_device[tid_x] * dbasis_z_eval_device[ ibfoff ];
+
+    z_matrix_device[ ibfoff ] = 
+      (0.5 * FXC_A_device[tid_x] * basis_eval_device[ ibfoff ] +  dx + dy + dz ); 
+  }
+}
+
+
+
+#define ZMAT_FXC_KERN(xc_approx) \
+  hipStream_t stream = queue.queue_as<util::hip_stream>(); \
+  dim3 threads(hip::warp_size,hip::max_warps_per_thread_block,1); \
+  dim3 blocks( util::div_ceil( max_npts, threads.x ), \
+               util::div_ceil( max_nbf,  threads.y ), \
+               ntasks ); \
+  if ( sel == DEN_S )       zmat_##xc_approx##_fxc_kernel<DEN_S><<< blocks, threads, 0, stream >>>( ntasks, tasks_device ); \
+  else if ( sel == DEN_Z )  zmat_##xc_approx##_fxc_kernel<DEN_Z><<< blocks, threads, 0, stream >>>( ntasks, tasks_device ); \
+
+
+
+void zmat_lda_fxc( size_t            ntasks,
+                   int32_t           max_nbf,
+                   int32_t           max_npts,
+                   XCDeviceTask*     tasks_device,
+                   density_id sel,
+                   device_queue queue ) {
+ZMAT_FXC_KERN(lda)
+}
+
+
+
+void zmat_gga_fxc( size_t            ntasks,
+                   int32_t           max_nbf,
+                   int32_t           max_npts,
+                   XCDeviceTask*     tasks_device,
+                   density_id sel,
+                   device_queue queue ) {
+ZMAT_FXC_KERN(gga)
+}
+
+
+
+void zmat_mgga_fxc( size_t            ntasks,
+                    int32_t           max_nbf,
+                    int32_t           max_npts,
+                    XCDeviceTask*     tasks_device,
+                    bool              do_lapl,
+                    density_id sel,
+                    device_queue queue ) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
+
+
+  dim3 threads(hip::warp_size,hip::max_warps_per_thread_block,1);
+  dim3 blocks( util::div_ceil( max_npts, threads.x ),
+               util::div_ceil( max_nbf,  threads.y ),
+               ntasks );
+
+  if(do_lapl)
+    GAUXC_GENERIC_EXCEPTION("Fxc contraction + do_lapl NYI");
+    
+  switch(sel) {
+    case DEN_S:
+        zmat_gga_fxc_kernel<DEN_S><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+      break;
+    case DEN_Z:
+        zmat_gga_fxc_kernel<DEN_Z><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+      break;
+  }
+
+}
+
+
+
+
+
+
+
+
+
+
+template <density_id id>
+__global__ void mmat_mgga_fxc_kernel( size_t        ntasks,
+                                     XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+  auto* FXC_C_s_device   = task.FXC_C_s;
+  if constexpr ( id == DEN_Z ) FXC_C_s_device = task.FXC_C_z;
+
+  const auto* dbasis_x_eval_device = task.dbfx;
+  const auto* dbasis_y_eval_device = task.dbfy;
+  const auto* dbasis_z_eval_device = task.dbfz;
+
+  auto* mmat_x = task.xmat_x;
+  auto* mmat_y = task.xmat_y;
+  auto* mmat_z = task.xmat_z;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if( tid_x < npts and tid_y < nbf ) {
+
+    const size_t ibfoff = tid_y * npts + tid_x;
+
+    const double fact = 0.25 * FXC_C_s_device[tid_x];
+
+    mmat_x[ ibfoff ] = fact * dbasis_x_eval_device[ ibfoff ]; 
+    mmat_y[ ibfoff ] = fact * dbasis_y_eval_device[ ibfoff ]; 
+    mmat_z[ ibfoff ] = fact * dbasis_z_eval_device[ ibfoff ]; 
+  }
+}
+
+void mmat_mgga_fxc( size_t            ntasks,
+                    int32_t           max_nbf,
+                    int32_t           max_npts,
+                    XCDeviceTask*     tasks_device,
+                    bool              do_lapl,
+                    density_id sel,
+                    device_queue queue ) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
+
+
+  dim3 threads(hip::warp_size,hip::max_warps_per_thread_block,1);
+  dim3 blocks( util::div_ceil( max_npts, threads.x ),
+               util::div_ceil( max_nbf,  threads.y ),
+               ntasks );
+
+  if(do_lapl)
+    GAUXC_GENERIC_EXCEPTION("Fxc contraction + do_lapl NYI");
+    
+  switch(sel) {
+    case DEN_S:
+        mmat_mgga_fxc_kernel<DEN_S><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+      break;
+    case DEN_Z:
+        mmat_mgga_fxc_kernel<DEN_Z><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+      break;
+  }
+  
+}
+
+}
+

--- a/src/xc_integrator/local_work_driver/device/hip/kernels/zmat_vxc.hip
+++ b/src/xc_integrator/local_work_driver/device/hip/kernels/zmat_vxc.hip
@@ -18,7 +18,7 @@
 namespace GauXC {
 
 
-__global__ void zmat_lda_vxc_kernel( size_t        ntasks,
+__global__ void zmat_lda_vxc_rks_kernel( size_t        ntasks,
                                      XCDeviceTask* tasks_device ) {
 
   const int batch_idx = blockIdx.z;
@@ -50,21 +50,91 @@ __global__ void zmat_lda_vxc_kernel( size_t        ntasks,
 
 
 
-void zmat_lda_vxc( size_t            ntasks,
-                   int32_t           max_nbf,
-                   int32_t           max_npts,
-                   XCDeviceTask*     tasks_device,
-                   device_queue queue ) {
-
-  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
 
 
-  dim3 threads(hip::warp_size,hip::max_warps_per_thread_block,1);
-  dim3 blocks( util::div_ceil( max_npts, threads.x ),
-               util::div_ceil( max_nbf,  threads.y ),
-               ntasks );
 
-  hipLaunchKernelGGL(zmat_lda_vxc_kernel, dim3(blocks), dim3(threads), 0, stream ,  ntasks, tasks_device );
+
+
+
+
+
+
+template<density_id den_selector>
+__global__ void zmat_lda_vxc_uks_kernel( size_t        ntasks,
+                                     XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+  const double* vrho_pos_device    = task.vrho_pos;
+  const double* vrho_neg_device    = task.vrho_neg;
+
+
+  const auto* basis_eval_device = task.bf;
+
+
+  auto* z_matrix_device = task.zmat;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if( tid_x < npts and tid_y < nbf ) {
+
+    const size_t ibfoff = tid_y * npts + tid_x;
+    const double factp = 0.5 * vrho_pos_device[tid_x];
+    const double factm = 0.5 * vrho_neg_device[tid_x];
+    double sign = 1.0;
+    if constexpr ( den_selector == DEN_Z )  sign = -1.0;
+    
+    z_matrix_device[ ibfoff ] = 0.5*(factp * basis_eval_device[ ibfoff ] + sign * factm * basis_eval_device[ ibfoff ]);
+  }
+
+}
+
+template<density_id den_selector>
+__global__ void zmat_lda_vxc_gks_kernel( size_t        ntasks,
+                                     XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+  const double* vrho_pos_device    = task.vrho_pos;
+  const double* vrho_neg_device    = task.vrho_neg;
+
+  double* K_device;
+  if constexpr ( den_selector == DEN_Z ) K_device = task.K_z;
+  if constexpr ( den_selector == DEN_Y ) K_device = task.K_y;
+  if constexpr ( den_selector == DEN_X ) K_device = task.K_x;
+  
+
+
+  const auto* basis_eval_device = task.bf;
+
+
+  auto* z_matrix_device = task.zmat;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if( tid_x < npts and tid_y < nbf ) {
+    const size_t ibfoff = tid_y * npts + tid_x;
+    const double factp = 0.5 * vrho_pos_device[tid_x];
+    const double factm = 0.5 * vrho_neg_device[tid_x];
+
+    if constexpr ( den_selector == DEN_S ) {
+      z_matrix_device[ ibfoff ] = 0.5*(factp * basis_eval_device[ ibfoff ] + factm * basis_eval_device[ ibfoff ]);
+    }
+    else {
+      const double factk = 0.5 * (factp - factm);
+      z_matrix_device[ ibfoff ] = K_device[ ibfoff ] * factk * basis_eval_device[ ibfoff ];
+    }
+  }
 
 }
 
@@ -76,18 +146,7 @@ void zmat_lda_vxc( size_t            ntasks,
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-__global__ void zmat_gga_vxc_kernel( size_t        ntasks,
+__global__ void zmat_gga_vxc_rks_kernel( size_t        ntasks,
                                      XCDeviceTask* tasks_device ) {
 
   const int batch_idx = blockIdx.z;
@@ -98,9 +157,9 @@ __global__ void zmat_gga_vxc_kernel( size_t        ntasks,
   const auto nbf             = task.bfn_screening.nbe;
   const auto* vrho_device    = task.vrho;
   const auto* vgamma_device  = task.vgamma;
-  const auto* den_x_eval_device = task.ddenx;
-  const auto* den_y_eval_device = task.ddeny;
-  const auto* den_z_eval_device = task.ddenz;
+  const auto* den_x_eval_device = task.dden_sx;
+  const auto* den_y_eval_device = task.dden_sy;
+  const auto* den_z_eval_device = task.dden_sz;
 
   const auto* basis_eval_device = task.bf;
   const auto* dbasis_x_eval_device = task.dbfx;
@@ -128,11 +187,418 @@ __global__ void zmat_gga_vxc_kernel( size_t        ntasks,
   }
 }
 
+
+
+
+
+
+
+
+template<density_id den_selector>
+__global__ void zmat_gga_vxc_uks_kernel( size_t        ntasks,
+                                     XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+
+  const double* vrho_pos_device    = task.vrho_pos;
+  const double* vrho_neg_device    = task.vrho_neg;
+  const double* vgamma_pp_device   = task.vgamma_pp;
+  const double* vgamma_pm_device   = task.vgamma_pm;
+  const double* vgamma_mm_device   = task.vgamma_mm;
+
+  const auto* den_pos_x_eval_device = task.dden_sx;
+  const auto* den_pos_y_eval_device = task.dden_sy;
+  const auto* den_pos_z_eval_device = task.dden_sz;
+  const auto* den_neg_x_eval_device = task.dden_zx;
+  const auto* den_neg_y_eval_device = task.dden_zy;
+  const auto* den_neg_z_eval_device = task.dden_zz;
+
+
+  const auto* basis_eval_device = task.bf;
+  const auto* dbasis_x_eval_device = task.dbfx;
+  const auto* dbasis_y_eval_device = task.dbfy;
+  const auto* dbasis_z_eval_device = task.dbfz;
+
+  auto* z_matrix_device = task.zmat;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if( tid_x < npts and tid_y < nbf ) {
+
+    const size_t ibfoff = tid_y * npts + tid_x;
+
+    const double factp = 0.25 * vrho_pos_device[tid_x];
+    const double factm = 0.25 * vrho_neg_device[tid_x];
+    
+    const auto gga_fact_pp  = vgamma_pp_device[tid_x];
+    const auto gga_fact_pm  = vgamma_pm_device[tid_x];
+    const auto gga_fact_mm  = vgamma_mm_device[tid_x];
+    
+    const auto gga_fact_1 = 0.5*(gga_fact_pp + gga_fact_pm + gga_fact_mm);
+    const auto gga_fact_2 = 0.5*(gga_fact_pp - gga_fact_mm);
+    const auto gga_fact_3 = 0.5*(gga_fact_pp - gga_fact_pm + gga_fact_mm);
+
+    double sign = 1.0;
+
+    double x_fact, y_fact, z_fact;
+
+    if constexpr ( den_selector == DEN_S ) {
+       x_fact = gga_fact_1 * den_pos_x_eval_device[ tid_x ] + gga_fact_2 * den_neg_x_eval_device[ tid_x ];
+       y_fact = gga_fact_1 * den_pos_y_eval_device[ tid_x ] + gga_fact_2 * den_neg_y_eval_device[ tid_x ];
+       z_fact = gga_fact_1 * den_pos_z_eval_device[ tid_x ] + gga_fact_2 * den_neg_z_eval_device[ tid_x ];
+      
+
+    }
+    if constexpr ( den_selector == DEN_Z ) {
+       sign = -1.0;
+       x_fact = gga_fact_3 * den_neg_x_eval_device[ tid_x ] + gga_fact_2 * den_pos_x_eval_device[ tid_x ];
+       y_fact = gga_fact_3 * den_neg_y_eval_device[ tid_x ] + gga_fact_2 * den_pos_y_eval_device[ tid_x ];
+       z_fact = gga_fact_3 * den_neg_z_eval_device[ tid_x ] + gga_fact_2 * den_pos_z_eval_device[ tid_x ];
+
+    }
+
+    z_matrix_device[ ibfoff ] =   x_fact * dbasis_x_eval_device[ ibfoff ]      
+                                + y_fact * dbasis_y_eval_device[ ibfoff ]
+                                + z_fact * dbasis_z_eval_device[ ibfoff ] 
+                                + (factp + sign * factm) * basis_eval_device[ ibfoff ];
+  }
+}
+
+
+
+
+template<density_id den_selector>
+__global__ void zmat_gga_vxc_gks_kernel( size_t        ntasks,
+                                     XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+
+  const double* vrho_pos_device    = task.vrho_pos;
+  const double* vrho_neg_device    = task.vrho_neg;
+  const double* vgamma_pp_device   = task.vgamma_pp;
+  const double* vgamma_pm_device   = task.vgamma_pm;
+  const double* vgamma_mm_device   = task.vgamma_mm;
+
+  
+  // for non-DEN_S
+  double* K_device;
+  double* H_device;
+  if constexpr ( den_selector == DEN_Z ) { K_device = task.K_z; H_device = task.H_z; }
+  if constexpr ( den_selector == DEN_Y ) { K_device = task.K_y; H_device = task.H_y; }
+  if constexpr ( den_selector == DEN_X ) { K_device = task.K_x; H_device = task.H_x; }
+
+  const auto* dden_sx_eval_device = task.dden_sx;
+  const auto* dden_sy_eval_device = task.dden_sy;
+  const auto* dden_sz_eval_device = task.dden_sz;
+  const auto* dden_zx_eval_device = task.dden_zx;
+  const auto* dden_zy_eval_device = task.dden_zy;
+  const auto* dden_zz_eval_device = task.dden_zz;
+  const auto* dden_yx_eval_device = task.dden_yx;
+  const auto* dden_yy_eval_device = task.dden_yy;
+  const auto* dden_yz_eval_device = task.dden_yz;
+  const auto* dden_xx_eval_device = task.dden_xx;
+  const auto* dden_xy_eval_device = task.dden_xy;
+  const auto* dden_xz_eval_device = task.dden_xz;
+
+
+  const auto* basis_eval_device = task.bf;
+  const auto* dbasis_x_eval_device = task.dbfx;
+  const auto* dbasis_y_eval_device = task.dbfy;
+  const auto* dbasis_z_eval_device = task.dbfz;
+
+  auto* z_matrix_device = task.zmat;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if( tid_x < npts and tid_y < nbf ) {
+
+    const size_t ibfoff = tid_y * npts + tid_x;
+
+    const double fact_p =  0.5*vrho_pos_device[tid_x];
+    const double fact_m =  0.5*vrho_neg_device[tid_x];
+    
+    const auto gga_fact_pp  = vgamma_pp_device[tid_x];
+    const auto gga_fact_pm  = vgamma_pm_device[tid_x];
+    const auto gga_fact_mm  = vgamma_mm_device[tid_x];
+    
+    const auto gga_fact_1 = 0.5*(gga_fact_pp + gga_fact_pm + gga_fact_mm);
+    const auto gga_fact_2 = 0.5*(gga_fact_pp - gga_fact_mm);
+    const auto gga_fact_3 = 0.5*(gga_fact_pp - gga_fact_pm + gga_fact_mm);
+
+    double s_fact, x_fact, y_fact, z_fact;
+
+    if constexpr ( den_selector == DEN_S ) {
+      const double* Hz_device          = task.H_z;
+      const double* Hy_device          = task.H_y;
+      const double* Hx_device          = task.H_x;
+      
+      s_fact = 0.5 * (fact_p + fact_m);
+
+      x_fact = gga_fact_1 * dden_sx_eval_device[ tid_x ]
+             + gga_fact_2 * (Hz_device[ tid_x ] * dden_zx_eval_device[ tid_x ]
+                          +  Hy_device[ tid_x ] * dden_yx_eval_device[ tid_x ]
+                          +  Hx_device[ tid_x ] * dden_xx_eval_device[ tid_x ] );
+      y_fact = gga_fact_1 * dden_sy_eval_device[ tid_x ]
+             + gga_fact_2 * (Hz_device[ tid_x ] * dden_zy_eval_device[ tid_x ]
+                          +  Hy_device[ tid_x ] * dden_yy_eval_device[ tid_x ]
+                          +  Hx_device[ tid_x ] * dden_xy_eval_device[ tid_x ] );
+      z_fact = gga_fact_1 * dden_sz_eval_device[ tid_x ]
+                        + gga_fact_2 * (Hz_device[ tid_x ] * dden_zz_eval_device[ tid_x ]
+                                     +  Hy_device[ tid_x ] * dden_yz_eval_device[ tid_x ]
+                                     +  Hx_device[ tid_x ] * dden_xz_eval_device[ tid_x ] );
+    }
+
+    if constexpr ( den_selector == DEN_Z ) {
+      s_fact  = K_device[ tid_x ] * 0.5 * (fact_p - fact_m);
+      x_fact  = gga_fact_3 * dden_zx_eval_device[ tid_x ]
+             +  gga_fact_2 * H_device[ tid_x ] * dden_sx_eval_device[ tid_x ];
+      y_fact  = gga_fact_3 * dden_zy_eval_device[ tid_x ]
+             +  gga_fact_2 * H_device[ tid_x ] * dden_sy_eval_device[ tid_x ];
+      z_fact  = gga_fact_3 * dden_zz_eval_device[ tid_x ]
+             +  gga_fact_2 * H_device[ tid_x ] * dden_sz_eval_device[ tid_x ];
+    }
+
+    if constexpr ( den_selector == DEN_Y ) {
+      s_fact  = K_device[ tid_x ] * 0.5 * (fact_p - fact_m);
+      x_fact  = gga_fact_3 * dden_yx_eval_device[ tid_x ]
+             +  gga_fact_2 * H_device[ tid_x ] * dden_sx_eval_device[ tid_x ];
+      y_fact  = gga_fact_3 * dden_yy_eval_device[ tid_x ]
+             +  gga_fact_2 * H_device[ tid_x ] * dden_sy_eval_device[ tid_x ];
+      z_fact  = gga_fact_3 * dden_yz_eval_device[ tid_x ]
+             +  gga_fact_2 * H_device[ tid_x ] * dden_sz_eval_device[ tid_x ];
+    }
+
+    if constexpr ( den_selector == DEN_X ) {
+      s_fact  = K_device[ tid_x ] * 0.5 * (fact_p - fact_m);
+      x_fact  = gga_fact_3 * dden_xx_eval_device[ tid_x ]
+             +  gga_fact_2 * H_device[ tid_x ] * dden_sx_eval_device[ tid_x ];
+      y_fact  = gga_fact_3 * dden_xy_eval_device[ tid_x ]
+             +  gga_fact_2 * H_device[ tid_x ] * dden_sy_eval_device[ tid_x ];
+      z_fact  = gga_fact_3 * dden_xz_eval_device[ tid_x ]
+             +  gga_fact_2 * H_device[ tid_x ] * dden_sz_eval_device[ tid_x ];
+    }
+
+    z_matrix_device[ ibfoff ] =   x_fact * dbasis_x_eval_device[ ibfoff ]      
+                                + y_fact * dbasis_y_eval_device[ ibfoff ]
+                                + z_fact * dbasis_z_eval_device[ ibfoff ] 
+                                + s_fact *  basis_eval_device[ ibfoff ];
+
+  }
+}
+
+
+
+
+template <bool need_lapl>
+__global__ void zmat_mgga_vxc_rks_kernel( size_t        ntasks,
+                                     XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+  const auto* vrho_device    = task.vrho;
+  const auto* vgamma_device  = task.vgamma;
+  const double* vlapl_device = need_lapl ? task.vlapl : nullptr;
+  const auto* den_x_eval_device = task.dden_sx;
+  const auto* den_y_eval_device = task.dden_sy;
+  const auto* den_z_eval_device = task.dden_sz;
+
+  const auto* basis_eval_device = task.bf;
+  const auto* dbasis_x_eval_device = task.dbfx;
+  const auto* dbasis_y_eval_device = task.dbfy;
+  const auto* dbasis_z_eval_device = task.dbfz;
+  const double* d2basis_lapl_eval_device = 
+    need_lapl ? task.d2bflapl : nullptr;
+  
+
+  auto* z_matrix_device = task.zmat;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if( tid_x < npts and tid_y < nbf ) {
+
+    const size_t ibfoff = tid_y * npts + tid_x;
+    const double fact_1 = 0.5 * vrho_device[tid_x]  ;
+    const double fact_2 = 2.0 * vgamma_device[tid_x];
+
+    const double dx = den_x_eval_device[ tid_x ] * dbasis_x_eval_device[ ibfoff ];
+    const double dy = den_y_eval_device[ tid_x ] * dbasis_y_eval_device[ ibfoff ];
+    const double dz = den_z_eval_device[ tid_x ] * dbasis_z_eval_device[ ibfoff ];
+
+    double val = 
+      fact_1 * basis_eval_device[ ibfoff ] + fact_2 * ( dx + dy + dz ); 
+
+    if constexpr (need_lapl) {
+      val += vlapl_device[tid_x] * d2basis_lapl_eval_device[ibfoff];
+    }
+
+    z_matrix_device[ ibfoff ] = val;
+  }
+}
+
+template<bool need_lapl, density_id den_selector>
+__global__ void zmat_mgga_vxc_uks_kernel( size_t        ntasks,
+                                     XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+
+  const double* vrho_pos_device    = task.vrho_pos;
+  const double* vrho_neg_device    = task.vrho_neg;
+  const double* vlapl_pos_device    = task.vlapl_pos;
+  const double* vlapl_neg_device    = task.vlapl_neg;
+  const double* vgamma_pp_device   = task.vgamma_pp;
+  const double* vgamma_pm_device   = task.vgamma_pm;
+  const double* vgamma_mm_device   = task.vgamma_mm;
+
+  const auto* den_pos_x_eval_device = task.dden_sx;
+  const auto* den_pos_y_eval_device = task.dden_sy;
+  const auto* den_pos_z_eval_device = task.dden_sz;
+  const auto* den_neg_x_eval_device = task.dden_zx;
+  const auto* den_neg_y_eval_device = task.dden_zy;
+  const auto* den_neg_z_eval_device = task.dden_zz;
+
+
+  const auto* basis_eval_device = task.bf;
+  const auto* dbasis_x_eval_device = task.dbfx;
+  const auto* dbasis_y_eval_device = task.dbfy;
+  const auto* dbasis_z_eval_device = task.dbfz;
+  const auto* d2basis_lapl_eval_device = task.d2bflapl;
+
+  auto* z_matrix_device = task.zmat;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if( tid_x < npts and tid_y < nbf ) {
+
+    const size_t ibfoff = tid_y * npts + tid_x;
+
+    const double factp = 0.25 * vrho_pos_device[tid_x];
+    const double factm = 0.25 * vrho_neg_device[tid_x];
+    
+    const auto gga_fact_pp  = vgamma_pp_device[tid_x];
+    const auto gga_fact_pm  = vgamma_pm_device[tid_x];
+    const auto gga_fact_mm  = vgamma_mm_device[tid_x];
+    
+    const auto gga_fact_1 = 0.5*(gga_fact_pp + gga_fact_pm + gga_fact_mm);
+    const auto gga_fact_2 = 0.5*(gga_fact_pp - gga_fact_mm);
+    const auto gga_fact_3 = 0.5*(gga_fact_pp - gga_fact_pm + gga_fact_mm);
+
+    double sign = 1.0;
+
+    double x_fact, y_fact, z_fact;
+
+    if constexpr ( den_selector == DEN_S ) {
+       x_fact = gga_fact_1 * den_pos_x_eval_device[ tid_x ] + gga_fact_2 * den_neg_x_eval_device[ tid_x ];
+       y_fact = gga_fact_1 * den_pos_y_eval_device[ tid_x ] + gga_fact_2 * den_neg_y_eval_device[ tid_x ];
+       z_fact = gga_fact_1 * den_pos_z_eval_device[ tid_x ] + gga_fact_2 * den_neg_z_eval_device[ tid_x ];
+    }
+    if constexpr ( den_selector == DEN_Z ) {
+       sign = -1.0;
+       x_fact = gga_fact_3 * den_neg_x_eval_device[ tid_x ] + gga_fact_2 * den_pos_x_eval_device[ tid_x ];
+       y_fact = gga_fact_3 * den_neg_y_eval_device[ tid_x ] + gga_fact_2 * den_pos_y_eval_device[ tid_x ];
+       z_fact = gga_fact_3 * den_neg_z_eval_device[ tid_x ] + gga_fact_2 * den_pos_z_eval_device[ tid_x ];
+    }
+
+    auto val = x_fact * dbasis_x_eval_device[ ibfoff ]      
+             + y_fact * dbasis_y_eval_device[ ibfoff ]
+             + z_fact * dbasis_z_eval_device[ ibfoff ] 
+             + (factp + sign * factm) * basis_eval_device[ ibfoff ];
+
+    if constexpr (need_lapl) {
+      const double lfactp = vlapl_pos_device[tid_x];
+      const double lfactm = vlapl_neg_device[tid_x];
+
+      val += 0.5 * (lfactp + sign * lfactm) * d2basis_lapl_eval_device[ ibfoff ];
+    }
+
+    z_matrix_device[ ibfoff ] = val;
+  }
+}
+
+
+
+#define ZMAT_VXC_KERN(xc_approx) \
+  hipStream_t stream = queue.queue_as<util::hip_stream>(); \
+  dim3 threads(hip::warp_size,hip::max_warps_per_thread_block,1); \
+  dim3 blocks( util::div_ceil( max_npts, threads.x ), \
+               util::div_ceil( max_nbf,  threads.y ), \
+               ntasks ); \
+  switch( scheme ) { \
+    case RKS: \
+      zmat_##xc_approx##_vxc_rks_kernel<<< blocks, threads, 0, stream >>>( ntasks, tasks_device ); \
+      break; \
+    case UKS: \
+      if ( sel == DEN_S )       zmat_##xc_approx##_vxc_uks_kernel<DEN_S><<< blocks, threads, 0, stream >>>( ntasks, tasks_device ); \
+      else if ( sel == DEN_Z )  zmat_##xc_approx##_vxc_uks_kernel<DEN_Z><<< blocks, threads, 0, stream >>>( ntasks, tasks_device ); \
+      else GAUXC_GENERIC_EXCEPTION( "zmat_##xc_approx##_vxc invalid density" ); \
+      break; \
+    case GKS: \
+      if ( sel == DEN_S )       zmat_##xc_approx##_vxc_gks_kernel<DEN_S><<< blocks, threads, 0, stream >>>( ntasks, tasks_device ); \
+      else if ( sel == DEN_Z )  zmat_##xc_approx##_vxc_gks_kernel<DEN_Z><<< blocks, threads, 0, stream >>>( ntasks, tasks_device ); \
+      else if ( sel == DEN_Y )  zmat_##xc_approx##_vxc_gks_kernel<DEN_Y><<< blocks, threads, 0, stream >>>( ntasks, tasks_device ); \
+      else if ( sel == DEN_X )  zmat_##xc_approx##_vxc_gks_kernel<DEN_X><<< blocks, threads, 0, stream >>>( ntasks, tasks_device ); \
+      else GAUXC_GENERIC_EXCEPTION( "zmat_##xc_approx##_vxc invalid density" ); \
+      break; \
+    default: \
+      GAUXC_GENERIC_EXCEPTION( "zmat_##xc_approx##_vxc invalid KS scheme" ); \
+  }
+
+
+
+void zmat_lda_vxc( size_t            ntasks,
+                   int32_t           max_nbf,
+                   int32_t           max_npts,
+                   XCDeviceTask*     tasks_device,
+                   integrator_ks_scheme scheme,
+                   density_id sel,
+                   device_queue queue ) {
+ZMAT_VXC_KERN(lda)
+}
+
+
+
 void zmat_gga_vxc( size_t            ntasks,
                    int32_t           max_nbf,
                    int32_t           max_npts,
                    XCDeviceTask*     tasks_device,
+                   integrator_ks_scheme scheme,
+                   density_id sel,
                    device_queue queue ) {
+ZMAT_VXC_KERN(gga)
+}
+
+
+
+void zmat_mgga_vxc( size_t            ntasks,
+                    int32_t           max_nbf,
+                    int32_t           max_npts,
+                    XCDeviceTask*     tasks_device,
+                    bool              do_lapl,
+                    integrator_ks_scheme scheme,
+                    density_id sel,
+                    device_queue queue ) {
 
   hipStream_t stream = queue.queue_as<util::hip_stream>() ;
 
@@ -142,13 +608,225 @@ void zmat_gga_vxc( size_t            ntasks,
                util::div_ceil( max_nbf,  threads.y ),
                ntasks );
 
-  hipLaunchKernelGGL(zmat_gga_vxc_kernel, dim3(blocks), dim3(threads), 0, stream ,  ntasks, tasks_device );
+  if(scheme == RKS) {
+    if(do_lapl)
+      zmat_mgga_vxc_rks_kernel<true><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+    else
+      zmat_mgga_vxc_rks_kernel<false><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+  } else if(scheme == UKS) {
+    switch(sel) {
+      case DEN_S:
+        if(do_lapl)
+          zmat_mgga_vxc_uks_kernel<true, DEN_S><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+        else
+          zmat_mgga_vxc_uks_kernel<false, DEN_S><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+        break;
+      case DEN_Z:
+        if(do_lapl)
+          zmat_mgga_vxc_uks_kernel<true, DEN_Z><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+        else
+          zmat_mgga_vxc_uks_kernel<false, DEN_Z><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+        break;
+    }
+  } else {
+    GAUXC_GENERIC_EXCEPTION("MGGA + DEVICE + GKS NYI");
+  }
 
 }
-              
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+template <bool need_lapl>
+__global__ void mmat_mgga_vxc_rks_kernel( size_t        ntasks,
+                                     XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+  const auto* vtau_device    = task.vtau;
+  const double* vlapl_device = need_lapl ? task.vlapl : nullptr;
+
+  const auto* dbasis_x_eval_device = task.dbfx;
+  const auto* dbasis_y_eval_device = task.dbfy;
+  const auto* dbasis_z_eval_device = task.dbfz;
+
+  auto* mmat_x = task.xmat_x;
+  auto* mmat_y = task.xmat_y;
+  auto* mmat_z = task.xmat_z;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if( tid_x < npts and tid_y < nbf ) {
+
+    const size_t ibfoff = tid_y * npts + tid_x;
+    const double fact_1 = 0.25 * vtau_device[tid_x] + 
+      (need_lapl ? vlapl_device[tid_x] : 0.0);
+
+    mmat_x[ ibfoff ] = fact_1 * dbasis_x_eval_device[ ibfoff ]; 
+    mmat_y[ ibfoff ] = fact_1 * dbasis_y_eval_device[ ibfoff ]; 
+    mmat_z[ ibfoff ] = fact_1 * dbasis_z_eval_device[ ibfoff ]; 
+  }
+}
+
+template <bool need_lapl, density_id id>
+__global__ void mmat_mgga_vxc_uks_kernel( size_t        ntasks,
+                                     XCDeviceTask* tasks_device ) {
+
+  const int batch_idx = blockIdx.z;
+  if( batch_idx >= ntasks ) return;
+
+  auto& task = tasks_device[ batch_idx ];
+  const auto npts            = task.npts;
+  const auto nbf             = task.bfn_screening.nbe;
+  const auto* vtau_pos_device    = task.vtau_pos;
+  const auto* vtau_neg_device    = task.vtau_neg;
+  const double* vlapl_pos_device = need_lapl ? task.vlapl_pos : nullptr;
+  const double* vlapl_neg_device = need_lapl ? task.vlapl_neg : nullptr;
+
+  const auto* dbasis_x_eval_device = task.dbfx;
+  const auto* dbasis_y_eval_device = task.dbfy;
+  const auto* dbasis_z_eval_device = task.dbfz;
+
+  auto* mmat_x = task.xmat_x;
+  auto* mmat_y = task.xmat_y;
+  auto* mmat_z = task.xmat_z;
+
+  const int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if( tid_x < npts and tid_y < nbf ) {
+
+    double sign = 1.0;
+    if(id == DEN_Z) sign = -1;
+
+    const size_t ibfoff = tid_y * npts + tid_x;
+    const auto tfactp = 0.25 * vtau_pos_device[tid_x];
+    const auto tfactm = 0.25 * vtau_neg_device[tid_x];
+    const double fact_tau = 0.5 * (tfactp + sign * tfactm);
+    double fact_lapl = 0.0;
+    if(need_lapl) {
+      const auto lfactp = vlapl_pos_device[tid_x];
+      const auto lfactm = vlapl_neg_device[tid_x];
+      fact_lapl = 0.5 * (lfactp + sign * lfactm);
+    }
+    const double fact_1 = fact_tau + fact_lapl;
+
+    mmat_x[ ibfoff ] = fact_1 * dbasis_x_eval_device[ ibfoff ]; 
+    mmat_y[ ibfoff ] = fact_1 * dbasis_y_eval_device[ ibfoff ]; 
+    mmat_z[ ibfoff ] = fact_1 * dbasis_z_eval_device[ ibfoff ]; 
+  }
+}
+
+//__global__ void print_zmat_stats( size_t            ntasks,
+//                    XCDeviceTask*     tasks_device) {
+//
+//  for(size_t iT = 0; iT < ntasks; ++iT) {
+//    auto& task = tasks_device[iT];
+//    const auto npts            = task.npts;
+//    const auto nbf             = task.bfn_screening.nbe;
+//
+//    const auto* zmat = task.zmat;
+//    const auto* bmat = task.bf;
+//    const auto* blmat = task.d2bflapl;
+//  
+//    double znrm = 0.0, bnrm = 0.0, blnrm = 0.0;
+//    for(auto j = 0; j < npts*nbf; ++j) {
+//      znrm += zmat[j] * zmat[j];
+//      bnrm += bmat[j] * bmat[j];
+//      blnrm += blmat[j] * blmat[j];
+//    }
+//
+//    const auto* eps = task.eps;
+//    const auto* vgamma = task.vgamma;
+//    const auto* vtau   = task.vtau;
+//    const auto* vlapl   = task.vlapl;
+//    const auto* vrho   = task.vrho;
+//    const auto* gamma = task.gamma;
+//    const auto* tau   = task.tau;
+//    const auto* lapl   = task.lapl;
+//    const auto* rho   = task.den;
+//    double enrm = 0.0, gnrm = 0.0, tnrm = 0.0, rnrm = 0.0, lnrm = 0.0;
+//    double vgnrm = 0.0, vtnrm = 0.0, vrnrm = 0.0, vlnrm = 0.0;
+//    for(auto j = 0; j < npts; ++j) {
+//      enrm += eps[j] * eps[j];
+//      vrnrm += vrho[j] * vrho[j];
+//      vgnrm += vgamma[j] * vgamma[j];
+//      vtnrm += vtau[j] * vtau[j];
+//      vlnrm += vlapl[j] * vlapl[j];
+//
+//      rnrm += rho[j] * rho[j];
+//      gnrm += gamma[j] * gamma[j];
+//      tnrm += tau[j] * tau[j];
+//      lnrm += lapl[j] * lapl[j];
+//    }
+//
+//        printf("ITASK = %lu B = %.6e BL = %.6e R = %.6e G = %.6e T = %.6e L = %.6e E = %.6e VR = %.6e VG = %6e VT = %.6e VL = %.6e Z = %.6e \n", 
+//          iT, bnrm, blnrm, rnrm, gnrm, tnrm, lnrm, enrm, vrnrm, vgnrm, vtnrm, vlnrm, znrm);
+//  }
+//
+//}
+
+void mmat_mgga_vxc( size_t            ntasks,
+                    int32_t           max_nbf,
+                    int32_t           max_npts,
+                    XCDeviceTask*     tasks_device,
+                    bool              do_lapl,
+                    integrator_ks_scheme scheme,
+                    density_id sel,
+                    device_queue queue ) {
+
+  hipStream_t stream = queue.queue_as<util::hip_stream>() ;
+
+
+  dim3 threads(hip::warp_size,hip::max_warps_per_thread_block,1);
+  dim3 blocks( util::div_ceil( max_npts, threads.x ),
+               util::div_ceil( max_nbf,  threads.y ),
+               ntasks );
+
+  if(scheme == RKS) {
+    if(do_lapl)
+      mmat_mgga_vxc_rks_kernel<true><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+    else
+      mmat_mgga_vxc_rks_kernel<false><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+  } else if(scheme == UKS) {
+    switch(sel) {
+      case DEN_S:
+        if(do_lapl)
+          mmat_mgga_vxc_uks_kernel<true, DEN_S><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+        else
+          mmat_mgga_vxc_uks_kernel<false, DEN_S><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+        break;
+      case DEN_Z:
+        if(do_lapl)
+          mmat_mgga_vxc_uks_kernel<true, DEN_Z><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+        else
+          mmat_mgga_vxc_uks_kernel<false, DEN_Z><<< blocks, threads, 0, stream >>>( ntasks, tasks_device );
+        break;
+    }
+  } else {
+    GAUXC_GENERIC_EXCEPTION("MGGA + DEVICE + GKS NYI");
+  }
+  
+
+  //print_zmat_stats<<<1,1,0,stream>>>(ntasks,tasks_device);
+}
 
 }
 


### PR DESCRIPTION
## Problem

The HIP backend does not build. `scheme1_base.cxx` is compiled for **both** backends — it is listed in `src/xc_integrator/local_work_driver/device/CMakeLists.txt:16`, before the conditional `cuda/` and `hip/` subdirectories — and it calls `zmat_*_fxc`, `increment_exc_grad_*`, `exx_ek_screening_bfn_stats` and the shell-to-task collocation. None of those had HIP definitions, so any `-DGAUXC_ENABLE_HIP=ON` build fails to link.

The HIP sources that did exist were stale as well:

* `kernels/zmat_vxc.hip` still had the pre-UKS/GKS kernel names (`zmat_lda_vxc_kernel` rather than `zmat_lda_vxc_{rks,uks,gks}_kernel`);
* `kernels/uvvars.hip` had no mGGA path at all (zero `tau` references against 19 on the CUDA side);
* `collocation_shell_to_task_kernels.hpp` and the split `uvvars_{lda,gga,mgga}.hpp` headers were absent.

In effect the HIP backend has been frozen at roughly its 2022 LDA/GGA-VXC feature level while mGGA, FXC contraction, EXC gradients and sn-LinK screening were added on the CUDA side.

## Root cause

`hip/hipify.sh` covered only 8 of the 24 current files under `cuda/kernels/` and was never updated as kernels were added.

## What this PR does

Rewrites `hipify.sh` to cover all current CUDA kernel sources, regenerates the HIP tree from it, and adds `zmat_fxc`, `increment_exc_grad` and `exx_ek_screening_bfn_stats` to `hip/CMakeLists.txt`.

The `hipify-perl` invocations are replaced with explicit `sed` rules. Two reasons: regeneration then works on machines without a ROCm installation, and the handful of decisions that are *not* mechanical end up documented in one place rather than in a maintainer's head:

* **Wavefront size** is never hardcoded; kernels take it from `GauXC::cuda::warp_size` → `GauXC::hip::warp_size` (32 vs 64), so launch geometry adapts. No literal 32s were introduced.
* **`__syncwarp()`** has no HIP equivalent (wavefronts are lockstep on AMD) and is commented out — the convention the existing 2022-era files in this directory already used.
* **`__shfl_*_sync(mask, …)` → `__shfl_*(…)`**, since HIP shuffles take no mask argument.
* **`cub` → `hipcub`** (`cub::DeviceScan` in the EXX screening kernel).
* **CUDA's two-tier shared-memory limit** has no AMD counterpart — LDS per workgroup is a single fixed limit — so both `cudaDevAttrMaxSharedMemoryPerBlock` and `…Optin` map to `hipDeviceAttributeMaxSharedMemoryPerBlock`. The overflow guard in `exx_ek_screening` is preserved; the opt-in branch becomes a no-op.
* **`__stcs()` and its inline-PTX fallback** in `pack_submat` are lowered to a plain store. `CUDART_VERSION` is undefined under HIP, so the preprocessor would otherwise select the PTX branch and fail to compile. The cache hint is an optimization, not semantics.
* **CUTLASS** is deliberately not translated; it has no HIP counterpart and `GAUXC_ENABLE_CUTLASS` is already a CUDA-only dependent option.

## Verification

Static checks only (see caveat):

* every kernel symbol referenced by `scheme1_base.cxx` now resolves against the HIP tree;
* no compile-breaking CUDA token remains in the generated sources;
* per-file function counts match the CUDA originals;
* the hand-maintained `hip_aos_scheme1{,_data}.cxx` were checked to have the same method sets as their CUDA counterparts (the line-count difference is CUTLASS-only code), so they did not need regeneration.

## Caveat — please read before merging

**This has not been compiled.** I have neither a ROCm installation nor AMD hardware, so the changes have never been through `hipcc`. Expect a round of compile fixes.

Beyond compilation, the one correctness risk worth a reviewer's eyes is wavefront width: nothing hardcodes 32 and launch geometry derives from `hip::warp_size`, but any intra-wavefront reduction whose trip count is written as a literal rather than derived from `warp_size` should be checked before the numbers are trusted on AMD. `hipify.sh` prints a `CHECK_WAVEFRONT` reminder to that effect.

I am happy to iterate on this if someone with an AMD GPU can run the test suite, or to split it into "script + build wiring" and "regenerated kernels" commits if that is easier to review.
